### PR TITLE
chore: fixed broken URL in hint for usage statistics.

### DIFF
--- a/src/components/Settings.vue
+++ b/src/components/Settings.vue
@@ -346,7 +346,7 @@
 											</v-row>
 											<v-col cols="12" sm="6">
 												<v-switch
-													hint="Usage statistics allows us to gain insight how `zwave-js` is used, which manufacturers and devices are most prevalent and where to best focus our efforts in order to improve `zwave-js` the most. We do not store any personal information. Details can be found under https://zwave-js.github.io/node-zwave-js/#/getting-started/telemetry.md#usage-statistics"
+													hint="Usage statistics allows us to gain insight how `zwave-js` is used, which manufacturers and devices are most prevalent and where to best focus our efforts in order to improve `zwave-js` the most. We do not store any personal information. Details can be found under https://zwave-js.github.io/node-zwave-js/#/data-collection/data-collection?id=usage-statistics"
 													persistent-hint
 													label="Enable statistics"
 													v-model="


### PR DESCRIPTION
I noticed this URL in the hint for usage statistics setting was a dead end. Found new URL and corrected.