### PR TITLE
fix: wrong security description in table

### DIFF
--- a/src/components/nodes-table/nodes-table.js
+++ b/src/components/nodes-table/nodes-table.js
@@ -86,6 +86,7 @@ export default {
 								node.security === 'LOW SECURITY'
 									? 'color: yellow'
 									: 'color: green'
+							v.description = node.security
 						} else if (node.isSecure === false) {
 							v.icon = mdiMinusCircle
 							v.iconStyle = 'color: red'


### PR DESCRIPTION
This PR fixes the wrong description "Unknown security status" when device is included secure:
![image](https://user-images.githubusercontent.com/207989/138854813-2397370f-ba3c-40a9-8abd-ac9a8188b236.png)
