### PR TITLE
fix(docker): use zwave-js's new pack utility, optimize layers, copy snippets

### DIFF
--- a/docker/Dockerfile.contrib
+++ b/docker/Dockerfile.contrib
@@ -16,8 +16,9 @@ ARG ZUI_REPOSITORY=https://github.com/zwave-js/zwave-js-ui
 USER node
 WORKDIR /home/node
 
-RUN git clone -b ${ZWJ_BRANCH} ${ZWJ_REPOSITORY}
-RUN git clone -b ${ZUI_BRANCH} --depth 1 ${ZUI_REPOSITORY}
+RUN \
+	git clone -b ${ZWJ_BRANCH} ${ZWJ_REPOSITORY} \
+	&& git clone -b ${ZUI_BRANCH} --depth 1 ${ZUI_REPOSITORY}
 
 # Option 2: Copy from local sources
 FROM node:16.3.0-buster AS local-copy-src
@@ -38,39 +39,39 @@ USER node
 WORKDIR /home/node/node-zwave-js
 ENV YARN_HTTP_TIMEOUT=300000
 
-RUN yarn
-RUN yarn build
-
-# Update the version info to match the branch built
-RUN yarn workspaces foreach version $(echo $(yarn node -p 'require("semver").inc(require("zwave-js/package.json").version, "prerelease")+".dev"')-$(git rev-parse --short HEAD)) --deferred && yarn version apply --all
-
-# Pack the repo into tarballs that reference each other
-RUN yarn monopack --target $(pwd) --no-version --absolute
+RUN \
+	yarn \
+	&& yarn build \
+	# Update the version info to match the branch built
+	&& yarn workspaces foreach version $(echo $(yarn node -p 'require("semver").inc(require("zwave-js/package.json").version, "prerelease")+".dev"')-$(git rev-parse --short HEAD)) --deferred \
+	&& yarn version apply --all \
+	# Pack the repo into tarballs that reference each other
+	&& yarn monopack --target $(pwd) --no-version --absolute
 
 ### Build zwave-js-ui ###
 WORKDIR /home/node/zwave-js-ui
 
-# Change dependency to use local packs
-RUN cat package.json \
-      | jq '.dependencies["zwave-js"] = "file:../node-zwave-js/zwave-js.tgz"' \
-      > package2.json && rm package.json && mv package2.json package.json
-
-RUN yarn
-RUN yarn build
-
-# Prune devDependencies
-RUN yarn remove $(cat package.json | jq -r '.devDependencies | keys | join(" ")') && \
-    rm -rf \
-    build \
-    package.sh \
-    src \
-    static \
-    docs \
-    .yarn
-
-# Copy to distribution folder
-RUN mkdir my_dist
-RUN cp -Lr .git package.json yarn.lock .yarnrc.yml bin config server dist hass lib store views node_modules my_dist/
+RUN \
+	# Change dependency to use local packs
+	cat package.json \
+		| jq '.dependencies["zwave-js"] = "file:../node-zwave-js/zwave-js.tgz"' \
+		> package2.json \
+	&& rm package.json && mv package2.json package.json \
+	\
+	&& yarn \
+	&& yarn build \
+	# Prune devDependencies
+	&& yarn remove $(cat package.json | jq -r '.devDependencies | keys | join(" ")') \
+	&& rm -rf \
+		build \
+		package.sh \
+		src \
+		static \
+		docs \
+		.yarn \
+	# Copy to distribution folder
+	&& mkdir my_dist \
+	&& cp -Lr .git package.json yarn.lock .yarnrc.yml bin config server dist hass lib store views node_modules my_dist/
 
 #####################
 # Setup Final Image #
@@ -80,7 +81,10 @@ LABEL maintainer="robertsLando"
 
 ENV ZWAVEJS_EXTERNAL_CONFIG=/usr/src/app/store/.config-db
 
-RUN apt-get update && apt-get install -y git && rm -rf /var/lib/apt/lists/*
+RUN \
+	apt-get update \
+	&& apt-get install -y git \
+	&& rm -rf /var/lib/apt/lists/*
 COPY --from=build /home/node/zwave-js-ui/my_dist /usr/src/app
 WORKDIR /usr/src/app
 EXPOSE 8091

--- a/docker/Dockerfile.contrib
+++ b/docker/Dockerfile.contrib
@@ -41,25 +41,18 @@ ENV YARN_HTTP_TIMEOUT=300000
 RUN yarn
 RUN yarn build
 
-RUN yarn plugin import version && yarn plugin import workspace-tools
-
 # Update the version info to match the branch built
 RUN yarn workspaces foreach version $(echo $(yarn node -p 'require("semver").inc(require("zwave-js/package.json").version, "prerelease")+".dev"')-$(git rev-parse --short HEAD)) --deferred && yarn version apply --all
 
-RUN yarn workspaces foreach pack
+# Pack the repo into tarballs that reference each other
+RUN yarn monopack --target $(pwd) --no-version --absolute
 
 ### Build zwave-js-ui ###
 WORKDIR /home/node/zwave-js-ui
 
-# Change resolutions to point to local packs
+# Change dependency to use local packs
 RUN cat package.json \
-      | jq '.resolutions += { "@zwave-js/config": "file:../node-zwave-js/packages/config/package.tgz" }' \
-      | jq '.resolutions += { "@zwave-js/core": "file:../node-zwave-js/packages/core/package.tgz" }' \
-      | jq '.resolutions += { "@zwave-js/nvmedit": "file:../node-zwave-js/packages/nvmedit/package.tgz" }' \
-      | jq '.resolutions += { "@zwave-js/serial": "file:../node-zwave-js/packages/serial/package.tgz" }' \
-      | jq '.resolutions += { "@zwave-js/shared": "file:../node-zwave-js/packages/shared/package.tgz" }' \
-      | jq '.resolutions += { "zwave-js": "file:../node-zwave-js/packages/zwave-js/package.tgz" }' \
-      | jq '.dependencies += { "zwave-js": "file:../node-zwave-js/packages/zwave-js/package.tgz" }' \
+      | jq '.dependencies["zwave-js"] = "file:../node-zwave-js/zwave-js.tgz"' \
       > package2.json && rm package.json && mv package2.json package.json
 
 RUN yarn

--- a/docker/Dockerfile.contrib
+++ b/docker/Dockerfile.contrib
@@ -64,14 +64,29 @@ RUN \
 	&& yarn remove $(cat package.json | jq -r '.devDependencies | keys | join(" ")') \
 	&& rm -rf \
 		build \
-		package.sh \
+		docs \
 		src \
 		static \
-		docs \
 		.yarn \
+		package.sh \
 	# Copy to distribution folder
 	&& mkdir my_dist \
-	&& cp -Lr .git package.json yarn.lock .yarnrc.yml bin config server dist hass lib store views node_modules my_dist/
+	&& cp -Lr \
+		.git \
+		bin \
+		config \
+		dist \
+		hass \
+		lib \
+		node_modules \
+		server \
+		snippets \
+		store \
+		views \
+		.yarnrc.yml \
+		package.json \
+		yarn.lock \
+		my_dist
 
 #####################
 # Setup Final Image #

--- a/docker/Dockerfile.contrib
+++ b/docker/Dockerfile.contrib
@@ -16,9 +16,8 @@ ARG ZUI_REPOSITORY=https://github.com/zwave-js/zwave-js-ui
 USER node
 WORKDIR /home/node
 
-RUN \
-	git clone -b ${ZWJ_BRANCH} ${ZWJ_REPOSITORY} \
-	&& git clone -b ${ZUI_BRANCH} --depth 1 ${ZUI_REPOSITORY}
+RUN git clone -b ${ZWJ_BRANCH} ${ZWJ_REPOSITORY}
+RUN git clone -b ${ZUI_BRANCH} --depth 1 ${ZUI_REPOSITORY}
 
 # Option 2: Copy from local sources
 FROM node:16.3.0-buster AS local-copy-src
@@ -39,38 +38,39 @@ USER node
 WORKDIR /home/node/node-zwave-js
 ENV YARN_HTTP_TIMEOUT=300000
 
-RUN \
-	yarn \
-	&& yarn build \
-	# Update the version info to match the branch built
-	&& yarn workspaces foreach version $(echo $(yarn node -p 'require("semver").inc(require("zwave-js/package.json").version, "prerelease")+".dev"')-$(git rev-parse --short HEAD)) --deferred \
-	&& yarn version apply --all \
-	# Pack the repo into tarballs that reference each other
-	&& yarn monopack --target $(pwd) --no-version --absolute
+RUN yarn
+RUN yarn build
+
+# Update the version info to match the branch built
+RUN yarn workspaces foreach version $(echo $(yarn node -p 'require("semver").inc(require("zwave-js/package.json").version, "prerelease")+".dev"')-$(git rev-parse --short HEAD)) --deferred && yarn version apply --all
+
+# Pack the repo into tarballs that reference each other
+RUN yarn monopack --target $(pwd) --no-version --absolute
 
 ### Build zwave-js-ui ###
 WORKDIR /home/node/zwave-js-ui
 
-RUN \
-	# Change dependency to use local packs
-	cat package.json \
+# Change dependency to use local packs
+RUN cat package.json \
 		| jq '.dependencies["zwave-js"] = "file:../node-zwave-js/zwave-js.tgz"' \
 		> package2.json \
-	&& rm package.json && mv package2.json package.json \
-	\
-	&& yarn \
-	&& yarn build \
-	# Prune devDependencies
-	&& yarn remove $(cat package.json | jq -r '.devDependencies | keys | join(" ")') \
+	&& rm package.json && mv package2.json package.json
+
+RUN yarn
+RUN yarn build
+
+# Prune devDependencies
+RUN yarn remove $(cat package.json | jq -r '.devDependencies | keys | join(" ")') \
 	&& rm -rf \
 		build \
 		docs \
 		src \
 		static \
 		.yarn \
-		package.sh \
-	# Copy to distribution folder
-	&& mkdir my_dist \
+		package.sh
+
+# Copy to distribution folder
+RUN mkdir my_dist \
 	&& cp -Lr \
 		.git \
 		bin \


### PR DESCRIPTION
This PR does a few things:
1. make Dockerfile.contrib compatible with zwave-js 10 and replace the hacky solution for packing the local build with a better one
2. reduce the number of layers by grouping RUN commands
3. fix a crash caused by a missing snippets folder