### PR TITLE
docs: rework the docs on HA Zwave-js integration to be more explicit

### DIFF
--- a/docs/homeassistant/homeassistant-official.md
+++ b/docs/homeassistant/homeassistant-official.md
@@ -23,7 +23,7 @@ Support tickets relating to Home Assistant should first be submitted to the Home
 
 ## MQTT Discovery
 
-To configure this method, you need an MQTT server in addition to the other components. 
+To configure this method, you need an MQTT server in addition to the other components.
 
 1. Set up the MQTT server, for example using the well known Mosquitto server
 2. Open Zwave-js-ui settings page

--- a/docs/homeassistant/homeassistant-official.md
+++ b/docs/homeassistant/homeassistant-official.md
@@ -3,7 +3,7 @@
 To integrate your Z-Wave components you can use either the official Home Assistant [Z-Wave integration](https://www.home-assistant.io/integrations/zwave_js) or MQTT discovery. To read more about the MQTT discovery, see [these docs](/usage/setup?id=home-assistant-using-mqtt-discovery).
 
 > [!NOTE]
-> Home assistant Z-Wave Integration it's the recommended choice as MQTT discovery is much more limited and less maintained.
+> Home assistant Z-Wave Integration is the recommended choice as MQTT discovery is much more limited and less maintained.
 
 ## Z-Wave integration
 

--- a/docs/homeassistant/homeassistant-official.md
+++ b/docs/homeassistant/homeassistant-official.md
@@ -1,17 +1,17 @@
 # Home Assistant Using the Official Integration
 
-To integrate your Z-Wave components you can use either the official Home Assistant [Z-Wave JS integration](https://www.home-assistant.io/integrations/zwave_js) and/or MQTT discovery.
+To integrate your Z-Wave components you can use either the official Home Assistant [Z-Wave integration](https://www.home-assistant.io/integrations/zwave_js) or MQTT discovery.
 
-## Z-Wave JS integration
+## Z-Wave integration
 
 Home Assistant has an integration for zwave which is based on zwave-js - you can read more about this at the [Z-Wave JS integration](https://www.home-assistant.io/integrations/zwave_js) docs.
 
 To enable the integration:
 
-1. Open Zwave-js-ui settings page
-2. Enable the "WS Server" setting in the "Home Assistant" tab
+1. Open the Z-Wave JS UI Settings page
+2. Enable the "WS Server" setting in the "Home Assistant" panel
 3. If you do not need the MQTT features, you can [Disable MQTT Gateway](/usage/setup?id=disable-gateway) and use Z-Wave JS UI as an additional user interface to control your Z-Wave network.
-4. Configure the ZWave JS Integration in Home Assistant, by following [the official docs](https://www.home-assistant.io/integrations/zwave_js)
+4. Configure the Z-Wave integration in Home Assistant by following [the official docs](https://www.home-assistant.io/integrations/zwave_js)
 
 Once this has been configured, entities should automatically be created in HA.
 
@@ -26,8 +26,8 @@ Support tickets relating to Home Assistant should first be submitted to the Home
 To configure this method, you need an MQTT server in addition to the other components.
 
 1. Set up the MQTT server, for example using the well known Mosquitto server
-2. Open Zwave-js-ui settings page
-3. Configure the MQTT server information under the "MQTT" tab
+2. Open the Z-Wave JS UI settings page
+3. Configure the MQTT server information under the "MQTT" panel
 4. Enable "MQTT Discovery", in the "Home Assistant" tab
 
 ## How it works

--- a/docs/homeassistant/homeassistant-official.md
+++ b/docs/homeassistant/homeassistant-official.md
@@ -2,6 +2,9 @@
 
 To integrate your Z-Wave components you can use either the official Home Assistant [Z-Wave integration](https://www.home-assistant.io/integrations/zwave_js) or MQTT discovery. To read more about the MQTT discovery, see [these docs](/usage/setup?id=home-assistant-using-mqtt-discovery).
 
+> [!NOTE]
+> Home assistant Z-Wave Integration it's the recommended choice as MQTT discovery is much more limited and less maintained.
+
 ## Z-Wave integration
 
 Home Assistant has an integration for Z-Wave which is based on Z-Wave JS. You can read more about this at the [Z-Wave integration](https://www.home-assistant.io/integrations/zwave_js) docs.

--- a/docs/homeassistant/homeassistant-official.md
+++ b/docs/homeassistant/homeassistant-official.md
@@ -1,15 +1,15 @@
 # Home Assistant Using the Official Integration
 
-To integrate your Z-Wave components you can use either the official Home Assistant [Z-Wave integration](https://www.home-assistant.io/integrations/zwave_js) or MQTT discovery.
+To integrate your Z-Wave components you can use either the official Home Assistant [Z-Wave integration](https://www.home-assistant.io/integrations/zwave_js) or MQTT discovery. To read more about the MQTT discovery, see [these docs](/usage/setup?id=home-assistant-using-mqtt-discovery).
 
 ## Z-Wave integration
 
-Home Assistant has an integration for zwave which is based on zwave-js - you can read more about this at the [Z-Wave JS integration](https://www.home-assistant.io/integrations/zwave_js) docs.
+Home Assistant has an integration for Z-Wave which is based on Z-Wave JS. You can read more about this at the [Z-Wave integration](https://www.home-assistant.io/integrations/zwave_js) docs.
 
 To enable the integration:
 
 1. Open the Z-Wave JS UI Settings page
-2. Enable the "WS Server" setting in the "Home Assistant" panel
+2. Enable the "WS Server" setting in the [Home Assistant](/usage/setup?id=home-assistant) panel
 3. If you do not need the MQTT features, you can [Disable MQTT Gateway](/usage/setup?id=disable-gateway) and use Z-Wave JS UI as an additional user interface to control your Z-Wave network.
 4. Configure the Z-Wave integration in Home Assistant by following [the official docs](https://www.home-assistant.io/integrations/zwave_js)
 
@@ -20,15 +20,6 @@ Once this has been configured, entities should automatically be created in HA.
 Should you need support with the official Home Assistant Integration, please consult that project's [documentation](https://www.home-assistant.io/integrations/zwave_js/).
 
 Support tickets relating to Home Assistant should first be submitted to the Home Assistant [project](https://github.com/home-assistant/core), who will redirect the ticket to Z-Wave JS if need be.
-
-## MQTT Discovery
-
-To configure this method, you need an MQTT server in addition to the other components.
-
-1. Set up the MQTT server, for example using the well known Mosquitto server
-2. Open the Z-Wave JS UI settings page
-3. Configure the MQTT server information under the "MQTT" panel
-4. Enable "MQTT Discovery", in the "Home Assistant" tab
 
 ## How it works
 

--- a/docs/homeassistant/homeassistant-official.md
+++ b/docs/homeassistant/homeassistant-official.md
@@ -4,7 +4,7 @@ To integrate your Z-Wave components you can use either the official Home Assista
 
 ## Z-Wave JS integration
 
-Home Assistant has an integration for zwave which is based on zwave-js - you can read more about this at the [Z-Wave JS integration](https://www.home-assistant.io/integrations/zwave_js) docs on Home Assistants docs.
+Home Assistant has an integration for zwave which is based on zwave-js - you can read more about this at the [Z-Wave JS integration](https://www.home-assistant.io/integrations/zwave_js) docs.
 
 To enable the integration:
 

--- a/docs/homeassistant/homeassistant-official.md
+++ b/docs/homeassistant/homeassistant-official.md
@@ -2,17 +2,33 @@
 
 To integrate your Z-Wave components you can use either the official Home Assistant [Z-Wave JS integration](https://www.home-assistant.io/integrations/zwave_js) and/or MQTT discovery.
 
-## Z-Wave JS server
+## Z-Wave JS integration
 
-The Z-Wave JS server is the official way to integrate your Z-Wave devices with Home Assistant. In order to use it go to Settings, [Home Assistant](/usage/setup?id=home-assistant) and enable the flag **WS Server**. Using this method, the official [Z-Wave JS integration](https://www.home-assistant.io/integrations/zwave_js) will automatically create entities in Home Assistant.
+Home Assistant has an integration for zwave which is based on zwave-js - you can read more about this at the [Z-Wave JS integration](https://www.home-assistant.io/integrations/zwave_js) docs on Home Assistants docs.
 
-If you do not need the MQTT features, you can [Disable MQTT Gateway](/usage/setup?id=disable-gateway) and use Z-Wave JS UI as an additional user interface to control your Z-Wave network.
+To enable the integration:
 
-## Assistance with the Official Integration
+1. Open Zwave-js-ui settings page
+2. Enable the "WS Server" setting in the "Home Assistant" tab
+3. If you do not need the MQTT features, you can [Disable MQTT Gateway](/usage/setup?id=disable-gateway) and use Z-Wave JS UI as an additional user interface to control your Z-Wave network.
+4. Configure the ZWave JS Integration in Home Assistant, by following [the official docs](https://www.home-assistant.io/integrations/zwave_js)
+
+Once this has been configured, entities should automatically be created in HA.
+
+### Assistance with the Official Integration
 
 Should you need support with the official Home Assistant Integration, please consult that project's [documentation](https://www.home-assistant.io/integrations/zwave_js/).
 
 Support tickets relating to Home Assistant should first be submitted to the Home Assistant [project](https://github.com/home-assistant/core), who will redirect the ticket to Z-Wave JS if need be.
+
+## MQTT Discovery
+
+To configure this method, you need an MQTT server in addition to the other components. 
+
+1. Set up the MQTT server, for example using the well known Mosquitto server
+2. Open Zwave-js-ui settings page
+3. Configure the MQTT server information under the "MQTT" tab
+4. Enable "MQTT Discovery", in the "Home Assistant" tab
 
 ## How it works
 


### PR DESCRIPTION
I had some troubles configuring the zwave-js-ui addon in HA, as I was consistently confused by the documentation which led me in circles. I was focusing on this doc though, so I believe that by making this more explicit, future users can be helped. Through slack, I also found that the "actual" docs are over on HA - where I believed that zwave-js(-ui) wasn't so well included in those docs.. The HA docs are better for actual setup, so I've made sure the step-by-step ends over there.