### PR TITLE
chore(docker): add tags for `major` and `minor` version to container images

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -13,7 +13,7 @@ jobs:
     permissions:
       packages: write
       contents: read
-      
+
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -45,6 +45,8 @@ jobs:
           images: zwavejs/zwave-js-ui,ghcr.io/zwave-js/zwave-js-ui
           tags: |
             type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
             type=sha
             type=ref,event=branch
           labels: |
@@ -52,7 +54,7 @@ jobs:
             org.opencontainers.image.documentation=https://zwave-js.github.io/zwave-js-ui
             org.opencontainers.image.authors=Daniel Lando <daniel.sorridi@gmail.com>
             maintainer=robertsLando
-      
+
       - name: Create Docker Meta for zwavejs2mqtt
         id: docker_meta2
         uses: docker/metadata-action@v4
@@ -60,6 +62,8 @@ jobs:
           images: zwavejs/zwavejs2mqtt
           tags: |
             type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
             type=sha
             type=ref,event=branch
           labels: |
@@ -67,12 +71,12 @@ jobs:
             org.opencontainers.image.documentation=https://zwave-js.github.io/zwave-js-ui
             org.opencontainers.image.authors=Daniel Lando <daniel.sorridi@gmail.com>
             maintainer=robertsLando
-      
+
       - name: Pre-build frontend and backend files
         run: |
           yarn install --immutable
           yarn build
-          
+
       - name: build+push
         uses: docker/build-push-action@v3
         with:
@@ -84,7 +88,7 @@ jobs:
           push: true
           tags: ${{ steps.docker_meta.outputs.tags }}
           labels: ${{ steps.docker_meta.outputs.labels }}
-      
+
       - name: build+push zwavejs2mqtt
         uses: docker/build-push-action@v3
         with:

--- a/docs/getting-started/docker.md
+++ b/docs/getting-started/docker.md
@@ -22,7 +22,10 @@ Available tags are:
 - `latest` for the latest official release.
 - `master` for the bleeding-edge version. This image is built after every new commit to the master branch in the [Z-Wave JS UI](https://github.com/zwave-js/zwave-js-ui/commits/master) repository. Use at your own caution.
 - `sha-<commit-sha>` (example: `sha-92d502a`)
-- `<version>` (example: `2.1.0`)
+- *Version tags:* We provide multiple ones with different specificity in the [samentic versioning](https://semver.org/):
+  - `<major>`: latest release **within the same major**, example: `8` will update for any v8.* but will not update for v9.0.0.
+  - `<major>.<minor>`: latest release **within the same minor**, example: `8.2` will update for any v8.2.1, v8.2.2 and v8.2.9; but not for v8.3.0.
+  - `<major>.<minor>.<patch>`: static pointer to a specific release, example `8.2.1`.
 
 ## Installation
 


### PR DESCRIPTION
## What is the objective of this PR

On release this adds tags `${major}` as well as `${major}.${minor}` to the container images.

This is quite common practice and allows users to follow minor or major releases instead of only `latest` _(typically not recommended)_ or specific patch versions, requiring to constantly monitor for new patches releases.

Any feedback is welcome. :) 