### PR TITLE
fix(ui): typo in fw update dialog title

### DIFF
--- a/src/components/ControlPanel.vue
+++ b/src/components/ControlPanel.vue
@@ -446,7 +446,7 @@ export default {
 						}
 
 						const result = await this.$listeners.showConfirm(
-							'Firmware udpate',
+							'Firmware update',
 							'',
 							'info',
 							{


### PR DESCRIPTION
The word `update` was previously spelled `udpate`. This was apparent on the dialog popup when navigating within the UI to a node, then Advanced, and after selecting "Begin" under "Firmware Update" of the "Advanced" popup.