### PR TITLE
docs: correcting typo on URL and updating to newer dashboard yaml

### DIFF
--- a/docs/homeassistant/accessing-lovelace.md
+++ b/docs/homeassistant/accessing-lovelace.md
@@ -11,12 +11,12 @@ First, add a new Lovelace dashboard. In the dashboard:
 
 ```yaml
 views:
-	- title: Z-Wave JS UI
-  	panel: true
-  	cards:
-    	- type: iframe
-      	url: 'http://127.0.0.1[OR SUBSTITUTE YOUR IP ADDRESS HERE]:8091/'
-      	aspect_ratio: 100%
+ - title: Z-Wave JS UI
+   panel: true
+   cards:
+     - type: iframe
+       url: 'http://127.0.0.1[OR SUBSTITUTE YOUR IP ADDRESS HERE]:8091/'
+       aspect_ratio: 100%
 ```
 
 Alternatively, you can add a new tab to a pre-existing dashboard by inserting the above yaml into the pre-existing dashboard's raw configuration.

--- a/docs/homeassistant/accessing-lovelace.md
+++ b/docs/homeassistant/accessing-lovelace.md
@@ -10,12 +10,13 @@ First, add a new Lovelace dashboard. In the dashboard:
 4. Paste the code below and save
 
 ```yaml
-- title: Z-Wave JS UI
-  panel: true
-  cards:
-    - type: iframe
-      url: 'http:/127.0.0.1[SUBSTITUTE YOUR IP ADDRESS HERE]:8091/'
-      aspect_ratio: 100%
+views:
+	- title: Z-Wave JS UI
+  	panel: true
+  	cards:
+    	- type: iframe
+      	url: 'http://127.0.0.1[OR SUBSTITUTE YOUR IP ADDRESS HERE]:8091/'
+      	aspect_ratio: 100%
 ```
 
 Alternatively, you can add a new tab to a pre-existing dashboard by inserting the above yaml into the pre-existing dashboard's raw configuration.


### PR DESCRIPTION
The URL only had one forward slash in it, and when I added this to the version of homeassistant I just installed, it had an additional "views" stanza in it so I included that full yaml.