### PR TITLE
chore: fix deprecation on GH actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ on:
       - master
   pull_request:
 
-concurrency: 
+concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
@@ -48,10 +48,10 @@ jobs:
           if ! git diff --quiet ; then
             echo "has changes"
             git diff > fix.patch
-            echo "::set-output name=changed::true"
+            echo "changed=true" >> $GITHUB_OUTPUT
           else
             echo "unchanged"
-            echo "::set-output name=changed::false"
+            echo "changed=false" >> $GITHUB_OUTPUT
           fi
       - name: Upload Patch
         if: |

--- a/.github/workflows/docker-release-test.yml
+++ b/.github/workflows/docker-release-test.yml
@@ -22,11 +22,11 @@ jobs:
           fetch-depth: 0 # fetch everything
           ref: ${{ github.event.inputs.branch }}
 
-      - uses: actions/setup-node@v3.4.1
+      - uses: actions/setup-node@v3.6.0
         with:
           node-version: 16
           cache: 'yarn'
-  
+
       - uses: docker/setup-buildx-action@v2
       - uses: docker/setup-qemu-action@v2
 
@@ -58,7 +58,7 @@ jobs:
             org.opencontainers.image.authors=Daniel Lando <daniel.sorridi@gmail.com>
             org.opencontainers.image.url=https://zwave-js.github.io/zwave-js-ui/#/
             maintainer=robertsLando
-      
+
       - name: Pre-build frontend and backend files
         run: |
           yarn install --immutable

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3.4.1
+      - uses: actions/setup-node@v3.6.0
         with:
           node-version: 16
           cache: 'yarn'

--- a/.github/workflows/docker-test.yml
+++ b/.github/workflows/docker-test.yml
@@ -5,7 +5,7 @@ on:
     paths-ignore:
       - 'docs/**'
 
-concurrency: 
+concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
@@ -21,7 +21,7 @@ jobs:
       - uses: docker/setup-buildx-action@v2
       - uses: docker/setup-qemu-action@v2
 
-      - uses: actions/github-script@v3
+      - uses: actions/github-script@v6
         id: ref-sanitized
         with:
           script: |

--- a/.github/workflows/release-it.yml
+++ b/.github/workflows/release-it.yml
@@ -26,7 +26,7 @@ jobs:
           token: ${{ secrets.BOT_TOKEN }}
 
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v3.4.1
+        uses: actions/setup-node@v3.6.0
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'yarn'

--- a/.github/workflows/update-dep.yml
+++ b/.github/workflows/update-dep.yml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      
+
       - name: Use Node.js 14
         uses: actions/setup-node@v3.4.1
         with:
@@ -36,12 +36,12 @@ jobs:
           git diff --name-only || true
           if ! git diff --quiet ; then
             echo "Has changes"
-            echo "::set-output name=changed::true"
+            echo "changed=true" >> $GITHUB_OUTPUT
             VERSION=$(npm info ${{github.event.inputs.dep}} version)
-            echo "::set-output name=version::$VERSION"
+            echo "version=$VERSION" >> $GITHUB_OUTPUT
           else
             echo "No changes detected. Dependency already up to date"
-            echo "::set-output name=changed::false"
+            echo "changed=false" >> $GITHUB_OUTPUT
           fi
       - name: Create Pull Request
         if: ${{ steps.check.outputs.changed == 'true' }}

--- a/.github/workflows/update-dep.yml
+++ b/.github/workflows/update-dep.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Use Node.js 14
-        uses: actions/setup-node@v3.4.1
+        uses: actions/setup-node@v3.6.0
         with:
           node-version: 14.x
           cache: 'yarn'

--- a/.github/workflows/zwave-js-bot_comment.yml
+++ b/.github/workflows/zwave-js-bot_comment.yml
@@ -78,7 +78,7 @@ jobs:
         run: |
           # Apply the patch
           if ! git apply ../patch/fix.patch ; then
-            echo "::set-output name=result::error"
+            echo "result=error" >> $GITHUB_OUTPUT
             exit 0
           fi
 
@@ -91,9 +91,9 @@ jobs:
             git reset -- .github
             git commit -m "style: fix lint"
             git push
-            echo "::set-output name=result::ok"
+            echo "result=ok" >> $GITHUB_OUTPUT
           else
-            echo "::set-output name=result::unchanged"
+            echo "result=unchanged" >> $GITHUB_OUTPUT
             exit 0
           fi
 
@@ -191,7 +191,7 @@ jobs:
             git config user.name "Z-Wave JS Bot"
             git push -f
           else
-            echo "::set-output name=result::error"
+            echo "result=error" >> $GITHUB_OUTPUT
           fi
 
       - name: Give feedback
@@ -279,9 +279,9 @@ jobs:
           if git commit --amend -m "$TITLE" ; then
             # Amending the commit worked
             git push -f
-            echo "::set-output name=result::success"
+            echo "result=success" >> $GITHUB_OUTPUT
           else
-            echo "::set-output name=result::error"
+            echo "result=error" >> $GITHUB_OUTPUT
           fi
 
       - name: Give feedback


### PR DESCRIPTION
Changes:

- Fix actions for set-output and save-state deprecations.
- update `actions/github-script` to new version from v3 to v6 (takes care of node v12 issue)
- update `actions/node-setup` from v3.4.1 to v3.6.0 (takes care of save-state issues)