### PR TITLE
chore: prevent dups runs on releases

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - master
+    tags-ignore: # prevents to run duplicated on releases
+      - '**'
   release:
     types:
       - created

--- a/src/components/nodes-table/nodes-table.js
+++ b/src/components/nodes-table/nodes-table.js
@@ -89,7 +89,7 @@ export default {
 						if (node.isSecure === true) {
 							v.icon = mdiCheckCircle
 							v.iconStyle =
-								node.security === 'S0_Legacy'
+								node.security === 'LOW SECURITY'
 									? `color: ${colors.orange.base}`
 									: `color: ${colors.green.base}`
 							v.description = node.security

--- a/src/components/nodes-table/nodes-table.js
+++ b/src/components/nodes-table/nodes-table.js
@@ -89,7 +89,7 @@ export default {
 						if (node.isSecure === true) {
 							v.icon = mdiCheckCircle
 							v.iconStyle =
-								node.security === 'LOW SECURITY'
+								node.security === 'S0_Legacy'
 									? `color: ${colors.orange.base}`
 									: `color: ${colors.green.base}`
 							v.description = node.security


### PR DESCRIPTION
This could fix the bug that for some reason stucks the release workflow and requires me to retrigger it