### PR TITLE
fix(discovery): add `state_class` to kwh sensors

### DIFF
--- a/lib/Constants.ts
+++ b/lib/Constants.ts
@@ -134,6 +134,7 @@ export function meterType(
 			switch (ccSpecific.scale) {
 				case 0x00: // kWh
 					cfg.props = {
+						state_class: 'total_increasing',
 						device_class: 'energy',
 					}
 					break


### PR DESCRIPTION
Add missing state_class attribute required for HA and energy statistics/dashboard

Fixes #2943 