### PR TITLE
chore(deps): remove support for node 14

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [14.x, 16.x, 18.x, 19.x]
+        node-version: [16.x, 18.x, 19.x]
 
     steps:
       - name: Checkout Z-Wave JS UI
@@ -32,12 +32,12 @@ jobs:
         run: yarn install --immutable
 
       - name: Lint
-        if: matrix['node-version'] == '14.x'
+        if: matrix['node-version'] == '18.x'
         run: yarn run lint
 
       - name: Prepare lint auto-fix patch
         if: |
-          matrix['node-version'] == '14.x' &&
+          matrix['node-version'] == '18.x' &&
           failure() &&
           github.event_name == 'pull_request'
         id: lint
@@ -55,7 +55,7 @@ jobs:
           fi
       - name: Upload Patch
         if: |
-          matrix['node-version'] == '14.x' &&
+          matrix['node-version'] == '18.x' &&
           failure() &&
           github.event_name == 'pull_request' &&
           steps.lint.outputs.changed == 'true'
@@ -68,13 +68,13 @@ jobs:
         run: yarn run test
 
       - name: Generate coverage report
-        if: matrix['node-version'] == '14.x'
+        if: matrix['node-version'] == '18.x'
         run: |
           yarn run coverage
           yarn run record-coverage
 
       - name: Coveralls
         uses: coverallsapp/github-action@master
-        if: matrix['node-version'] == '14.x'
+        if: matrix['node-version'] == '18.x'
         with:
           github-token: ${{ secrets.github_token }}

--- a/.github/workflows/update-dep.yml
+++ b/.github/workflows/update-dep.yml
@@ -21,10 +21,10 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Use Node.js 14
+      - name: Use Node.js 18
         uses: actions/setup-node@v3.6.0
         with:
-          node-version: 14.x
+          node-version: 18.x
           cache: 'yarn'
 
       - name: Update dependency

--- a/.github/workflows/zwave-js-bot_comment.yml
+++ b/.github/workflows/zwave-js-bot_comment.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: [ubuntu-latest]
     strategy:
       matrix:
-        node-version: [14.x]
+        node-version: [18.x]
 
     steps:
       - name: Checkout master branch
@@ -120,7 +120,7 @@ jobs:
     runs-on: [ubuntu-latest]
     strategy:
       matrix:
-        node-version: [14.x]
+        node-version: [18.x]
 
     steps:
       - name: Checkout master branch
@@ -216,7 +216,7 @@ jobs:
     runs-on: [ubuntu-latest]
     strategy:
       matrix:
-        node-version: [14.x]
+        node-version: [18.x]
 
     steps:
       - name: Checkout master branch


### PR DESCRIPTION
node 14 LTS security patches end in [2 months](https://endoflife.date/nodejs), so getting ahead of this and removing the references for node 14 and see what CI things it breaks