### PR TITLE
fix: toSubscribe being set to bool instead of map

### DIFF
--- a/lib/MqttClient.ts
+++ b/lib/MqttClient.ts
@@ -565,7 +565,7 @@ class MqttClient extends TypedEventEmitter<MqttClientEventCallbacks> {
 			subscribePromises.push(this.subscribe(t, this.toSubscribe.get(t)))
 		}
 
-		this.toSubscribe == new Map()
+		this.toSubscribe = new Map()
 
 		await allSettled(subscribePromises)
 


### PR DESCRIPTION
I setup [sonarcloud](https://sonarcloud.io/summary/overall?id=lightswitch05_zwave-js-ui) on my fork, and this was reported as a bug. I don't use the MQTT gateway on my local setup, so I'm not sure what type of testing is required, but it seems like a pretty obvious bug.