### PR TITLE
feat: websocket support to kubernetes configs

### DIFF
--- a/kubernetes/deployment.yaml
+++ b/kubernetes/deployment.yaml
@@ -31,6 +31,9 @@ spec:
         - containerPort: 8091
           name: http
           protocol: TCP
+        - containerPort: 3000
+          name: websocket
+          protocol: TCP
         resources:
           limits:
             cpu: "1"

--- a/kubernetes/service.yaml
+++ b/kubernetes/service.yaml
@@ -7,5 +7,8 @@ spec:
     - name: http
       port: 80
       targetPort: http
+    - name: websocket
+      port: 3000
+      targetPort: websocket
   selector:
     name: zwave


### PR DESCRIPTION
HomeAssistant needs to use the websocket APIs to operate, but the websocket port is not exposed in the current definitions. By declaring the port, one can write an `Ingress` if desired to expose the websocket server on port 80/443 like so:
```
apiVersion: networking.k8s.io/v1
kind: Ingress
metadata:
  name: zwave-ws
  annotations:
    cert-manager.io/cluster-issuer: "letsencrypt"
spec:
  tls:
  - hosts:
    - zwave-ws.example.com
    secretName: tls-zwave-ws-ingress-http
  rules:
    - host: zwave-ws.example.com
      http:
        paths:
        - path: /
          pathType: Prefix
          backend:
            service:
              name: zwave
              port:
                name: websocket
```