### PR TITLE
feat: bump zwave-js-server@1.27.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -122,7 +122,7 @@
     "@jamescoyle/vue-icon": "^0.1.2",
     "@kvaster/zwavejs-prom": "^0.0.2",
     "@mdi/js": "7.2.96",
-    "@zwave-js/server": "^1.26.0",
+    "@zwave-js/server": "^1.27.0",
     "@zwave-js/winston-daily-rotate-file": "^4.5.6-1",
     "ansi_up": "^5.1.0",
     "app-root-path": "^3.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3639,19 +3639,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@zwave-js/server@npm:^1.26.0":
-  version: 1.26.0
-  resolution: "@zwave-js/server@npm:1.26.0"
+"@zwave-js/server@npm:^1.27.0":
+  version: 1.27.0
+  resolution: "@zwave-js/server@npm:1.27.0"
   dependencies:
     "@homebridge/ciao": ^1.1.3
     minimist: ^1.2.5
     ws: ^8.0.0
   peerDependencies:
-    zwave-js: ^10.10.0
+    zwave-js: ^10.12.0
   bin:
     zwave-client: dist/bin/client.js
     zwave-server: dist/bin/server.js
-  checksum: 40426d00e615c81a7c8bfd74173da2d9fc7dbcd2e1a1df73efdeabcd374c4c89d4cfbfe36992f7cfe25ec5eb0eafe017f503fc4df480004decb179dd027b4d32
+  checksum: 15fb9c626b60539936417a545683c69ed275113ee84e10fb62b82a75e891d4446db8750b1c511502089ca5d9792f7b436959f666f91c4514b989e535f8b4717c
   languageName: node
   linkType: hard
 
@@ -16813,7 +16813,7 @@ __metadata:
     "@typescript-eslint/eslint-plugin": ^5.55.0
     "@typescript-eslint/parser": ^5.55.0
     "@vue/compiler-sfc": ^3.2.47
-    "@zwave-js/server": ^1.26.0
+    "@zwave-js/server": ^1.27.0
     "@zwave-js/winston-daily-rotate-file": ^4.5.6-1
     ansi_up: ^5.1.0
     app-root-path: ^3.1.0


### PR DESCRIPTION
as usual, would love a release for this so that we can include support for 10.11 and 10.12 features