### PR TITLE
fix: use CharDevice for USB device

### DIFF
--- a/kubernetes/deployment.yaml
+++ b/kubernetes/deployment.yaml
@@ -65,7 +65,7 @@ spec:
           # Do not use /dev/ttyUSBX serial devices, as those mappings can change over time.
           # Instead, use the /dev/serial/by-id/X serial device for your Z-Wave stick.
           path: /dev/serial/by-id/insert_stick_reference_here
-          type: File
+          type: CharDevice
       - name: data
         hostPath:
           path: /zwave/data


### PR DESCRIPTION
Using the kubernetes `deployment.yaml`, the pod fails to become healthy because of this error:

```
MountVolume.SetUp failed for volume "zwavestick" : hostPath type check failed: /dev/serial/by-id/usb-Silicon_Labs_CP2102N_USB_to_UART_Bridge_Controller_<snip> is not a file
```

And gets stuck in `ContainerCreating`:

```
$ kubectl get pod zwave-884dcdbb4-vhpjm -n homeassistant
NAME                    READY   STATUS              RESTARTS   AGE
zwave-884dcdbb4-vhpjm   0/1     ContainerCreating   0          54s
```

The error can be resolved by using the `CharDevice` [type](https://kubernetes.io/docs/concepts/storage/volumes/#hostpath) instead of `File`.

And the container becomes healthy and the USB device appears in the UI:

```
$ kubectl get pod zwave-7b98dbb456-s9hll -n homeassistant
NAME                     READY   STATUS    RESTARTS     AGE
zwave-7b98dbb456-s9hll   1/1     Running   1 (5s ago)   2m22s
```

![image](https://user-images.githubusercontent.com/3052593/227441755-53dddccd-2d54-43ba-88d4-4bf2dea9c6fa.png)
