### PR TITLE
chore: add launch task to start webpack and z-wave with F5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,7 +71,6 @@ typings/
 
 # Editor directories and files
 .idea
-.vscode
 *.suo
 *.ntvs*
 *.njsproj

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,18 @@
+{
+	"configurations": [
+		{
+			"type": "node",
+			"request": "launch",
+			"name": "Debug",
+			"runtimeExecutable": "yarn",
+			"runtimeArgs": [
+				"dev:server"
+			],
+			"env": {},
+			"console": "integratedTerminal",
+			"skipFiles": ["<node_internals>/**"],
+			"sourceMaps": true,
+			"preLaunchTask": "Webpack",
+		},
+	]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,42 @@
+{
+	// See https://go.microsoft.com/fwlink/?LinkId=733558
+	// for the documentation about the tasks.json format
+	"version": "2.0.0",
+	"tasks": [
+		{
+			"type": "npm",
+			"script": "dev",
+			"label": "Webpack",
+			"detail": "webpack serve --progress --host 0.0.0.0 --config build/webpack.dev.conf.js",
+			"isBackground": true,
+			"icon": {
+				"id": "server-process",
+				"color": "terminal.ansiBlue"
+			},
+			"problemMatcher": [
+				{
+					"owner": "webpack",
+					"severity": "error",
+					"fileLocation": "absolute",
+					"pattern": [
+						{
+							"regexp": "ERROR in [^ ]* (.*):(.*):(.*)",
+							"file": 1,
+							"line": 2,
+							"column": 3
+						},
+						{
+							"regexp": ".*",
+							"message": 0
+						}
+					],
+					"background": {
+						"activeOnStart": false,
+						"beginsPattern": "Project is running at",
+						"endsPattern": "compiled successfully"
+					}
+				}
+			],
+		}
+	]
+}


### PR DESCRIPTION
With this PR, one can just press F5 to start both the `dev` script (if not running yet) and the `dev:server` script for debugging, instead of having to start both manually via the CLI.

![grafik](https://user-images.githubusercontent.com/17641229/232569555-205035e8-9966-4b19-b318-b1c751029fbf.png)
