### PR TITLE
fix(ui): filter battery null values

### DIFF
--- a/lib/ZwaveClient.ts
+++ b/lib/ZwaveClient.ts
@@ -227,11 +227,11 @@ const observedCCProps: {
 } = {
 	[CommandClasses.Battery]: {
 		level(node, value) {
-			const levels: number[] = node.batteryLevels || []
+			const levels: { [key: number]: number } = node.batteryLevels || {}
 
 			levels[value.endpoint] = value.value
 			node.batteryLevels = levels
-			node.minBatteryLevel = Math.min(...levels)
+			node.minBatteryLevel = Math.min(...Object.values(levels))
 
 			this.emitNodeUpdate(node, {
 				batteryLevels: levels,
@@ -470,7 +470,7 @@ export type ZUINode = {
 	inited: boolean
 	healProgress?: HealNodeStatus | undefined
 	minBatteryLevel?: number
-	batteryLevels?: number[]
+	batteryLevels?: { [key: number]: number }
 	firmwareUpdate?: FirmwareUpdateProgress
 	firmwareCapabilities?: FirmwareUpdateCapabilities
 	eventsQueue: NodeEvent[]

--- a/src/components/nodes-table/SmartView.vue
+++ b/src/components/nodes-table/SmartView.vue
@@ -301,7 +301,7 @@ import {
 } from '@mdi/js'
 import { mapState } from 'pinia'
 import useBaseStore from '../../stores/base.js'
-import { jsonToList } from '../../lib/utils.js'
+import { getBatteryDescription, jsonToList } from '../../lib/utils.js'
 
 export default {
 	props: {
@@ -505,10 +505,7 @@ export default {
 				icon = mdiPowerPlug
 				description = 'Main power source'
 			} else {
-				description = Array.isArray(node.batteryLevels)
-					? 'All battery levels: ' +
-					  node.batteryLevels.map((v) => `${v}%`).join(',')
-					: 'Unknown battery level'
+				description = getBatteryDescription(node)
 				if (level <= 10) {
 					icon = mdiBatteryAlertVariantOutline
 					iconStyle = `color: ${colors.red.base}`

--- a/src/components/nodes-table/nodes-table.js
+++ b/src/components/nodes-table/nodes-table.js
@@ -26,6 +26,7 @@ import {
 	mdiSleep,
 } from '@mdi/js'
 import useBaseStore from '../../stores/base.js'
+import { getBatteryDescription } from '../../lib/utils.js'
 
 export default {
 	props: {
@@ -273,10 +274,7 @@ export default {
 				description = 'mains-powered'
 			} else {
 				label = `${level}%`
-				description = Array.isArray(node.batteryLevels)
-					? 'All battery levels: ' +
-					  node.batteryLevels.map((v) => `${v}%`).join(',')
-					: 'Unknown battery level'
+				description = getBatteryDescription(node)
 				if (level <= 10) {
 					icon = mdiBatteryAlertVariantOutline
 					iconStyle = `color: ${colors.red.base}`

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -166,3 +166,12 @@ export function arraysEqual(a, b) {
 
 	return true
 }
+
+export function getBatteryDescription(node) {
+	return typeof node.batteryLevels !== 'undefined'
+		? 'All battery levels: ' +
+				Object.values(node.batteryLevels)
+					.map((v) => `${v}%`)
+					.join(',')
+		: 'Unknown battery level'
+}

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -172,6 +172,6 @@ export function getBatteryDescription(node) {
 		? 'All battery levels: ' +
 				Object.values(node.batteryLevels)
 					.map((v) => `${v}%`)
-					.join(',')
+					.join(', ')
 		: 'Unknown battery level'
 }


### PR DESCRIPTION
For fibaro thermostat we may have endpoint 1 and endpoint 2 for batteries. In such case battery level for endpoint 0 will be also shown. And it will be shown as 'null' value.