### PR TITLE
feat: added state_class: measurement to appropriate sensors

### DIFF
--- a/lib/Constants.ts
+++ b/lib/Constants.ts
@@ -17,6 +17,7 @@ interface ISensorType {
 }
 
 interface ISensorProps {
+	state_class?: string
 	device_class?: string
 	unit_of_measurement?: string
 	icon?: string
@@ -140,16 +141,19 @@ export function meterType(
 					break
 				case 0x02: // W
 					cfg.props = {
+						state_class: 'measurement',
 						device_class: 'power',
 					}
 					break
 				case 0x04: // V
 					cfg.props = {
+						state_class: 'measurement',
 						device_class: 'voltage',
 					}
 					break
 				case 0x05: // A
 					cfg.props = {
+						state_class: 'measurement',
 						device_class: 'current',
 					}
 					break
@@ -204,12 +208,14 @@ export const _sensorMap: ISensorMap = {
 		77: 'discharge_line',
 		80: 'defrost',
 		props: {
+			state_class: 'measurement',
 			device_class: 'temperature',
 		},
 	},
 	illuminance: {
 		3: '', // illuminance
 		props: {
+			state_class: 'measurement',
 			device_class: 'illuminance',
 			unit_of_measurement: 'lx',
 		},
@@ -217,18 +223,21 @@ export const _sensorMap: ISensorMap = {
 	power: {
 		4: 'power',
 		props: {
+			state_class: 'measurement',
 			device_class: 'power',
 		},
 	},
 	voltage: {
 		15: 'voltage',
 		props: {
+			state_class: 'measurement',
 			device_class: 'voltage',
 		},
 	},
 	current: {
 		16: 'current',
 		props: {
+			state_class: 'measurement',
 			device_class: 'current',
 		},
 	},
@@ -236,6 +245,7 @@ export const _sensorMap: ISensorMap = {
 		28: 'resistivity',
 		29: 'conductivity',
 		props: {
+			state_class: 'measurement',
 			device_class: 'power',
 		},
 	},
@@ -243,6 +253,7 @@ export const _sensorMap: ISensorMap = {
 		5: 'air', // humidity
 		41: 'soil',
 		props: {
+			state_class: 'measurement',
 			device_class: 'humidity',
 		},
 	},
@@ -267,6 +278,7 @@ export const _sensorMap: ISensorMap = {
 		9: 'barometric',
 		57: 'water',
 		props: {
+			state_class: 'measurement',
 			device_class: 'pressure',
 		},
 	},
@@ -328,6 +340,7 @@ export const _sensorMap: ISensorMap = {
 	signal: {
 		58: 'strength',
 		props: {
+			state_class: 'measurement',
 			device_class: 'signal_strength',
 		},
 	},

--- a/package.sh
+++ b/package.sh
@@ -42,7 +42,7 @@ echo "App-name: $APP"
 VERSION=$(node -p "require('./package.json').version")
 echo "Version: $VERSION"
 
-NODE_MAJOR=$(node -v | egrep -o '[0-9].' | head -n 1)
+NODE_MAJOR=$(node -v | grep -E -o '[0-9].' | head -n 1)
 
 echo "## Clear $PKG_FOLDER folder"
 rm -rf $PKG_FOLDER/*
@@ -51,7 +51,7 @@ rm -rf $PKG_FOLDER/*
 if [[ "$@" == *"--arch"* ]]; then
 	ARCH=$(echo "$@" | grep -oP '(?<=--arch=)[^ ]+')
 else
-	ARCH=$(arch)
+	ARCH=$(uname -m)
 fi
 
 echo "## Architecture: $ARCH"
@@ -89,7 +89,7 @@ else
 	echo '## Choose architecture to build'
 	echo '###################################################'
 	echo ' '
-	echo 'Your architecture is' $(arch)
+	echo 'Your architecture is' $ARCH
 	PS3="Architecture: >"
 	options=(
 		"x64"

--- a/package.sh
+++ b/package.sh
@@ -66,7 +66,7 @@ if [ ! -z "$1" ]; then
 	else
 		echo "## Skipping build..."
 	fi
-	
+
 	if [ "$ARCH" = "aarch64" ] || [ "$ARCH" = "arm64" ]; then
 		echo "Executing command: pkg package.json -t node$NODE_MAJOR-linux-arm64 --out-path $PKG_FOLDER"
 		pkg package.json -t node$NODE_MAJOR-linux-arm64 --out-path $PKG_FOLDER
@@ -77,7 +77,7 @@ if [ ! -z "$1" ]; then
 		echo "Executing command: pkg package.json -t node$NODE_MAJOR-linux-x64,node$NODE_MAJOR-win-x64 --out-path $PKG_FOLDER"
 		pkg package.json -t node$NODE_MAJOR-linux-x64,node$NODE_MAJOR-win-x64  --out-path $PKG_FOLDER
 	fi
-	
+
 else
 
 	if ask "Re-build $APP?"; then
@@ -160,7 +160,7 @@ if [ ! -z "$1" ]; then
 		echo "## Create zip file $APP-v$VERSION-linux"
 		zip -r $APP-v$VERSION-linux.zip store $APP-linux
 	fi
-	
+
 else
 	echo "## Create zip file $APP-v$VERSION"
 	zip -r $APP-v$VERSION.zip store $APP

--- a/test/lib/Constants.test.ts
+++ b/test/lib/Constants.test.ts
@@ -32,7 +32,10 @@ describe('#Constants', () => {
 			expect(mod.sensorType(1)).to.deep.equal({
 				sensor: 'temperature',
 				objectId: 'air',
-				props: { device_class: 'temperature' },
+				props: {
+					device_class: 'temperature',
+					state_class: 'measurement',
+				},
 			}))
 		it('no props', () =>
 			expect(mod.sensorType(2)).to.deep.equal({


### PR DESCRIPTION
There are several sensor types that do not currently report a property of "state_class": "measurement" which means home-assistant does not have the ability to show them in a statistics graph. This causes issues for certain types of UI cards as they are unable to display any data. 

Documentation for the values is here: 

https://developers.home-assistant.io/docs/core/entity/sensor/#available-state-classes

I have run `yarn test` and `yarn lint` successfully. I have also updated the matching test. 

Additionally when trying to run `yarn pkg` I ran into two issues.

1. `egrep` deprecation (migrated to `grep -E` per: https://pubs.opengroup.org/onlinepubs/9699919799/utilities/grep.html)
1. `arch` command binary not available (migrated to `uname -m` per: https://linux.die.net/man/1/arch)

Testable container image is available here: `btreecat/zwave-js-ui-dev:feat-add-state-classes`