### PR TITLE
fix: authentication flow for JWT tokens

### DIFF
--- a/app.ts
+++ b/app.ts
@@ -762,13 +762,13 @@ async function isAuthenticated(req: Request, res: Response, next: () => void) {
 		next()
 	} catch (error) {
 		logger.debug('Authentication failed', error)
-	}
 
-	res.json({
-		success: false,
-		message: RESPONSE_CODES.GENERAL_ERROR,
-		code: 3,
-	})
+		res.json({
+			success: false,
+			message: RESPONSE_CODES.GENERAL_ERROR,
+			code: 3,
+		})
+	}
 }
 
 // logout the user


### PR DESCRIPTION
there was an error in the `isAuthenticated` function which also sent the `res.json(...)` error response after calling `next()` without returning from the function

this will fix #3133