### PR TITLE
fix: minor typo in ping and heal messages

### DIFF
--- a/src/mixins/InstancesMixin.js
+++ b/src/mixins/InstancesMixin.js
@@ -35,7 +35,7 @@ export default {
 
 			if (response.success && response.result) {
 				this.showSnackbar(
-					`Ping of node ${node.id} successfull`,
+					`Ping of node ${node.id} successful`,
 					'success'
 				)
 			} else {
@@ -57,7 +57,7 @@ export default {
 
 			if (response.success && response.result) {
 				this.showSnackbar(
-					`Heal of node ${node.id} successfull`,
+					`Heal of node ${node.id} successful`,
 					'success'
 				)
 			} else {


### PR DESCRIPTION
Fix a minor typo in the toast messages for ping and heal actions. This should read "successful", not "successfull". Thanks for this amazing project!

<img width="372" alt="image" src="https://github.com/zwave-js/zwave-js-ui/assets/4603901/c7a346e6-57f9-4a89-8684-0c70bd579c32">
