### PR TITLE
feat: bump zwave-js@11.8 and @zwave-js/server to 1.30.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -123,7 +123,7 @@
     "@jamescoyle/vue-icon": "^0.1.2",
     "@kvaster/zwavejs-prom": "^0.0.2",
     "@mdi/js": "7.2.96",
-    "@zwave-js/server": "^1.29.1",
+    "@zwave-js/server": "^1.30.0",
     "@zwave-js/winston-daily-rotate-file": "^4.5.6-1",
     "ansi_up": "^5.1.0",
     "app-root-path": "^3.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3648,19 +3648,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@zwave-js/server@npm:^1.29.1":
-  version: 1.29.1
-  resolution: "@zwave-js/server@npm:1.29.1"
+"@zwave-js/server@npm:^1.30.0":
+  version: 1.30.0
+  resolution: "@zwave-js/server@npm:1.30.0"
   dependencies:
     "@homebridge/ciao": ^1.1.3
     minimist: ^1.2.5
     ws: ^8.0.0
   peerDependencies:
-    zwave-js: ^11.1.0
+    zwave-js: ^11.5.3
   bin:
     zwave-client: dist/bin/client.js
     zwave-server: dist/bin/server.js
-  checksum: 93ab4aa06eccbad769213f137cbf616166d95eb765515917fd059e490229f2d4e3050916410ef2ce186869d87d159407f3ee9afe6b3ea255ae536cfe173c3d89
+  checksum: a242be23b00dbc463ed0559a50fade975c3c6a6ed00dc2fca40de61f8c4401c9b2a21eb39bc75dc70652217413c2aa9a079568cf3d6cf3fa25427b8980532091
   languageName: node
   linkType: hard
 
@@ -16205,7 +16205,7 @@ __metadata:
     "@typescript-eslint/eslint-plugin": ^5.55.0
     "@typescript-eslint/parser": ^5.55.0
     "@vue/compiler-sfc": ^3.2.47
-    "@zwave-js/server": ^1.29.1
+    "@zwave-js/server": ^1.30.0
     "@zwave-js/winston-daily-rotate-file": ^4.5.6-1
     ansi_up: ^5.1.0
     app-root-path: ^3.1.0


### PR DESCRIPTION
https://github.com/zwave-js/zwave-js-server/releases/tag/1.30.0