### PR TITLE
fix: remove controller default powerlevel message

### DIFF
--- a/src/components/nodes-table/NodeDetails.vue
+++ b/src/components/nodes-table/NodeDetails.vue
@@ -135,7 +135,7 @@
 				>
 					<small
 						>{{
-							`Please consult the manufacturer for the default values, as these can vary between different sticks. The defaults for most 700 series sticks are:\n- TX Power: 0.0 dBm\n- Measured output power at 0 dBm: +3.3 dBm`
+							`Please consult the manufacturer for the default values, as these can vary between different sticks.`
 						}}
 					</small>
 				</v-alert>


### PR DESCRIPTION
The message regarding the typical controller powerlevel settings is not really accurate anymore. Both Zooz and Aeotec use different values. It probably only applies to the UZB7 developer reference board and the US region, but even SiLabs has never provided correct numbers. It's better to just remove these as it causes confusion when using other models of controllers.
