### PR TITLE
fix(graph): match text color with icon color on ZWave Graph legend

### DIFF
--- a/src/components/custom/ZwaveGraph.vue
+++ b/src/components/custom/ZwaveGraph.vue
@@ -400,22 +400,22 @@ export default {
 				},
 				{
 					color: '#00BCD4',
-					textColor: '#006064',
+					textColor: '#00BCD4',
 					text: '1 hop',
 				},
 				{
 					color: '#2DCC70',
-					textColor: '#1D8548',
+					textColor: '#2DCC70',
 					text: '2 hops',
 				},
 				{
 					color: '#F1C40F',
-					textColor: '#D25400',
+					textColor: '#F1C40F',
 					text: '3 hops',
 				},
 				{
 					color: '#E77E23',
-					textColor: '#D25400',
+					textColor: '#E77E23',
 					text: '4 hops',
 				},
 				{


### PR DESCRIPTION
change the legend text color to match the legend icon's color.

Before (dark): 
![image](https://github.com/zwave-js/zwave-js-ui/assets/3521652/fed71bde-8ec6-418a-9d3c-ee1731d279d0)

Before (light):
![image](https://github.com/zwave-js/zwave-js-ui/assets/3521652/6683d8bc-8ced-48a9-bcb7-4e29a2724d7e)

After (dark):
![image](https://github.com/zwave-js/zwave-js-ui/assets/3521652/69af76d6-9f77-4132-af7f-87b2e77c971d)

After (light):
![image](https://github.com/zwave-js/zwave-js-ui/assets/3521652/e339b75f-92eb-42e9-9aeb-454c50a76543)

