### PR TITLE
fix: bump @zwave-js/server to 1.32.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -117,7 +117,7 @@
     "@jamescoyle/vue-icon": "^0.1.2",
     "@kvaster/zwavejs-prom": "^0.0.2",
     "@mdi/js": "7.2.96",
-    "@zwave-js/server": "^1.32.0",
+    "@zwave-js/server": "^1.32.1",
     "@zwave-js/winston-daily-rotate-file": "^4.5.6-1",
     "ansi_up": "^5.1.0",
     "app-root-path": "^3.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3058,9 +3058,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@zwave-js/server@npm:^1.32.0":
-  version: 1.32.0
-  resolution: "@zwave-js/server@npm:1.32.0"
+"@zwave-js/server@npm:^1.32.1":
+  version: 1.32.1
+  resolution: "@zwave-js/server@npm:1.32.1"
   dependencies:
     "@homebridge/ciao": ^1.1.7
     minimist: ^1.2.8
@@ -3070,7 +3070,7 @@ __metadata:
   bin:
     zwave-client: dist/bin/client.js
     zwave-server: dist/bin/server.js
-  checksum: 68cfcd166f785721d2e3c703194c10999c86827fe67633ed0f5a7dc601f4eb3b4923e995cd2ac9e8de7f3b49df5ca4c97dd8f6d7de2bc0f043bc20da73a0eb9e
+  checksum: 6e27bd99275f5c4c42bafaed6ed897908ef13581dc98e334edfb54d84a7cf32aec396af4acecab98450ee8a5ae42b08942983c4d51bd84c82dd89825e12b715c
   languageName: node
   linkType: hard
 
@@ -14486,7 +14486,7 @@ __metadata:
     "@typescript-eslint/eslint-plugin": ^5.55.0
     "@typescript-eslint/parser": ^5.55.0
     "@vitejs/plugin-vue2": ^2.2.0
-    "@zwave-js/server": ^1.32.0
+    "@zwave-js/server": ^1.32.1
     "@zwave-js/winston-daily-rotate-file": ^4.5.6-1
     ansi_up: ^5.1.0
     app-root-path: ^3.1.0


### PR DESCRIPTION
@robertsLando 1.32.0 breaks HA for people not on the beta. Can we merge and release this package update?