### PR TITLE
fix: don't create `STORE_DIR/logs` if `ZWAVEJS_LOGS_DIR` is setted

### DIFF
--- a/api/config/app.ts
+++ b/api/config/app.ts
@@ -6,7 +6,8 @@ config({ path: './.env.app' })
 // config/app.js
 export const title: string = 'Z-Wave JS UI'
 export const storeDir: string = process.env.STORE_DIR || joinPath(true, 'store')
-export const logsDir: string = process.env.ZWAVEJS_LOGS_DIR || joinPath(storeDir, 'logs')
+export const logsDir: string =
+	process.env.ZWAVEJS_LOGS_DIR || joinPath(storeDir, 'logs')
 export const snippetsDir: string = joinPath(storeDir, 'snippets')
 
 export const tmpDir: string = joinPath(storeDir, '.tmp')

--- a/api/config/app.ts
+++ b/api/config/app.ts
@@ -6,7 +6,7 @@ config({ path: './.env.app' })
 // config/app.js
 export const title: string = 'Z-Wave JS UI'
 export const storeDir: string = process.env.STORE_DIR || joinPath(true, 'store')
-export const logsDir: string = joinPath(storeDir, 'logs')
+export const logsDir: string = process.env.ZWAVEJS_LOGS_DIR || joinPath(storeDir, 'logs')
 export const snippetsDir: string = joinPath(storeDir, 'snippets')
 
 export const tmpDir: string = joinPath(storeDir, '.tmp')

--- a/api/lib/ZwaveClient.ts
+++ b/api/lib/ZwaveClient.ts
@@ -305,10 +305,7 @@ export type SensorTypeScale = {
 
 export type AllowedApis = (typeof allowedApis)[number]
 
-const ZWAVEJS_LOG_FILE = utils.joinPath(
-	process.env.ZWAVEJS_LOGS_DIR || logsDir,
-	'zwavejs_%DATE%.log',
-)
+const ZWAVEJS_LOG_FILE = utils.joinPath(logsDir, 'zwavejs_%DATE%.log')
 
 export type ZUIValueIdState = {
 	text: string


### PR DESCRIPTION
Currently, if `ZWAVEJS_LOGS_DIR` is setted, the `STORE_DIR/logs` directory continues to be created without any content being saved in it.