### PR TITLE
fix: check for undefined driver

### DIFF
--- a/api/lib/ZwaveClient.ts
+++ b/api/lib/ZwaveClient.ts
@@ -3990,7 +3990,7 @@ class ZwaveClient extends TypedEventEmitter<ZwaveClientEventCallbacks> {
 
 		logger.log('info', 'Calling api %s with args: %o', apiName, args)
 
-		if (this.driverReady || this.driver.isInBootloader()) {
+		if (this.driverReady || this.driver?.isInBootloader()) {
 			try {
 				const allowed =
 					typeof this[apiName] === 'function' &&


### PR DESCRIPTION
Fixes #3461.

If the driver has not been created, and some Z-Wave client API is called, an exception is thrown:

```text
2023-12-02 12:04:48.586 INFO Z-WAVE: Calling api getProvisioningEntries with args: [ [length]: 0 ]
2023-12-02 12:04:48.586 ERROR APP: Unhandled Rejection, reason: TypeError: Cannot read properties of undefined (reading 'isInBootloader')
TypeError: Cannot read properties of undefined (reading 'isInBootloader')
    at ZwaveClient.callApi (/home/keith/src/zwave-js-ui/src/api/lib/ZwaveClient.ts:2710:41)
    at Socket.<anonymous> (/home/keith/src/zwave-js-ui/src/api/app.ts:518:41)
    at Socket.emit (node:events:529:35)
    at Socket.emitUntyped (/home/keith/src/zwave-js-ui/src/node_modules/socket.io/dist/typed-events.js:69:22)
    at /home/keith/src/zwave-js-ui/src/node_modules/socket.io/dist/socket.js:704:39
    at processTicksAndRejections (node:internal/process/task_queues:77:11)
```

A fix is to check for an undefined `this.driver` before checking the `isInBootloader` property.

Now, instead of an exception, in some places an error will be reported. Here's the provisioning list:

![image](https://github.com/zwave-js/zwave-js-ui/assets/791794/8c9f4a7c-18c9-4b47-88d6-d42630392a4c)

However, going to the Network map just results in an infinite progress indicator:

![image](https://github.com/zwave-js/zwave-js-ui/assets/791794/bafa1772-6e94-4a46-ab39-4c4dca6f0d63)

Presumably no error is shown because it appears to be disabled on purpose:

https://github.com/zwave-js/zwave-js-ui/blob/e6710bbbc61a494dc545d0a41b9b2827f2b5d796/src/views/Mesh.vue#L192-L196

Not sure if it's important to handle this or not, but at least the exception is avoided and the error is logged:

```text
2023-12-02 12:17:14.282 INFO Z-WAVE: Calling api refreshNeighbors with args: [ [length]: 0 ]
2023-12-02 12:17:14.282 INFO Z-WAVE: Z-Wave client not connected refreshNeighbors undefined
```