### PR TITLE
fix(ui): preferred scales alignment

### DIFF
--- a/src/views/Settings.vue
+++ b/src/views/Settings.vue
@@ -769,7 +769,11 @@
 											v-model="newZwave.logToFile"
 										></v-switch>
 									</v-col>
-									<v-col cols="12" sm="6" v-if="newZwave.logEnabled">
+									<v-col
+										cols="12"
+										sm="6"
+										v-if="newZwave.logEnabled"
+									>
 										<v-text-field
 											v-model.number="newZwave.maxFiles"
 											label="Max files"

--- a/src/views/Settings.vue
+++ b/src/views/Settings.vue
@@ -699,7 +699,7 @@
 										type="hidden"
 										:value="newZwave.disclaimerVersion"
 									/>
-									<v-col cols="12" sm="6" md="4">
+									<v-col cols="12" sm="6">
 										<v-autocomplete
 											hint="Select preferred sensors scales. You can select a scale For more info check https://github.com/zwave-js/node-zwave-js/blob/master/packages/config/config/sensorTypes.json"
 											persistent-hint

--- a/src/views/Settings.vue
+++ b/src/views/Settings.vue
@@ -769,7 +769,7 @@
 											v-model="newZwave.logToFile"
 										></v-switch>
 									</v-col>
-									<v-col cols="6" v-if="newZwave.logEnabled">
+									<v-col cols="12" sm="6" v-if="newZwave.logEnabled">
 										<v-text-field
 											v-model.number="newZwave.maxFiles"
 											label="Max files"
@@ -797,7 +797,7 @@
 											v-model="newZwave.nodeFilter"
 										></v-combobox>
 									</v-col>
-									<v-col cols="6">
+									<v-col cols="12" sm="6">
 										<v-text-field
 											v-model.number="
 												newZwave.commandsTimeout
@@ -810,7 +810,7 @@
 											type="number"
 										></v-text-field>
 									</v-col>
-									<v-col cols="6">
+									<v-col cols="12" sm="6">
 										<v-text-field
 											v-model.number="
 												newZwave.sendToSleepTimeout
@@ -823,7 +823,7 @@
 											type="number"
 										></v-text-field>
 									</v-col>
-									<v-col cols="6">
+									<v-col cols="12" sm="6">
 										<v-text-field
 											v-model.number="
 												newZwave.responseTimeout
@@ -836,7 +836,7 @@
 											type="number"
 										></v-text-field>
 									</v-col>
-									<v-col cols="6">
+									<v-col cols="12" sm="6">
 										<v-text-field
 											v-model.number="
 												newZwave.maxNodeEventsQueueSize


### PR DESCRIPTION
Correctly align `preferred scales` with `log enabled` on settings -> Zwave.

Currently:
![Captura desde 2023-12-22 14-41-31](https://github.com/zwave-js/zwave-js-ui/assets/63747287/27edbf44-f4a1-4a16-a8ed-1523705e3e36)

After:
![Captura desde 2023-12-22 14-43-06](https://github.com/zwave-js/zwave-js-ui/assets/63747287/b2e2744d-2b16-4f89-a7f5-5926a7126fe6)
