### PR TITLE
feat(discovery): add support for availability topics

### DIFF
--- a/api/lib/Gateway.ts
+++ b/api/lib/Gateway.ts
@@ -931,7 +931,7 @@ export default class Gateway {
 					// Set device information using node info
 					payload.device = this._deviceInfo(node, nodeName)
 
-					this._availabilityConfig(node, payload)
+					this.setDiscoveryAvailability(node, payload)
 
 					hassDevice.object_id = utils
 						.sanitizeTopic(hassDevice.object_id, true)
@@ -1673,7 +1673,7 @@ export default class Gateway {
 				payload.command_topic = setTopic || getTopic + '/set'
 			}
 
-			this._availabilityConfig(node, payload)
+			this.setDiscoveryAvailability(node, payload)
 
 			if (
 				['binary_sensor', 'sensor', 'lock', 'climate', 'fan'].includes(
@@ -2370,7 +2370,7 @@ export default class Gateway {
 		}
 	}
 
-	private _availabilityConfig(
+	private setDiscoveryAvailability(
 		node: ZUINode,
 		payload: { [key: string]: any },
 	) {

--- a/api/lib/Gateway.ts
+++ b/api/lib/Gateway.ts
@@ -1677,22 +1677,24 @@ export default class Gateway {
 				{
 					payload_available: 'true',
 					payload_not_available: 'false',
-					topic: this.mqtt.getTopic(this.nodeTopic(node)) + '/status'
+					topic: this.mqtt.getTopic(this.nodeTopic(node)) + '/status',
 				},
 				{
 					topic: this.mqtt.getStatusTopic(),
-					value_template: "{{'online' if value_json.value else 'offline'}}"
+					value_template:
+						"{{'online' if value_json.value else 'offline'}}",
 				},
 				{
 					payload_available: 'true',
 					payload_not_available: 'false',
-					topic: this.mqtt.getTopic('driver/status')
-				}
+					topic: this.mqtt.getTopic('driver/status'),
+				},
 			]
 			if (this.config.payloadType !== PAYLOAD_TYPE.RAW) {
-				payload.availability[0].value_template = "{{'true' if value_json.value else 'false'}}"
+				payload.availability[0].value_template =
+					"{{'true' if value_json.value else 'false'}}"
 			}
-			payload.availability_mode = "all"
+			payload.availability_mode = 'all'
 
 			if (
 				['binary_sensor', 'sensor', 'lock', 'climate', 'fan'].includes(

--- a/api/lib/MqttClient.ts
+++ b/api/lib/MqttClient.ts
@@ -116,6 +116,13 @@ class MqttClient extends TypedEventEmitter<MqttClientEventCallbacks> {
 	}
 
 	/**
+	 * Returns the topic used to report client status
+	 */
+	getStatusTopic() {
+		return this.getClientTopic(MqttClient.STATUS_TOPIC)
+	}
+
+	/**
 	 * Method used to close clients connection, use this before destroy
 	 */
 	close(): Promise<void> {
@@ -352,7 +359,7 @@ class MqttClient extends TypedEventEmitter<MqttClientEventCallbacks> {
 			clean: config.clean,
 			rejectUnauthorized: !config.allowSelfsigned,
 			will: {
-				topic: this.getClientTopic(MqttClient.STATUS_TOPIC),
+				topic: this.getStatusTopic(),
 				payload: JSON.stringify({ value: false }) as any,
 				qos: this.config.qos,
 				retain: this.config.retain,


### PR DESCRIPTION
Require the client to be connected (LWT will set to false when MQTT connection is lost because the process goes down), the driver to be ready, and the individual node to be online