### PR TITLE
feat: expose configuration properties via HASS discovery

### DIFF
--- a/api/hass/configurations.ts
+++ b/api/hass/configurations.ts
@@ -18,6 +18,8 @@ type HassDeviceKey =
 	| 'thermostat'
 	| 'fan'
 	| 'sound_switch'
+	| 'config_switch'
+	| 'config_number'
 
 const configurations: Record<HassDeviceKey, HassDevice> = {
 	// Binary sensor https://www.home-assistant.io/components/binary_sensor.mqtt
@@ -216,6 +218,31 @@ const configurations: Record<HassDeviceKey, HassDevice> = {
 			payload_on: 25,
 			state_value_template: '{{ value_json.value | int }}',
 			speed_value_template: '{{ value_json.value | int }}',
+		},
+	},
+
+	config_switch: {
+		type: 'switch',
+		object_id: 'config_switch',
+		discovery_payload: {
+			payload_off: '0',
+			payload_on: '1',
+			value_template: '{{ value_json.value }}',
+			command_topic: true,
+			enabled_by_default: false,
+			entity_category: 'config',
+		},
+	},
+
+	// https://www.home-assistant.io/integrations/number.mqtt
+	config_number: {
+		type: 'number',
+		object_id: 'config_number',
+		discovery_payload: {
+			value_template: '{{ value_json.value }}',
+			command_topic: true,
+			enabled_by_default: false,
+			entity_category: 'config',
 		},
 	},
 }

--- a/api/lib/Gateway.ts
+++ b/api/lib/Gateway.ts
@@ -1654,6 +1654,50 @@ export default class Gateway {
 					}
 					break
 				}
+				case CommandClasses.Configuration: {
+					if (!valueId.writeable) {
+						return
+					}
+					let type = valueId.type
+					if (
+						type === 'number' &&
+						valueId.min === 0 &&
+						valueId.max === 1
+					) {
+						type = 'boolean'
+					}
+					switch (type) {
+						case 'boolean':
+							cfg = utils.copy(hassCfg.config_switch)
+
+							// Combine unique Object id, by using all possible scenarios
+							cfg.object_id = utils.joinProps(
+								cfg.object_id,
+								valueId.property,
+								valueId.propertyKey,
+							)
+							break
+						case 'number':
+							cfg = utils.copy(hassCfg.config_number)
+
+							// Combine unique Object id, by using all possible scenarios
+							cfg.object_id = utils.joinProps(
+								cfg.object_id,
+								valueId.property,
+								valueId.propertyKey,
+							)
+							if (valueId.min !== 1) {
+								cfg.discovery_payload.min = valueId.min
+							}
+							if (valueId.max !== 100) {
+								cfg.discovery_payload.max = valueId.max
+							}
+							break
+						default:
+							return
+					}
+					break
+				}
 				default:
 					return
 			}

--- a/api/lib/ZwaveClient.ts
+++ b/api/lib/ZwaveClient.ts
@@ -403,6 +403,7 @@ export type HassDevice = {
 		| 'lock'
 		| 'switch'
 		| 'fan'
+		| 'number'
 	object_id: string
 	discovery_payload: { [key: string]: any }
 	discoveryTopic?: string


### PR DESCRIPTION
but disable them by default. this gives you the option of creating automations around them if you desire, or ignoring them if you don't need them