### PR TITLE
change default for central_scene value_template for MQTT AD

### DIFF
--- a/api/hass/configurations.ts
+++ b/api/hass/configurations.ts
@@ -46,7 +46,7 @@ const configurations: Record<HassDeviceKey, HassDevice> = {
 		object_id: 'scene_state',
 		discovery_payload: {
 			state_topic: true,
-			value_template: "{{ value_json.value | default('') }}",
+			value_template: '{{ value_json.value | default(0) }}',
 		},
 	},
 	// Light https://www.home-assistant.io/components/light.mqtt


### PR DESCRIPTION
to be a number, not a string, since it's a number data type now

refs #3570

tested against openHAB and Home Assistant