### PR TITLE
fix(mqtt-ad): revert setting state_class on central scene entities

### DIFF
--- a/api/lib/Gateway.ts
+++ b/api/lib/Gateway.ts
@@ -1330,9 +1330,6 @@ export default class Gateway {
 						valueId.property,
 						valueId.propertyKey,
 					)
-					if (valueId.type === 'number') {
-						cfg.discovery_payload.state_class = 'measurement'
-					}
 					break
 				case CommandClasses['Binary Sensor']: {
 					// https://github.com/zwave-js/node-zwave-js/blob/master/packages/zwave-js/src/lib/commandclass/BinarySensorCC.ts#L41


### PR DESCRIPTION
While it is a number, it also often has no value at all, and Home Assistant can't deal with that properly, so leaving it as a string that can default to an empty string when it has no value is a better solution.

Refs #3570