### PR TITLE
fix(ui): use vuetify's material design palette colors for protocol color

### DIFF
--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -1,4 +1,5 @@
 import { isValidDSK, Protocols } from '@zwave-js/core/safe'
+import colors from 'vuetify/lib/util/colors'
 
 export function copy(o) {
 	return JSON.parse(JSON.stringify(o))
@@ -194,10 +195,10 @@ export function getProtocol(node) {
 export function getProtocolColor(node) {
 	switch (node.protocol) {
 		case Protocols.ZWave:
-			return 'blue'
+			return colors.blue.base
 		case Protocols.ZWaveLongRange:
-			return 'purple'
+			return colors.purple.base
 		default:
-			return 'grey'
+			return colors.grey.base
 	}
 }


### PR DESCRIPTION
This PR is intended to update the colors of the protocol icons to those of the [Material design palette offered by Vuetify](https://vuetifyjs.com/en/styles/colors/#material-colors). This matches the color palette of the other columns in the node table.

Considerations:
* In the spirit of an easily digestible PR, I am not addressing non-Material colors elsewhere in the ZWJS UI
* I tried using `colors.indigo.base` for `Protocols.ZWave`, but the contrast between ZWave and ZWaveLongRange wasn't great. There isn't a good color in the material design palette that's close to the outdated `rgb(0, 0, 255)` color -- perhaps one of the indigo/blue accent colors would better match the original author's intention.
* There's no requirement to adhere to the original author's intention -- it's not like we're using colors chosen by the Z-Wave Alliance to represent protocol icons, so we could pick something other than blue if it feels like those are too close to the app's primary color.

Before:
![image](https://github.com/zwave-js/zwave-js-ui/assets/9013284/adaece67-efee-4dc2-907d-69b0dc782836)

After:
![image](https://github.com/zwave-js/zwave-js-ui/assets/9013284/ab18dd49-84c5-45c3-820b-656dcfb7b532)
![image](https://github.com/zwave-js/zwave-js-ui/assets/9013284/845ad5c7-7294-4d53-afbb-675454039ebc)

