### PR TITLE
fix(ui): nodes table header from breaking line

### DIFF
--- a/src/components/nodes-table/ColumnFilter.vue
+++ b/src/components/nodes-table/ColumnFilter.vue
@@ -7,6 +7,7 @@
 				v-bind="attrs"
 				v-on="on"
 				title="Filter options..."
+				style="padding-right: 2px; padding-bottom: 3px"
 			>
 				{{ hasFilter ? 'filter_list_alt' : 'filter_list' }}
 			</v-icon>

--- a/src/components/nodes-table/index.vue
+++ b/src/components/nodes-table/index.vue
@@ -15,7 +15,7 @@
 		@input="managedNodes.selected = $event"
 		@click:row="toggleExpanded($event)"
 		item-key="id"
-		class="elevation-1"
+		class="elevation-1 nodes-table"
 		show-expand
 		show-select
 		:search="search"
@@ -134,7 +134,7 @@
 					@change="managedNodes.setPropFilter(column.value, $event)"
 					@update:group-by="managedNodes.groupBy = $event"
 				></column-filter>
-				{{ header.text }}
+				<span style="padding-right: 1px">{{ header.text }}</span>
 			</span>
 		</template>
 		<template
@@ -327,3 +327,18 @@
 </template>
 <script src="./nodes-table.js"></script>
 <style scoped src="./nodes-table.css"></style>
+<style>
+.nodes-table {
+	table {
+		tr {
+			th {
+				white-space: nowrap;
+			}
+			th,
+			td {
+				padding: 0 8px !important;
+			}
+		}
+	}
+}
+</style>


### PR DESCRIPTION
## Changes
Adjusts the headers in the nodes-table to not break lines.
Adjust minor css of headers to make it pleasant

## Testing Artifacts
- Before:
  - <img width="1329" alt="image" src="https://github.com/zwave-js/zwave-js-ui/assets/1888323/2cafc663-252e-4c2b-bbaa-914fa3084179">
- After:
  - <img width="1329" alt="image" src="https://github.com/zwave-js/zwave-js-ui/assets/1888323/8cde79d6-9857-4c73-9ff5-4a2276ae8f12">
