### PR TITLE
fix(ui): broken auth for skeletons

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -271,13 +271,15 @@
 		<main style="height: 100%">
 			<v-main style="height: 100%">
 				<router-view
-					v-if="auth !== undefined && inited"
+					v-if="auth !== undefined && (skeletons == '' || inited)"
 					@import="importFile"
 					@export="exportConfiguration"
 					@showConfirm="confirm"
 					:socket="socket"
 				/>
-				<v-container v-else-if="auth !== undefined && !inited">
+				<v-container
+					v-else-if="auth !== undefined && !!skeletons && !inited"
+				>
 					<!-- put some skeleton loaders while loading settings -->
 					<v-skeleton-loader
 						v-for="(s, i) in skeletons"


### PR DESCRIPTION
## Changes
- Allows pages that do not have a skeleton type defined to pass through with router.
- Fixes #3737  issue with skeleton code blocked on init when need to login first before init finishes.

## Testing Artifacts
- Before:
  - Blank Screen   
  - <img width="1017" alt="image" src="https://github.com/zwave-js/zwave-js-ui/assets/1888323/083ca2f2-5360-4ade-84af-404ea7887b84">
- After:
  - Able to view login 
  - <img width="1017" alt="image" src="https://github.com/zwave-js/zwave-js-ui/assets/1888323/9ab2645a-6670-41a0-824a-4c5bf70ad2e6">
  - After login:
    - <img width="1017" alt="image" src="https://github.com/zwave-js/zwave-js-ui/assets/1888323/500a1714-58e7-426d-b2ec-a071505f568c">

