### PR TITLE
feat(env): add Long Range key overrides from env

### DIFF
--- a/api/lib/utils.ts
+++ b/api/lib/utils.ts
@@ -329,10 +329,7 @@ export function parseSecurityKeys(
 		'S2_AccessControl',
 		'S0_Legacy',
 	]
-	const availableLongRangeKeys = [
-		'S2_Authenticated',
-		'S2_AccessControl',
-	]
+	const availableLongRangeKeys = ['S2_Authenticated', 'S2_AccessControl']
 
 	const envKeys = Object.keys(process.env)
 		.filter((k) => k?.startsWith('KEY_'))
@@ -349,7 +346,7 @@ export function parseSecurityKeys(
 		}
 	}
 	// load long range security keys from env
-	for (const k of envKeys) {
+	for (const k of longRangeEnvKeys) {
 		if (availableLongRangeKeys.includes(k)) {
 			config.securityKeysLongRange[k] = process.env[`KEY_LR_${k}`]
 		}

--- a/api/lib/utils.ts
+++ b/api/lib/utils.ts
@@ -329,15 +329,29 @@ export function parseSecurityKeys(
 		'S2_AccessControl',
 		'S0_Legacy',
 	]
+	const availableLongRangeKeys = [
+		'S2_Authenticated',
+		'S2_AccessControl',
+	]
 
 	const envKeys = Object.keys(process.env)
 		.filter((k) => k?.startsWith('KEY_'))
 		.map((k) => k.substring(4))
 
+	const longRangeEnvKeys = Object.keys(process.env)
+		.filter((k) => k?.startsWith('KEY_LR_'))
+		.map((k) => k.substring(7))
+
 	// load security keys from env
 	for (const k of envKeys) {
 		if (availableKeys.includes(k)) {
 			config.securityKeys[k] = process.env[`KEY_${k}`]
+		}
+	}
+	// load long range security keys from env
+	for (const k of envKeys) {
+		if (availableLongRangeKeys.includes(k)) {
+			config.securityKeysLongRange[k] = process.env[`KEY_LR_${k}`]
 		}
 	}
 
@@ -359,10 +373,10 @@ export function parseSecurityKeys(
 
 	config.securityKeysLongRange = config.securityKeysLongRange || {}
 
-	// convert security keys to buffer
+	// convert long range security keys to buffer
 	for (const key in config.securityKeysLongRange) {
 		if (
-			availableKeys.includes(key) &&
+			availableLongRangeKeys.includes(key) &&
 			config.securityKeysLongRange[key].length === 32
 		) {
 			options.securityKeysLongRange[key] = Buffer.from(

--- a/docs/guide/env-vars.md
+++ b/docs/guide/env-vars.md
@@ -8,6 +8,8 @@ This is the list of the supported environment variables:
   - `KEY_S2_Unauthenticated`
   - `KEY_S2_Authenticated`
   - `KEY_S2_AccessControl`
+  - `KEY_LR_S2_Authenticated`
+  - `KEY_LR_S2_AccessControl`
 - HTTPS:
   - `HTTPS`: Enable https
   - `SSL_CERTIFICATE` (optional): Absolute path to SSL certificate (for Docker, ensure this is the path as it appears within the container)


### PR DESCRIPTION
Add environment variables to override the long range security keys.

  - `KEY_LR_S2_Authenticated`
  - `KEY_LR_S2_AccessControl`
  
  Ideally, this shouldn't any features outside of configuration of the long range security keys on startup.
Seems to work on my local setup now. 🎉 

## Related Issue

Fixes #3765 