### PR TITLE
fix(ui): trigger page reload on 401 (fix basic auth)

### DIFF
--- a/src/apis/ConfigApis.js
+++ b/src/apis/ConfigApis.js
@@ -66,7 +66,7 @@ export default {
 				Accept: 'application/json',
 			},
 		})
-		if (response.type === 'opaqueredirect') {
+		if (response.type === 'opaqueredirect' || response.status === 401) {
 			throw new axios.AxiosError(
 				'Caught redirect for auth-enabled, rethrowing',
 				response.status,


### PR DESCRIPTION
# Changes
Throw exception when `401` returned from `/auth-enabled` to trigger page reload. This is needed for  http basic auth to work properly.

# Details
I run zwave-js-ui behind basic http auth and get  "Unexpected end of JSON input" error after browser restart:
![Screenshot 2024-07-22 at 2 33 55 PM](https://github.com/user-attachments/assets/03df31b0-4b7f-416d-b8ee-b224307e7263)

This happens when `401` status is returned since Chrome keeps auth only until browser restart.
Typically Chrome would display the auth popup in this case  but turns out it doesn't work requests made by service workers:  
 https://issues.chromium.org/issues/40474438

This is essentially the same issue as  #3427 

FWIW Without this PR, it can be "fixed" with the following Caddy config (send `302` when `Authorization` header is missing)
```
(auth) {
        basicauth {
                ...
        }
}

zwave.mydomain.com {
        @auth_check {
                path /api/auth-enabled
                header !Authorization
        }
        # trigger redirect when auth header not set
        handle @auth_check {
               redir zwave.mydomain.com 302
        }
        handle {
                import auth
                reverse_proxy 127.0.0.1:8091
        }
}
```


