### PR TITLE
fix(discovery): use valueId endpoint device class for multilevel switch CC discovery

### DIFF
--- a/api/lib/Gateway.ts
+++ b/api/lib/Gateway.ts
@@ -1237,6 +1237,10 @@ export default class Gateway {
 
 			const cmdClass = valueId.commandClass
 
+			const deviceClass =
+				node.endpoints[valueId.endpoint]?.deviceClass ??
+				node.deviceClass
+
 			switch (cmdClass) {
 				case CommandClasses['Binary Switch']:
 				case CommandClasses['All Switch']:
@@ -1256,8 +1260,8 @@ export default class Gateway {
 					if (valueId.isCurrentValue) {
 						const specificDeviceClass =
 							Constants.specificDeviceClass(
-								node.deviceClass.generic,
-								node.deviceClass.specific,
+								deviceClass.generic,
+								deviceClass.specific,
 							)
 						// Use a cover_position configuration if ...
 						if (

--- a/api/lib/ZwaveClient.ts
+++ b/api/lib/ZwaveClient.ts
@@ -104,6 +104,7 @@ import {
 	ProvisioningEntryStatus,
 	AssociationCheckResult,
 	LinkReliabilityCheckResult,
+	DeviceClass,
 } from 'zwave-js'
 import { getEnumMemberName, parseQRCodeString } from 'zwave-js/Utils'
 import { logsDir, nvmBackupsDir, storeDir } from '../config/app'
@@ -467,6 +468,7 @@ export interface FwFile {
 export interface ZUIEndpoint {
 	index: number
 	label?: string
+	deviceClass?: DeviceClass
 }
 
 export enum ZUIScheduleEntryLockMode {
@@ -6007,6 +6009,7 @@ class ZwaveClient extends TypedEventEmitter<ZwaveClientEventCallbacks> {
 			return {
 				index: e.index,
 				label: e.endpointLabel || defaultLabel,
+				deviceClass: e.deviceClass,
 			}
 		})
 		node.isSecure = zwaveNode.isSecure

--- a/api/lib/ZwaveClient.ts
+++ b/api/lib/ZwaveClient.ts
@@ -104,7 +104,6 @@ import {
 	ProvisioningEntryStatus,
 	AssociationCheckResult,
 	LinkReliabilityCheckResult,
-	DeviceClass,
 } from 'zwave-js'
 import { getEnumMemberName, parseQRCodeString } from 'zwave-js/Utils'
 import { logsDir, nvmBackupsDir, storeDir } from '../config/app'
@@ -468,7 +467,11 @@ export interface FwFile {
 export interface ZUIEndpoint {
 	index: number
 	label?: string
-	deviceClass?: DeviceClass
+	deviceClass: {
+		basic: number
+		generic: number
+		specific: number
+	}
 }
 
 export enum ZUIScheduleEntryLockMode {
@@ -6009,7 +6012,11 @@ class ZwaveClient extends TypedEventEmitter<ZwaveClientEventCallbacks> {
 			return {
 				index: e.index,
 				label: e.endpointLabel || defaultLabel,
-				deviceClass: e.deviceClass,
+				deviceClass: {
+					basic: e.deviceClass?.basic,
+					generic: e.deviceClass?.generic.key,
+					specific: e.deviceClass?.specific.key,
+				},
 			}
 		})
 		node.isSecure = zwaveNode.isSecure


### PR DESCRIPTION
Fixes #3862