### PR TITLE
fix(ui): correct legend wrt nlwr

### DIFF
--- a/src/components/custom/NodePanel.vue
+++ b/src/components/custom/NodePanel.vue
@@ -99,7 +99,7 @@
 					</div>
 
 					<div v-if="nlwr">
-						<v-subheader>Next Last working route</v-subheader>
+						<v-subheader>Next to Last working route</v-subheader>
 						<v-list-item dense v-for="(s, i) in nlwr" :key="i">
 							<v-list-item-content>{{
 								s.title


### PR DESCRIPTION
Per [this Discord discussion](https://discord.com/channels/330944238910963714/332357267364249621/1284184575534305382) and a search of "NLWR" in the Z-Wave specifications, "Next Last" is the wrong name for the dashed line.