### PR TITLE
feat: add INGRESS_TOKEN env variable to set the ingress session cookie

### DIFF
--- a/docs/development/intro.md
+++ b/docs/development/intro.md
@@ -21,3 +21,4 @@ that you can use to redirect to a different backend:
 - **SERVER_SSL**: [Default: undefined] if set to a value it will use _https_/_wss_ to connect to the backend;
 - **SERVER_URL**: [Default: use the other variables] the full URL for the backend API, IE: `https://zwavetomqtt.home.net:8443/`
 - **SERVER_WS_URL**: [Default: use the other variables] the full URL for the backend Socket, IE: `wss://zwavetomqtt.home.net:8443/`
+- **INGRESS_TOKEN**: [Default: undefined] a token to set the ingress session cookie if you want to develop against a remote backend via an Hass.io Ingress;

--- a/vite.config.mjs
+++ b/vite.config.mjs
@@ -11,6 +11,7 @@ const proxyHostname = process.env.SERVER_HOST
 	? process.env.SERVER_HOST
 	: 'localhost'
 const proxyPort = process.env.SERVER_PORT ? process.env.SERVER_PORT : '8091'
+const ingressToken = process.env.INGRESS_TOKEN
 
 const proxyURL = process.env.SERVER_URL
 	? process.env.SERVER_URL
@@ -112,16 +113,25 @@ export default defineConfig(({ mode }) => {
 					ws: true,
 					secure: false, // allow self signed certificates
 					changeOrigin: true,
+					...(ingressToken && {
+						headers: { cookie: `ingress_session=${ingressToken}` },
+					}),
 				},
 				'/health': {
 					target: proxyURL,
 					secure: false,
 					changeOrigin: true,
+					...(ingressToken && {
+						headers: { cookie: `ingress_session=${ingressToken}` },
+					}),
 				},
 				'/api': {
 					target: proxyURL,
 					secure: false,
 					changeOrigin: true,
+					...(ingressToken && {
+						headers: { cookie: `ingress_session=${ingressToken}` },
+					}),
 				},
 			},
 		},


### PR DESCRIPTION
`SERVER_URL=https://192.168.1.x:8123/api/hassio_ingress/abcdefg INGRESS_TOKEN=123456789  npm run dev`

![image](https://github.com/user-attachments/assets/7ab340a2-24e6-4002-a864-6cd4b06f38d9)

I needed a way to connect my local development frontend to the remote zwave-js-ui backend. Since the HASSIO docker container doesn't expose the port to the host the easiest way around it is via [Hass.io Ingress](https://www.home-assistant.io/blog/2019/04/15/hassio-ingress/). Unfortunately that needs cookie authentication, which can be easily injected via Vite's built-in proxy. This PR adds an `INGRESS_TOKEN` env variable where you can specify the token and it will take care of injecting the cookie for each API request. Use Chrome/Firefox DevTools to figure out what's the correct Ingress `SERVER_URL` and `INGRESS_TOKEN`.