### PR TITLE
feat: make default credentials for auth customizable

### DIFF
--- a/api/config/app.ts
+++ b/api/config/app.ts
@@ -16,8 +16,8 @@ export const backupsDir: string =
 export const nvmBackupsDir: string = joinPath(backupsDir, 'nvm')
 export const storeBackupsDir: string = joinPath(backupsDir, 'store')
 
-export const defaultUser: string = 'admin'
-export const defaultPsw: string = 'zwave'
+export const defaultUser: string = process.env.DEFAULT_USERNAME || 'admin'
+export const defaultPsw: string = process.env.DEFAULT_PASSWORD || 'zwave'
 // lgtm [js/hardcoded-credentials]
 export const sessionSecret: string =
 	process.env.SESSION_SECRET || 'DEFAULT_SESSION_SECRET_CHANGE_ME'

--- a/docs/guide/env-vars.md
+++ b/docs/guide/env-vars.md
@@ -2,6 +2,8 @@
 
 This is the list of the supported environment variables:
 
+- `DEFAULT_USERNAME`: The default username when auth is enabled.
+- `DEFAULT_PASSWORD`: The default password when auth is enabled.
 - `NETWORK_KEY`: Z-Wave S0 Network key. **Deprecated**
 - Network keys:
   - `KEY_S0_Legacy`


### PR DESCRIPTION
The current implementation defaults to username: `admin` and password: `zwave` when enabling auth. However, it can also be beneficial to make this customizable so that it can avoid some additional steps in updating these values.This is completely backwards compatible as well.

@robertsLando I didn't see any contributing guidelines, but if there's anything missing, please let me know.