### PR TITLE
fix: replace `import.meta.url` with CJS shim

### DIFF
--- a/esbuild-import-meta-url-shim.js
+++ b/esbuild-import-meta-url-shim.js
@@ -1,0 +1,5 @@
+export const __import_meta_url =
+	typeof document === 'undefined'
+		? new (require('url'.replace('', '')).URL)('file:' + __filename).href
+		: (document.currentScript && document.currentScript.src) ||
+			new URL('main.js', document.baseURI).href

--- a/esbuild.js
+++ b/esbuild.js
@@ -21,7 +21,7 @@ async function patchPkgJson(path) {
 	const pkgJsonPath = join(outputDir, path, 'package.json')
 	const pkgJson = require('./' + pkgJsonPath)
 	cleanPkgJson(pkgJson)
-	delete pkgJson.exports
+	delete pkgJson.scripts
 	await writeFile(pkgJsonPath, JSON.stringify(pkgJson, null, 2))
 }
 


### PR DESCRIPTION
fixes the new error "The argument 'filename' must be ..." reported in https://github.com/zwave-js/zwave-js-ui/issues/3995

fixes: #3995