### PR TITLE
Bump zwave-js and zwave-js-server

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@kvaster/zwavejs-prom": "^0.0.2",
         "@mdi/js": "7.4.47",
         "@zwave-js/log-transport-json": "^3.0.0",
-        "@zwave-js/server": "^1.40.0",
+        "@zwave-js/server": "^1.40.1",
         "ansi_up": "^6.0.2",
         "archiver": "^7.0.1",
         "axios": "^1.7.2",
@@ -60,7 +60,7 @@
         "vuetify": "^2.7.2",
         "winston": "^3.13.0",
         "winston-daily-rotate-file": "^5.0.0",
-        "zwave-js": "^14.3.2",
+        "zwave-js": "^14.3.4",
         "zxing-wasm": "^1.2.15"
       },
       "bin": {
@@ -4212,14 +4212,14 @@
       }
     },
     "node_modules/@zwave-js/cc": {
-      "version": "14.3.3",
-      "resolved": "https://registry.npmjs.org/@zwave-js/cc/-/cc-14.3.3.tgz",
-      "integrity": "sha512-E1J7xjLgoK59CMVkIX9GG5zIYSIL4tcJuvyDhBw1AW8rvnUxrcBPMKiF8msLTqROI8LdWyDcD/tQYb/s+kifyA==",
+      "version": "14.3.4",
+      "resolved": "https://registry.npmjs.org/@zwave-js/cc/-/cc-14.3.4.tgz",
+      "integrity": "sha512-8CTpjaluVsqiFc9VmNP61vb9UvVUvVo27Pd6Ke6iE9iTpI2MCF4Rv0ZyPyWdmYCZT9/glAC+kSIfa1/bXRKkkQ==",
       "license": "MIT",
       "dependencies": {
-        "@zwave-js/core": "14.3.3",
-        "@zwave-js/host": "14.3.3",
-        "@zwave-js/shared": "14.3.2",
+        "@zwave-js/core": "14.3.4",
+        "@zwave-js/host": "14.3.4",
+        "@zwave-js/shared": "14.3.4",
         "alcalzone-shared": "^5.0.0",
         "ansi-colors": "^4.1.3",
         "reflect-metadata": "^0.2.2"
@@ -4241,13 +4241,13 @@
       }
     },
     "node_modules/@zwave-js/config": {
-      "version": "14.3.3",
-      "resolved": "https://registry.npmjs.org/@zwave-js/config/-/config-14.3.3.tgz",
-      "integrity": "sha512-mXoQEGcUS38VGQ9P/SDxbaU6e159SaR9OtkfOHS7KEH2TBWku2lY814WHb6PiA1+zLetyApj+8BYLUpAAtsWow==",
+      "version": "14.3.4",
+      "resolved": "https://registry.npmjs.org/@zwave-js/config/-/config-14.3.4.tgz",
+      "integrity": "sha512-CHZHPtF8c0jJvCYwPxwTIu4Z5J05dl/CC3gVmxU1I2SOyOb++T2UK1B4Qrd+ENQv52o8PdOVJJrYPs/2bKFkEw==",
       "license": "MIT",
       "dependencies": {
-        "@zwave-js/core": "14.3.3",
-        "@zwave-js/shared": "14.3.2",
+        "@zwave-js/core": "14.3.4",
+        "@zwave-js/shared": "14.3.4",
         "alcalzone-shared": "^5.0.0",
         "ansi-colors": "^4.1.3",
         "json-logic-js": "^2.0.5",
@@ -4284,13 +4284,13 @@
       }
     },
     "node_modules/@zwave-js/core": {
-      "version": "14.3.3",
-      "resolved": "https://registry.npmjs.org/@zwave-js/core/-/core-14.3.3.tgz",
-      "integrity": "sha512-9k2KiDZKQTZye3AMl8KuiRMJx7YJNJtPqt4BIsBYEr8ik35KscvfGrIVbDIgRk15mqy3V5V3ptPWsE+XyzTRHw==",
+      "version": "14.3.4",
+      "resolved": "https://registry.npmjs.org/@zwave-js/core/-/core-14.3.4.tgz",
+      "integrity": "sha512-3kyJOK0Cp+k3gpqIz7YMTqnVE8FAU3iCLHzhGWYLDQGh+aiHA0jv+Oy5ckCjtCcTiPchp5r4jfQ//z91jJDEow==",
       "license": "MIT",
       "dependencies": {
         "@alcalzone/jsonl-db": "^3.1.1",
-        "@zwave-js/shared": "14.3.2",
+        "@zwave-js/shared": "14.3.4",
         "alcalzone-shared": "^5.0.0",
         "ansi-colors": "^4.1.3",
         "dayjs": "^1.11.13",
@@ -4333,14 +4333,14 @@
       }
     },
     "node_modules/@zwave-js/host": {
-      "version": "14.3.3",
-      "resolved": "https://registry.npmjs.org/@zwave-js/host/-/host-14.3.3.tgz",
-      "integrity": "sha512-00KOnDSH6vRbWMAbD5sd/OxqbQfDelqeuyDQrgV+0wTLTE0Q2A3fDXe78pDEd7XXfaQMbM3A6dRC9nXJzuvh9Q==",
+      "version": "14.3.4",
+      "resolved": "https://registry.npmjs.org/@zwave-js/host/-/host-14.3.4.tgz",
+      "integrity": "sha512-VkvglzjE+HgPOzwqpqJhK1DYurCM5jZhDjAnZZV8pPsMx24tfDs1k1YhqT8EmHpa/wDHV5qt+3O7af1jKO3jYQ==",
       "license": "MIT",
       "dependencies": {
-        "@zwave-js/config": "14.3.3",
-        "@zwave-js/core": "14.3.3",
-        "@zwave-js/shared": "14.3.2",
+        "@zwave-js/config": "14.3.4",
+        "@zwave-js/core": "14.3.4",
+        "@zwave-js/shared": "14.3.4",
         "alcalzone-shared": "^5.0.0"
       },
       "engines": {
@@ -4377,13 +4377,13 @@
       }
     },
     "node_modules/@zwave-js/nvmedit": {
-      "version": "14.3.3",
-      "resolved": "https://registry.npmjs.org/@zwave-js/nvmedit/-/nvmedit-14.3.3.tgz",
-      "integrity": "sha512-xuW3+u2EV7CLcRQf3lBSJbh+MzO95WL1ipe6vHSOiVmiuN0tEHs9WFMStckGvo2VpwiTTDlYwQBb5hQYQXDxRQ==",
+      "version": "14.3.4",
+      "resolved": "https://registry.npmjs.org/@zwave-js/nvmedit/-/nvmedit-14.3.4.tgz",
+      "integrity": "sha512-fSECPQ1ZDZCwKySxm54bhjYcv5P3U5fAqPZwEMGhQFJccbrKNk/s16d617Y+2s8ptkdSUmqosl2MLhvqpmNEXA==",
       "license": "MIT",
       "dependencies": {
-        "@zwave-js/core": "14.3.3",
-        "@zwave-js/shared": "14.3.2",
+        "@zwave-js/core": "14.3.4",
+        "@zwave-js/shared": "14.3.4",
         "alcalzone-shared": "^5.0.0",
         "reflect-metadata": "^0.2.2",
         "semver": "^7.6.3",
@@ -4523,16 +4523,16 @@
       }
     },
     "node_modules/@zwave-js/serial": {
-      "version": "14.3.3",
-      "resolved": "https://registry.npmjs.org/@zwave-js/serial/-/serial-14.3.3.tgz",
-      "integrity": "sha512-64cbZnbGjHen+TUBYmh0dTgrrMhR7BxEKOcyqFa/oqwiQz9j1IVwoa8Hg8vLkfBXxxu0RbQHNicx7Opaldzitw==",
+      "version": "14.3.4",
+      "resolved": "https://registry.npmjs.org/@zwave-js/serial/-/serial-14.3.4.tgz",
+      "integrity": "sha512-BfWhLSp6uLQbKFntW2FxSSbGKSn0ksnbHRe0T3VTi1GGC/brsMCGQjo+weW6j7MaVCw56NHfPpImJe6/eFVG6A==",
       "license": "MIT",
       "dependencies": {
         "@serialport/stream": "^12.0.0",
-        "@zwave-js/cc": "14.3.3",
-        "@zwave-js/core": "14.3.3",
-        "@zwave-js/host": "14.3.3",
-        "@zwave-js/shared": "14.3.2",
+        "@zwave-js/cc": "14.3.4",
+        "@zwave-js/core": "14.3.4",
+        "@zwave-js/host": "14.3.4",
+        "@zwave-js/shared": "14.3.4",
         "alcalzone-shared": "^5.0.0",
         "serialport": "^12.0.0",
         "winston": "^3.15.0"
@@ -4554,27 +4554,48 @@
       }
     },
     "node_modules/@zwave-js/server": {
-      "version": "1.40.0",
-      "resolved": "https://registry.npmjs.org/@zwave-js/server/-/server-1.40.0.tgz",
-      "integrity": "sha512-rPpCzQ5DTmssPQM60iofgj3sqpwVFiMvIOq/LCp3GQ7W3cuzxjPgUsuUESv49GKz8kbEdVZ9oN1nHQ4wN5DIyg==",
+      "version": "1.40.1",
+      "resolved": "https://registry.npmjs.org/@zwave-js/server/-/server-1.40.1.tgz",
+      "integrity": "sha512-0kzBxgFveRdFNrcke6aXpxMo8CX2i6+QZTH3tAOqJuJbm1Wyzy/FF4g7hK9vX3FTvmC8D5KsCDU/RggimJDQOw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@homebridge/ciao": "^1.1.7",
         "minimist": "^1.2.8",
-        "ws": "^8.13.0"
+        "ws": "^8.18.0"
       },
       "bin": {
-        "zwave-client": "dist/bin/client.js",
-        "zwave-server": "dist/bin/server.js"
+        "zwave-client": "dist-esm/bin/client.js",
+        "zwave-server": "dist-esm/bin/server.js"
       },
       "peerDependencies": {
         "zwave-js": "^14.0.0"
       }
     },
+    "node_modules/@zwave-js/server/node_modules/ws": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
+      "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@zwave-js/shared": {
-      "version": "14.3.2",
-      "resolved": "https://registry.npmjs.org/@zwave-js/shared/-/shared-14.3.2.tgz",
-      "integrity": "sha512-1d7JcEXOfD1byrkBI3yy/6S2xbsKMTC8FeBqeg6kZKfAJ7Rr8hkVgs6ajBdo60maFAkvuubQ2XlAp3x2+dRI/g==",
+      "version": "14.3.4",
+      "resolved": "https://registry.npmjs.org/@zwave-js/shared/-/shared-14.3.4.tgz",
+      "integrity": "sha512-gLpdzm/zrl+Z+dDujkk5eOPvPUMOmc07W4WXotr4RK3m3ZYf5pp93GzsetJcjTHvEkhZKKSRzNxTiXO/sEa1cw==",
       "license": "MIT",
       "dependencies": {
         "alcalzone-shared": "^5.0.0"
@@ -4596,15 +4617,15 @@
       }
     },
     "node_modules/@zwave-js/testing": {
-      "version": "14.3.3",
-      "resolved": "https://registry.npmjs.org/@zwave-js/testing/-/testing-14.3.3.tgz",
-      "integrity": "sha512-72gw3/kvbSRaRlwVgrM1yzBGcVBacJ8OsFkAIj+/p+vCYBIkplh2Fk5fX/e20Y09WuE//ejCZJ7pks4e/jEyhw==",
+      "version": "14.3.4",
+      "resolved": "https://registry.npmjs.org/@zwave-js/testing/-/testing-14.3.4.tgz",
+      "integrity": "sha512-fvb8ClGYsg1iiSX2WjmzUQYScTl0pQBsQHbjWmnHGKXkorhDzEosDNTKW+FaeLG/y+xSMAt8Rkf2KeeMU/QUBg==",
       "license": "MIT",
       "dependencies": {
-        "@zwave-js/core": "14.3.3",
-        "@zwave-js/host": "14.3.3",
-        "@zwave-js/serial": "14.3.3",
-        "@zwave-js/shared": "14.3.2",
+        "@zwave-js/core": "14.3.4",
+        "@zwave-js/host": "14.3.4",
+        "@zwave-js/serial": "14.3.4",
+        "@zwave-js/shared": "14.3.4",
         "alcalzone-shared": "^5.0.0",
         "ansi-colors": "^4.1.3"
       },
@@ -20292,21 +20313,21 @@
       }
     },
     "node_modules/zwave-js": {
-      "version": "14.3.3",
-      "resolved": "https://registry.npmjs.org/zwave-js/-/zwave-js-14.3.3.tgz",
-      "integrity": "sha512-1x/MIPoOh6UooVy8o7gEmYfDJ3LQ7PWHK69k0TmXOgW1O+FaaLSo9/HcfqUzly3EDjF07pE5RrLu24oZIqgAKA==",
+      "version": "14.3.4",
+      "resolved": "https://registry.npmjs.org/zwave-js/-/zwave-js-14.3.4.tgz",
+      "integrity": "sha512-VG+/NFud2icntEZOZ1qzxjoPmCt0eQHw9b7nmNQUeR2CdmcRyV1BhR+NhTiqdz2Hi7L94Z7ml0ZLZ9C8bfXM5A==",
       "license": "MIT",
       "dependencies": {
         "@alcalzone/jsonl-db": "^3.1.1",
         "@homebridge/ciao": "^1.3.1",
-        "@zwave-js/cc": "14.3.3",
-        "@zwave-js/config": "14.3.3",
-        "@zwave-js/core": "14.3.3",
-        "@zwave-js/host": "14.3.3",
-        "@zwave-js/nvmedit": "14.3.3",
-        "@zwave-js/serial": "14.3.3",
-        "@zwave-js/shared": "14.3.2",
-        "@zwave-js/testing": "14.3.3",
+        "@zwave-js/cc": "14.3.4",
+        "@zwave-js/config": "14.3.4",
+        "@zwave-js/core": "14.3.4",
+        "@zwave-js/host": "14.3.4",
+        "@zwave-js/nvmedit": "14.3.4",
+        "@zwave-js/serial": "14.3.4",
+        "@zwave-js/shared": "14.3.4",
+        "@zwave-js/testing": "14.3.4",
         "alcalzone-shared": "^5.0.0",
         "ansi-colors": "^4.1.3",
         "execa": "^5.1.1",

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "@kvaster/zwavejs-prom": "^0.0.2",
     "@mdi/js": "7.4.47",
     "@zwave-js/log-transport-json": "^3.0.0",
-    "@zwave-js/server": "^1.40.0",
+    "@zwave-js/server": "^1.40.1",
     "ansi_up": "^6.0.2",
     "archiver": "^7.0.1",
     "axios": "^1.7.2",
@@ -112,7 +112,7 @@
     "vuetify": "^2.7.2",
     "winston": "^3.13.0",
     "winston-daily-rotate-file": "^5.0.0",
-    "zwave-js": "^14.3.2",
+    "zwave-js": "^14.3.4",
     "zxing-wasm": "^1.2.15"
   },
   "devDependencies": {


### PR DESCRIPTION
Fixes issues with the hybrid ESM/CJS packages that caused the bundle size to double and broke some CC-related logic in the driver.