### PR TITLE
fix(ui): typo on NodeDetails.vue

### DIFF
--- a/src/components/nodes-table/NodeDetails.vue
+++ b/src/components/nodes-table/NodeDetails.vue
@@ -112,8 +112,8 @@
 			<v-col style="max-width: 700px" dense>
 				<v-alert text type="warning">
 					<strong
-						>DO NOT CHANGE THIS VALUES UNLESS YOU KNOW WHAT YOU ARE
-						DOING</strong
+						>DO NOT CHANGE THESE VALUES UNLESS YOU KNOW WHAT YOU ARE
+						DOING </strong
 					>
 					<small
 						>Increasing the TX power (normal power level) may be

--- a/src/components/nodes-table/NodeDetails.vue
+++ b/src/components/nodes-table/NodeDetails.vue
@@ -118,7 +118,7 @@
 					<small
 						>Increasing the TX power (normal power level) may be
 						<b>illegal</b>, depending on where you are
-						located</small
+						located. </small
 					>
 
 					<small

--- a/src/components/nodes-table/NodeDetails.vue
+++ b/src/components/nodes-table/NodeDetails.vue
@@ -113,13 +113,12 @@
 				<v-alert text type="warning">
 					<strong
 						>DO NOT CHANGE THESE VALUES UNLESS YOU KNOW WHAT YOU ARE
-						DOING </strong
-					>
+						DOING
+					</strong>
 					<small
 						>Increasing the TX power (normal power level) may be
-						<b>illegal</b>, depending on where you are
-						located. </small
-					>
+						<b>illegal</b>, depending on where you are located.
+					</small>
 
 					<small
 						>Increasing the TX power will only make the nodes "hear"


### PR DESCRIPTION
Correcting a grammatical mishap and fixing a visual glitch where two texts are squished together