### PR TITLE
feat: add default value for external Z-Wave JS config database path

### DIFF
--- a/api/config/app.ts
+++ b/api/config/app.ts
@@ -16,6 +16,8 @@ export const backupsDir: string =
 export const nvmBackupsDir: string = joinPath(backupsDir, 'nvm')
 export const storeBackupsDir: string = joinPath(backupsDir, 'store')
 
+export const configDbDir: string = joinPath(storeDir, '.config-db')
+
 export const defaultUser: string = process.env.DEFAULT_USERNAME || 'admin'
 export const defaultPsw: string = process.env.DEFAULT_PASSWORD || 'zwave'
 // lgtm [js/hardcoded-credentials]

--- a/api/lib/ZwaveClient.ts
+++ b/api/lib/ZwaveClient.ts
@@ -110,7 +110,7 @@ import {
 	LinkReliabilityCheckResult,
 } from 'zwave-js'
 import { getEnumMemberName, parseQRCodeString } from 'zwave-js/Utils'
-import { logsDir, nvmBackupsDir, storeDir } from '../config/app'
+import { configDbDir, logsDir, nvmBackupsDir, storeDir } from '../config/app'
 import store from '../config/store'
 import jsonStore from './jsonStore'
 import * as LogManager from './logger'
@@ -2195,6 +2195,12 @@ class ZwaveClient extends TypedEventEmitter<ZwaveClientEventCallbacks> {
 			userAgent: {
 				[utils.pkgJson.name]: utils.pkgJson.version,
 			},
+		}
+
+		// when no env is specified copy config db to store dir
+		// fixes issues with pkg (and no more need to set this env on docker)
+		if (!process.env.ZWAVEJS_EXTERNAL_CONFIG) {
+			zwaveOptions.storage.deviceConfigExternalDir = configDbDir
 		}
 
 		if (this.cfg.rf) {

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -68,8 +68,6 @@ FROM base AS runtime
 # Copy files from previous build stage
 COPY --from=build-zui /usr/src/app /usr/src/app
 
-ENV ZWAVEJS_EXTERNAL_CONFIG=/usr/src/app/store/.config-db
-
 ENV TAG_NAME=${image_name}
 
 ENV NODE_ENV=production

--- a/docker/Dockerfile.contrib
+++ b/docker/Dockerfile.contrib
@@ -95,7 +95,6 @@ RUN mkdir my_dist \
 FROM node:18.14.2-bullseye
 LABEL maintainer="robertsLando"
 
-ENV ZWAVEJS_EXTERNAL_CONFIG=/usr/src/app/store/.config-db
 ENV NODE_ENV=production
 
 RUN \

--- a/docker/Dockerfile.debian
+++ b/docker/Dockerfile.debian
@@ -60,8 +60,6 @@ RUN apt-get update && apt-get install -y \
 # Copy files from the previous build stage
 COPY --from=build-zui /usr/src/app /usr/src/app
 
-ENV ZWAVEJS_EXTERNAL_CONFIG=/usr/src/app/store/.config-db
-
 ENV TAG_NAME=${image_name}
 
 ENV NODE_ENV=production

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -8,7 +8,6 @@ services:
     stop_signal: SIGINT
     environment:
       - SESSION_SECRET=mysupersecretkey
-      - ZWAVEJS_EXTERNAL_CONFIG=/usr/src/app/store/.config-db
       # Uncomment if you want logs time and dates to match your timezone instead of UTC
       # Available at https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
       #- TZ=America/New_York

--- a/docs/getting-started/docker.md
+++ b/docs/getting-started/docker.md
@@ -78,7 +78,6 @@ services:
         stop_signal: SIGINT
         environment:
             - SESSION_SECRET=mysupersecretkey
-            - ZWAVEJS_EXTERNAL_CONFIG=/usr/src/app/store/.config-db
             # Uncomment if you want log times and dates to match your timezone instead of UTC
             # Available at https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
             #- TZ=America/New_York

--- a/docs/getting-started/other-methods.md
+++ b/docs/getting-started/other-methods.md
@@ -55,7 +55,6 @@ Run with custom storage path:
 
 ```bash
 STORE_DIR=~/.zwave-js-ui \
-ZWAVEJS_EXTERNAL_CONFIG=~/.zwave-js-ui/.config-db \
 zwave-js-ui
 ```
 
@@ -77,7 +76,6 @@ module.exports = {
         script: "zwave-js-ui",
         env: {
           STORE_DIR: "~/.zwave-js-ui",
-          ZWAVEJS_EXTERNAL_CONFIG: "~/.zwave-js-ui/.config-db",
         },
       },
   ]

--- a/docs/guide/env-vars.md
+++ b/docs/guide/env-vars.md
@@ -22,7 +22,7 @@ This is the list of the supported environment variables:
 - `HOST`: The host address to bind to. Keep it empty to bind to all interfaces both IPv4 and IPv6
 - `STORE_DIR`: The absolute path to the directory where all files will be stored. Default is `<path to your zui dir>/store`
 - `BACKUPS_DIR`: The absolute path to the directory where all backups files will be stored. Default is `<path to your zui dir>/store/backups`
-- `ZWAVEJS_EXTERNAL_CONFIG`: Mostly needed for docker users, it's the path to the folder used by Z-Wave JS to [store config database](https://zwave-js.github.io/node-zwave-js/#/usage/external-config?id=specifying-an-external-config-db-location), by default on docker it is `/usr/src/app/store/.config-db`. For users that are using a custom `STORE_DIR` this must be changed too.
+- `ZWAVEJS_EXTERNAL_CONFIG`: It's the path to the folder used by Z-Wave JS to [store config database](https://zwave-js.github.io/node-zwave-js/#/usage/external-config?id=specifying-an-external-config-db-location), by default it is `<store_dir>/.config-db`.
 - `ZWAVEJS_LOGS_DIR`: The folder used to store Z-Wave JS logs if `Log to file` is selected in the Z-Wave settings. By default, this is the `store` folder.
 - `MQTT_NAME`: The name used as client name when connecting to the mqtt server. Overrides `mqtt.name` in `settings.json`
 - `DISABLE_LOG_ROTATION`: Set this env var to `'true'` to disable application log rotation management


### PR DESCRIPTION
This will prevent issues when not setting this env var causing `Writing the device index to disk failed: ENOENT: no such file or directory` on pkg

Ref #4053 #4003