### PR TITLE
fix(ui): set default iterations for link reliability check to 100

### DIFF
--- a/src/components/dialogs/DialogLinkReliability.vue
+++ b/src/components/dialogs/DialogLinkReliability.vue
@@ -266,7 +266,7 @@ export default {
 			],
 			infinite: false,
 			interval: 250,
-			iterations: 25,
+			iterations: 100,
 			statistics: null,
 			progress: 0,
 		}


### PR DESCRIPTION
Whenever I use this, I find myself setting the iterations to 100, so let's make it the default.