### PR TITLE
docs: typo on healthcheck.md curl command

### DIFF
--- a/docs/guide/healthcheck.md
+++ b/docs/guide/healthcheck.md
@@ -15,4 +15,4 @@ Using `wget`:
 
 Using `curl`:
 
-`curl localhost:8091/health/zwave -H "Accept: text/plain`
+`curl localhost:8091/health/zwave -H "Accept: text/plain"`


### PR DESCRIPTION
Fix unclosed string in curl healthcheck documentation.