### PR TITLE
Add learn mode support

### DIFF
--- a/api/lib/ZwaveClient.ts
+++ b/api/lib/ZwaveClient.ts
@@ -108,6 +108,9 @@ import {
 	ProvisioningEntryStatus,
 	AssociationCheckResult,
 	LinkReliabilityCheckResult,
+	JoinNetworkOptions,
+	JoinNetworkStrategy,
+	JoinNetworkResult,
 } from 'zwave-js'
 import { getEnumMemberName, parseQRCodeString } from 'zwave-js/Utils'
 import { configDbDir, logsDir, nvmBackupsDir, storeDir } from '../config/app'
@@ -217,6 +220,8 @@ export const allowedApis = validateMethods([
 	'checkForConfigUpdates',
 	'installConfigUpdate',
 	'shutdownZwaveAPI',
+	'startLearnMode',
+	'stopLearnMode',
 	'pingNode',
 	'restart',
 	'grantSecurityClasses',
@@ -2889,6 +2894,48 @@ class ZwaveClient extends TypedEventEmitter<ZwaveClientEventCallbacks> {
 		} else {
 			throw new DriverNotReadyError()
 		}
+	}
+
+	/**
+	 * Stops learn mode
+	 */
+	stopLearnMode(): Promise<boolean> {
+		if (this.driverReady) {
+			if (this.commandsTimeout) {
+				clearTimeout(this.commandsTimeout)
+				this.commandsTimeout = null
+			}
+			return this._driver.controller.stopJoiningNetwork()
+		}
+
+		throw new DriverNotReadyError()
+	}
+
+	/**
+	 * Starts learn mode
+	 */
+	async startLearnMode(): Promise<JoinNetworkResult> {
+		if (this.driverReady) {
+			if (this.commandsTimeout) {
+				clearTimeout(this.commandsTimeout)
+				this.commandsTimeout = null
+			}
+
+			this.commandsTimeout = setTimeout(
+				() => {
+					this.stopLearnMode().catch(logger.error)
+				},
+				(this.cfg.commandsTimeout || 0) * 1000 || 30000,
+			)
+
+			let joinNetworkOptions: JoinNetworkOptions = {
+				strategy: JoinNetworkStrategy.Default
+			}
+
+			return this._driver.controller.beginJoiningNetwork(joinNetworkOptions)
+		}
+
+		throw new DriverNotReadyError()
 	}
 
 	/**

--- a/src/views/ControlPanel.vue
+++ b/src/views/ControlPanel.vue
@@ -308,6 +308,21 @@ export default {
 					color: 'warning',
 					desc: 'Allows to shutdown the Zwave API to safely unplug the Zwave stick.',
 				},
+				{
+					text: 'Learn mode',
+					options: [
+						{
+							name: 'Start',
+							action: 'startLearnMode',
+							args: {
+								confirm:
+									'Initiate lear mode on primary controller first and then click OK here.',
+							},
+						},
+					],
+					icon: 'join_inner',
+					desc: 'Instruct controller to run learning mode (can join pre-existing network)',
+				},
 			],
 			rules: {
 				required: (value) => {

--- a/src/views/ControlPanel.vue
+++ b/src/views/ControlPanel.vue
@@ -316,7 +316,7 @@ export default {
 							action: 'startLearnMode',
 							args: {
 								confirm:
-									'Initiate lear mode on primary controller first and then click OK here.',
+									'Initiate learn mode on primary controller first and then click OK here.',
 							},
 						},
 					],


### PR DESCRIPTION
Add support of "learn mode". Controller can be added to pre-existing network and used as "secondary" controller.

[Driver function ref](https://github.com/zwave-js/node-zwave-js/blob/master/docs/api/controller.md#beginjoiningnetwork)

![Screenshot 2025-01-19 at 13 54 40](https://github.com/user-attachments/assets/7b4c3972-350b-4c2f-80e1-d2ae06acf891)
![image](https://github.com/user-attachments/assets/32e52610-7e4e-4028-ac12-bfb617f36fb6)
