### PR TITLE
feat: support changing max. LR powerlevel

### DIFF
--- a/src/components/nodes-table/NodeDetails.vue
+++ b/src/components/nodes-table/NodeDetails.vue
@@ -36,6 +36,34 @@
 			>
 
 			<v-row>
+				<v-col cols="12" style="max-width: 300px">
+					<v-select
+						label="RF Region"
+						:items="node.rfRegions"
+						v-model="node.RFRegion"
+					>
+						<template v-slot:append-outer>
+							<v-btn
+								color="primary"
+								small
+								icon
+								@click="updateControllerNodeProp('RFRegion')"
+							>
+								<v-icon>refresh</v-icon>
+							</v-btn>
+							<v-btn
+								color="primary"
+								small
+								icon
+								@click="updateRFRegion"
+							>
+								<v-icon>send</v-icon>
+							</v-btn>
+						</template>
+					</v-select>
+				</v-col>
+			</v-row>
+			<v-row>
 				<v-col cols="12" sm="6" style="max-width: 300px">
 					<v-text-field
 						label="Normal Power Level"
@@ -78,18 +106,24 @@
 						</template>
 					</v-text-field>
 				</v-col>
+			</v-row>
+			<v-row v-if="node.supportsLongRange">
 				<v-col cols="12" style="max-width: 300px">
 					<v-select
-						label="RF Region"
-						:items="node.rfRegions"
-						v-model="node.RFRegion"
+						label="Maximum LR Power Level"
+						:items="maxLRPowerLevels"
+						v-model="node.maxLongRangePowerlevel"
 					>
 						<template v-slot:append-outer>
 							<v-btn
 								color="primary"
 								small
 								icon
-								@click="updateControllerNodeProp('RFRegion')"
+								@click="
+									updateControllerNodeProp(
+										'maxLongRangePowerlevel',
+									)
+								"
 							>
 								<v-icon>refresh</v-icon>
 							</v-btn>
@@ -97,7 +131,7 @@
 								color="primary"
 								small
 								icon
-								@click="updateRFRegion"
+								@click="updateMaxLRPowerLevel"
 							>
 								<v-icon>send</v-icon>
 							</v-btn>
@@ -341,6 +375,7 @@
 <script>
 import { mapState, mapActions } from 'pinia'
 import { validTopic } from '../../lib/utils'
+import { maxLRPowerLevels } from '../../lib/items'
 import { ConfigValueFormat } from '@zwave-js/core/safe'
 import useBaseStore from '../../stores/base.js'
 import InstancesMixin from '../../mixins/InstancesMixin.js'
@@ -360,6 +395,7 @@ export default {
 			locError: null,
 			nameError: null,
 			options: {},
+			maxLRPowerLevels,
 			newName: this.node.name,
 			newLoc: this.node.loc,
 			configCCValueFormats: [
@@ -609,6 +645,22 @@ export default {
 
 				if (response.success) {
 					this.showSnackbar('RF Region updated', 'success')
+				}
+			}
+		},
+		async updateMaxLRPowerLevel() {
+			if (this.node) {
+				const args = [this.node.maxLongRangePowerlevel]
+				const response = await this.app.apiRequest(
+					'setMaxLRPowerLevel',
+					args,
+				)
+
+				if (response.success) {
+					this.showSnackbar(
+						'Maximum LR power level updated',
+						'success',
+					)
 				}
 			}
 		},

--- a/src/lib/items.js
+++ b/src/lib/items.js
@@ -33,3 +33,14 @@ export const protocolsItems = [
 		value: Protocols.ZWaveLongRange,
 	},
 ]
+
+export const maxLRPowerLevels = [
+	{
+		text: '+14 dBm',
+		value: 14,
+	},
+	{
+		text: '+20 dBm',
+		value: 20,
+	},
+]

--- a/src/stores/base.js
+++ b/src/stores/base.js
@@ -32,6 +32,7 @@ const useBaseStore = defineStore('base', {
 			logLevel: 'debug',
 			rf: {
 				region: undefined,
+				maxLongRangePowerlevel: undefined,
 				txPower: {
 					powerlevel: undefined,
 					measured0dBm: undefined,

--- a/src/views/Settings.vue
+++ b/src/views/Settings.vue
@@ -807,6 +807,20 @@
 											>
 											</v-select>
 										</v-col>
+										<v-col cols="6">
+											<v-select
+												label="Maximum LR Power Level"
+												persistent-hint
+												hint="The maximum power level to be used by the dynamic power algorithm of Z-Wave LR. Will be applied on every startup if the current setting of your Z-Wave controller differs. Only LR-capable controllers support this setting."
+												:items="maxLRPowerLevels"
+												clearable
+												v-model="
+													newZwave.rf
+														.maxLongRangePowerlevel
+												"
+											>
+											</v-select>
+										</v-col>
 									</v-row>
 									<v-row class="mt-0">
 										<v-col cols="12" sm="6">
@@ -2046,7 +2060,7 @@ import { mapActions, mapState } from 'pinia'
 import ConfigApis from '@/apis/ConfigApis'
 import { parse } from 'native-url'
 import { wait, copy, isUndef, deepEqual } from '../lib/utils'
-import { rfRegions, znifferRegions } from '../lib/items'
+import { rfRegions, znifferRegions, maxLRPowerLevels } from '../lib/items'
 import cronstrue from 'cronstrue'
 import useBaseStore from '../stores/base'
 
@@ -2201,6 +2215,7 @@ export default {
 		return {
 			rfRegions,
 			znifferRegions,
+			maxLRPowerLevels,
 			valid_zwave: true,
 			dialogValue: false,
 			sslDisabled: false,
@@ -2372,7 +2387,7 @@ export default {
 			return (
 				(validPower && validMeasured) ||
 				(!validPower && !validMeasured) ||
-				'Both powerlevel and measured 0 dBm must be set when using custom tx power'
+				'Both powerlevel and measured 0 dBm must be set when using custom TX power'
 			)
 		},
 		parseCron(cron) {


### PR DESCRIPTION
This PR adds support for changing the maximum powerlevel used by the LR dynamic power algorithm:

![grafik](https://github.com/user-attachments/assets/8dfc1f26-2542-4513-a0a8-8a1eca5a2976)

It also adds corresponding default settings in the settings tab.