### PR TITLE
fix: config path resolution inside pkg on Windows

### DIFF
--- a/api/lib/PkgFsBindings.ts
+++ b/api/lib/PkgFsBindings.ts
@@ -6,7 +6,10 @@ import path from 'node:path'
 // when running inside a `pkg` bundle. In this case, it will resolve its embedded
 // configuration dir to the path "/config", but the files reside in "node_modules/@zwave-js/config/config" instead.
 
-const CONFIG_PATH = path.resolve('/config')
+// Inside a pkg bundle, the current filename/directory is always "C:\...",
+// so the config dir needs to be resolved relative to __filename, otherwise
+// it would be relative to the current working directory, which might not be on the same drive.
+const CONFIG_PATH = path.resolve(__filename, '/config')
 const CONFIG_PATH_IN_PKG = path.join(
 	__dirname,
 	`node_modules/@zwave-js/config/config`,

--- a/api/lib/ZwaveClient.ts
+++ b/api/lib/ZwaveClient.ts
@@ -129,8 +129,9 @@ import backupManager, { NVM_BACKUP_PREFIX } from './BackupManager'
 import { socketEvents } from './SocketEvents'
 import { isUint8Array } from 'util/types'
 import { PkgFsBindings } from './PkgFsBindings'
+import { join } from 'path'
 
-export const deviceConfigPriorityDir = storeDir + '/config'
+export const deviceConfigPriorityDir = join(storeDir, 'config')
 
 export const configManager = new ConfigManager({
 	deviceConfigPriorityDir,


### PR DESCRIPTION
As it turns out, Z-Wave JS would always look for the config directory on `C:\` due to how the current filename is set inside pkg. `path.resolve` on the other hand takes the current process directory into account, which might be on a different drive.

fixes: https://github.com/zwave-js/zwave-js-ui/issues/4183