### PR TITLE
fix!: add OTW firmware update event handling

### DIFF
--- a/api/lib/SocketEvents.ts
+++ b/api/lib/SocketEvents.ts
@@ -22,6 +22,7 @@ export enum socketEvents {
 	znifferFrame = 'ZNIFFER_FRAME',
 	znifferState = 'ZNIFFER_STATE',
 	linkReliability = 'LINK_RELIABILITY',
+	otwFirmwareUpdate = 'OTW_FIRMWARE_UPDATE',
 }
 
 // events from client ---> server

--- a/api/lib/ZwaveClient.ts
+++ b/api/lib/ZwaveClient.ts
@@ -4530,58 +4530,35 @@ class ZwaveClient extends TypedEventEmitter<ZwaveClientEventCallbacks> {
 	}
 
 	private _onOTWFirmwareUpdateProgress(progress: OTWFirmwareUpdateProgress) {
-		const nodeId = this.driver.controller.ownNodeId
-		const node = this.nodes.get(nodeId)
-		if (node) {
-			node.firmwareUpdate = {
-				sentFragments: progress.sentFragments,
-				totalFragments: progress.totalFragments,
-				progress: progress.progress,
-				currentFile: node.firmwareUpdate?.currentFile ?? 1,
-				totalFiles: node.firmwareUpdate?.currentFile ?? 1,
-			}
-
-			// send at most 4msg per second
-			this.throttle(
-				this._onOTWFirmwareUpdateProgress.name,
-				this.emitNodeUpdate.bind(this, node, {
-					firmwareUpdate: node.firmwareUpdate,
-				} as utils.DeepPartial<ZUINode>),
-				250,
-			)
-		}
+		this.throttle(
+			this._onOTWFirmwareUpdateProgress.name,
+			this.sendToSocket.bind(this, socketEvents.otwFirmwareUpdate, {
+				progress,
+			}),
+			250,
+		)
 
 		this.emit(
 			'event',
-			EventSource.CONTROLLER,
+			EventSource.DRIVER,
 			'controller firmware update progress',
-			this.zwaveNodeToJSON(this.driver.controller.nodes.get(nodeId)),
 			progress,
 		)
 	}
 
 	private _onOTWFirmwareUpdateFinished(result: OTWFirmwareUpdateResult) {
-		const nodeId = this.driver.controller.ownNodeId
-		const node = this.nodes.get(nodeId)
-		const zwaveNode = this.driver.controller.nodes.get(nodeId)
-
-		if (node) {
-			node.firmwareUpdate = undefined
-
-			this.emitNodeUpdate(node, {
-				firmwareUpdate: false,
-				firmwareUpdateResult: {
-					success: result.success,
-					status: getEnumMemberName(
-						OTWFirmwareUpdateStatus,
-						result.status,
-					),
-				},
-			} as any)
-		}
+		this.sendToSocket(socketEvents.otwFirmwareUpdate, {
+			result: {
+				success: result.success,
+				status: getEnumMemberName(
+					OTWFirmwareUpdateStatus,
+					result.status,
+				),
+			},
+		})
 
 		logger.info(
-			`Controller ${zwaveNode.id} firmware update OTW finished ${
+			`Controller firmware update OTW finished ${
 				result.success ? 'successfully' : 'with error'
 			}.\n   Status: ${getEnumMemberName(
 				OTWFirmwareUpdateStatus,
@@ -4591,9 +4568,8 @@ class ZwaveClient extends TypedEventEmitter<ZwaveClientEventCallbacks> {
 
 		this.emit(
 			'event',
-			EventSource.CONTROLLER,
+			EventSource.DRIVER,
 			'controller firmware update finished',
-			this.zwaveNodeToJSON(zwaveNode),
 			result,
 		)
 	}

--- a/src/App.vue
+++ b/src/App.vue
@@ -627,41 +627,6 @@ export default {
 		pages() {
 			// this.verifyRoute()
 		},
-		controllerNode(node) {
-			if (!node) return
-
-			if (node.firmwareUpdate) {
-				if (!this.dialogLoader) {
-					this.loaderTitle = ''
-					this.loaderText =
-						'Updating controller firmware, please wait...'
-					this.dialogLoader = true
-				}
-				this.loaderProgress = node.firmwareUpdate.progress
-				this.loaderIndeterminate = this.loaderProgress === 0
-			} else if (node.firmwareUpdateResult) {
-				this.dialogLoader = true // always open it to show the result, in case no progress is done it would be closed
-				this.loaderProgress = -1
-				this.loaderTitle = ''
-				const result = node.firmwareUpdateResult
-
-				useBaseStore().updateNode(
-					{
-						id: node.id,
-						firmwareUpdateResult: false,
-					},
-					true,
-				)
-
-				this.loaderText = `<span style="white-space: break-spaces;" class="${
-					result.success ? 'success' : 'error'
-				}--text">Controller firmware update finished ${
-					result.success
-						? 'successfully. It may take a few seconds for the stick to restart.'
-						: 'with error'
-				}.\n Status: ${result.status}</span>`
-			}
-		},
 	},
 	data() {
 		return {
@@ -717,6 +682,31 @@ export default {
 			}
 			this.showNodesManager('')
 			this.$refs.nodesManager.onGrantSecurityCC(requested)
+		},
+		onOTWFirmwareUpdate(data) {
+			const { progress, result } = data
+			if (progress) {
+				if (!this.dialogLoader) {
+					this.loaderTitle = ''
+					this.loaderText =
+						'Updating controller firmware, please wait...'
+					this.dialogLoader = true
+				}
+				this.loaderProgress = progress.progress
+				this.loaderIndeterminate = this.loaderProgress === 0
+			} else if (result) {
+				this.dialogLoader = true // always open it to show the result, in case no progress is done it would be closed
+				this.loaderProgress = -1
+				this.loaderTitle = ''
+
+				this.loaderText = `<span style="white-space: break-spaces;" class="${
+					result.success ? 'success' : 'error'
+				}--text">Controller firmware update finished ${
+					result.success
+						? 'successfully. It may take a few seconds for the stick to restart.'
+						: 'with error'
+				}.\n Status: ${result.status}</span>`
+			}
 		},
 		...mapActions(useBaseStore, [
 			'init',
@@ -1238,6 +1228,11 @@ export default {
 			this.socket.on(socketEvents.znifferState, (data) => {
 				this.setZnifferState(data)
 			})
+
+			this.socket.on(
+				socketEvents.otwFirmwareUpdate,
+				this.onOTWFirmwareUpdate.bind(this),
+			)
 			// don't await this, will cause a loop of calls
 			this.getConfig()
 		},

--- a/src/lib/SocketEvents.js
+++ b/src/lib/SocketEvents.js
@@ -22,6 +22,7 @@ export const socketEvents = Object.freeze({
 	znifferFrame: 'ZNIFFER_FRAME',
 	znifferState: 'ZNIFFER_STATE',
 	linkReliability: 'LINK_RELIABILITY',
+	otwFirmwareUpdate: 'OTW_FIRMWARE_UPDATE',
 })
 
 // events from client ---> server


### PR DESCRIPTION
Fixes #4194

BREAKING CHANGE: Starting from z-wave-js@15 OTW firmware update has been moved from controller to driver. Following this the MQTT event has been moved from `controller` `driver` and the payload will not be the entire controller node but only `progress` updates. This will only affect users implementing custom logics based on MQTT events.