### PR TITLE
feat: expose values of the controller node

### DIFF
--- a/src/components/nodes-table/NodeDetails.vue
+++ b/src/components/nodes-table/NodeDetails.vue
@@ -171,11 +171,14 @@
 			</v-col>
 		</template>
 
-		<div v-if="!node.isControllerNode">
-			<v-subheader class="title" style="padding: 0"
+		<div>
+			<v-subheader
+				class="title"
+				style="padding: 0"
+				v-if="!node.isControllerNode"
 				>Send Options</v-subheader
 			>
-			<v-row class="mt-0">
+			<v-row class="mt-0" v-if="!node.isControllerNode">
 				<v-col
 					cols="12"
 					sm="6"
@@ -217,7 +220,7 @@
 
 			<!-- NODE VALUES -->
 
-			<v-row>
+			<v-row v-if="!node.isControllerNode || node.values.length">
 				<v-subheader class="title">Values</v-subheader>
 
 				<v-expansion-panels
@@ -283,7 +286,10 @@
 							</v-row>
 							<v-row>
 								<v-col
-									v-if="className.startsWith('Configuration')"
+									v-if="
+										className.startsWith('Configuration') &&
+										!node.isControllerNode
+									"
 									cols="12"
 									sm="6"
 									md="4"


### PR DESCRIPTION
Recent zwave-js versions added support for "fake" values to interact with proprietary functionality of Z-Wave controllers, e.g. LED control.

With this PR, Z-Wave JS UI can show controls for those values in the UI.