### PR TITLE
refactor: eliminate usage of zwave-js's `/safe` entrypoints

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -60,7 +60,7 @@
         "vuetify": "^2.7.2",
         "winston": "^3.13.0",
         "winston-daily-rotate-file": "^5.0.0",
-        "zwave-js": "^15.1.3",
+        "zwave-js": "^15.2.1",
         "zxing-wasm": "^1.2.15"
       },
       "bin": {
@@ -4246,14 +4246,14 @@
       }
     },
     "node_modules/@zwave-js/cc": {
-      "version": "15.1.2",
-      "resolved": "https://registry.npmjs.org/@zwave-js/cc/-/cc-15.1.2.tgz",
-      "integrity": "sha512-bFwNqG6fhKbDNcC7q7rk1hplQGF5ZupEkw9hqb4KD4qssp30NpUh1JJfyUo/eF00p1Zd3k8vqvli95AcB1qSsQ==",
+      "version": "15.2.1",
+      "resolved": "https://registry.npmjs.org/@zwave-js/cc/-/cc-15.2.1.tgz",
+      "integrity": "sha512-/qp/an1T6c3vv6Egytt3RUkF2FY6OPaBmv7Vs511Dn6z3sa2umuHQPiZoC01G3Ck9/FSOaEU43/UyMLfdYlY2w==",
       "license": "MIT",
       "dependencies": {
-        "@zwave-js/core": "15.1.2",
-        "@zwave-js/host": "15.1.2",
-        "@zwave-js/shared": "15.1.2",
+        "@zwave-js/core": "15.2.1",
+        "@zwave-js/host": "15.2.1",
+        "@zwave-js/shared": "15.2.1",
         "alcalzone-shared": "^5.0.0",
         "ansi-colors": "^4.1.3",
         "reflect-metadata": "^0.2.2"
@@ -4275,13 +4275,13 @@
       }
     },
     "node_modules/@zwave-js/config": {
-      "version": "15.1.2",
-      "resolved": "https://registry.npmjs.org/@zwave-js/config/-/config-15.1.2.tgz",
-      "integrity": "sha512-vk+RqOW33bHL3xqKSH+xvG+gq4lgasmrUZk8eeXbyhDLIecIrwVRPlEJVy4U5UIAxgEl5UlfRZKFLwAO/M4Ljg==",
+      "version": "15.2.1",
+      "resolved": "https://registry.npmjs.org/@zwave-js/config/-/config-15.2.1.tgz",
+      "integrity": "sha512-LvY2T5PeOujgD9byqqBnxbTwC+wTE8SY61Ce8zGCjsLSFHRA5TNmU8OXoZC3RmOcR2Cq7NTbjGM7I8CrT+M2bw==",
       "license": "MIT",
       "dependencies": {
-        "@zwave-js/core": "15.1.2",
-        "@zwave-js/shared": "15.1.2",
+        "@zwave-js/core": "15.2.1",
+        "@zwave-js/shared": "15.2.1",
         "alcalzone-shared": "^5.0.0",
         "ansi-colors": "^4.1.3",
         "json-logic-js": "^2.0.5",
@@ -4307,13 +4307,13 @@
       }
     },
     "node_modules/@zwave-js/core": {
-      "version": "15.1.2",
-      "resolved": "https://registry.npmjs.org/@zwave-js/core/-/core-15.1.2.tgz",
-      "integrity": "sha512-Y/yn3g1hv6bPxyQhM+CUMUcwp/bjNv9vyKVTguvAKPnrikEbXtwjkAiucNgOKb5Zpw4nkpf6v4x25PfxR26v+w==",
+      "version": "15.2.1",
+      "resolved": "https://registry.npmjs.org/@zwave-js/core/-/core-15.2.1.tgz",
+      "integrity": "sha512-DyJI5DnFHtWzN20NLKwJX2HdbYLJCqe6BHXf3At1bA4yHVTYt7cuE1w/elf+gwHGy94RpbCdJ5/+ILFSCSc1/A==",
       "license": "MIT",
       "dependencies": {
         "@alcalzone/jsonl-db": "^3.1.1",
-        "@zwave-js/shared": "15.1.2",
+        "@zwave-js/shared": "15.2.1",
         "alcalzone-shared": "^5.0.0",
         "ansi-colors": "^4.1.3",
         "dayjs": "^1.11.13",
@@ -4357,14 +4357,14 @@
       }
     },
     "node_modules/@zwave-js/host": {
-      "version": "15.1.2",
-      "resolved": "https://registry.npmjs.org/@zwave-js/host/-/host-15.1.2.tgz",
-      "integrity": "sha512-h/LyvtIGHWgLqTX1uI6sCbtuXyqqmHnwjXw4+IiGs4eIpw8v55pSzIzLHpOjFbQI1Pdeu+0O/f0SIlJAQ7Usgg==",
+      "version": "15.2.1",
+      "resolved": "https://registry.npmjs.org/@zwave-js/host/-/host-15.2.1.tgz",
+      "integrity": "sha512-Yv9p/4zdd7HmbaCRODdMrGw+L/nLP5uH2iLt5ttg6Ol15RGDOQ1MoQQLbcgAn6pVVwQruigKr9iouDXjIKp5pw==",
       "license": "MIT",
       "dependencies": {
-        "@zwave-js/config": "15.1.2",
-        "@zwave-js/core": "15.1.2",
-        "@zwave-js/shared": "15.1.2",
+        "@zwave-js/config": "15.2.1",
+        "@zwave-js/core": "15.2.1",
+        "@zwave-js/shared": "15.2.1",
         "alcalzone-shared": "^5.0.0"
       },
       "engines": {
@@ -4402,13 +4402,13 @@
       }
     },
     "node_modules/@zwave-js/nvmedit": {
-      "version": "15.1.2",
-      "resolved": "https://registry.npmjs.org/@zwave-js/nvmedit/-/nvmedit-15.1.2.tgz",
-      "integrity": "sha512-JkOO739vT1li+oqv+rbHcIdLW8wttXXvIGKPdK2nXMUahtrt9WYL7RghK949ssxyW/+fygIvJA62P6lTo5rqsg==",
+      "version": "15.2.1",
+      "resolved": "https://registry.npmjs.org/@zwave-js/nvmedit/-/nvmedit-15.2.1.tgz",
+      "integrity": "sha512-xjsfEHFR0WGu58hQsRTGh7db+fSXKMJkFVwI+8bzO+jo8G+YBcB99JaUNiR4fSoV5QKavo1zpf6+TzpaU1MIwQ==",
       "license": "MIT",
       "dependencies": {
-        "@zwave-js/core": "15.1.2",
-        "@zwave-js/shared": "15.1.2",
+        "@zwave-js/core": "15.2.1",
+        "@zwave-js/shared": "15.2.1",
         "alcalzone-shared": "^5.0.0",
         "reflect-metadata": "^0.2.2",
         "semver": "^7.6.3",
@@ -4536,16 +4536,16 @@
       }
     },
     "node_modules/@zwave-js/serial": {
-      "version": "15.1.2",
-      "resolved": "https://registry.npmjs.org/@zwave-js/serial/-/serial-15.1.2.tgz",
-      "integrity": "sha512-DC5RnOuDpAyDzojX0giT+Xhl38X/9RlSBnqHE6VnHEHvsK+TIoEnEKPEK0KPsrDByCCP4EjsJpGMyvHL0kJfzg==",
+      "version": "15.2.1",
+      "resolved": "https://registry.npmjs.org/@zwave-js/serial/-/serial-15.2.1.tgz",
+      "integrity": "sha512-zZ0/6bVmpzPdvDl8x8D5Ocl13o9YW20p0XorERXBo9rlmLgxfKhX+9sSyuLqVvHl17mFl6hw0slDAIE3vhYZsg==",
       "license": "MIT",
       "dependencies": {
         "@serialport/stream": "^13.0.0",
-        "@zwave-js/cc": "15.1.2",
-        "@zwave-js/core": "15.1.2",
-        "@zwave-js/host": "15.1.2",
-        "@zwave-js/shared": "15.1.2",
+        "@zwave-js/cc": "15.2.1",
+        "@zwave-js/core": "15.2.1",
+        "@zwave-js/host": "15.2.1",
+        "@zwave-js/shared": "15.2.1",
         "alcalzone-shared": "^5.0.0",
         "serialport": "^13.0.0",
         "winston": "^3.17.0"
@@ -4609,9 +4609,9 @@
       }
     },
     "node_modules/@zwave-js/shared": {
-      "version": "15.1.2",
-      "resolved": "https://registry.npmjs.org/@zwave-js/shared/-/shared-15.1.2.tgz",
-      "integrity": "sha512-dZY8NJ3T2PBCoI840O7Xc524LlL9CWibVBGp/q0SBqgorKdLSiqoW8OlDZVjw0beuCx8yPwPLojNSlk0P9iCPA==",
+      "version": "15.2.1",
+      "resolved": "https://registry.npmjs.org/@zwave-js/shared/-/shared-15.2.1.tgz",
+      "integrity": "sha512-apjZj4DOj5dMQiM/Muu062Zd54uIaaa5zyxFP8nc8t0xAkSTkGN26MgEkhGtRAspv16iHSI6O1ZII6BTIKK8lw==",
       "license": "MIT",
       "dependencies": {
         "alcalzone-shared": "^5.0.0",
@@ -4634,15 +4634,15 @@
       }
     },
     "node_modules/@zwave-js/testing": {
-      "version": "15.1.2",
-      "resolved": "https://registry.npmjs.org/@zwave-js/testing/-/testing-15.1.2.tgz",
-      "integrity": "sha512-qrCnNek9ThU8Bt4zv0PsJyglc07wHwB6jT9NlH2ohxBE9SOkRmMz8KUWAedSmKKVV4U2ky0UOkb3b4SvqKCQ8Q==",
+      "version": "15.2.1",
+      "resolved": "https://registry.npmjs.org/@zwave-js/testing/-/testing-15.2.1.tgz",
+      "integrity": "sha512-BTbQhfYOVANuMm7iKL0XQaKYPtjEqovZnxyRadKum68Oj3vhYco5gZrbtIw8iwUlREtj4hurq/Ch+Ra2CsSqbw==",
       "license": "MIT",
       "dependencies": {
-        "@zwave-js/core": "15.1.2",
-        "@zwave-js/host": "15.1.2",
-        "@zwave-js/serial": "15.1.2",
-        "@zwave-js/shared": "15.1.2",
+        "@zwave-js/core": "15.2.1",
+        "@zwave-js/host": "15.2.1",
+        "@zwave-js/serial": "15.2.1",
+        "@zwave-js/shared": "15.2.1",
         "alcalzone-shared": "^5.0.0",
         "ansi-colors": "^4.1.3"
       },
@@ -20384,22 +20384,22 @@
       }
     },
     "node_modules/zwave-js": {
-      "version": "15.1.3",
-      "resolved": "https://registry.npmjs.org/zwave-js/-/zwave-js-15.1.3.tgz",
-      "integrity": "sha512-RgTeH0Jv9X4XP3TEbg3eUcflaGJ1/72ZJG2ZJQe4gv13yL9kaNh/so5LsCPkm5osHRST78HiNFZW2Puekua8kw==",
+      "version": "15.2.1",
+      "resolved": "https://registry.npmjs.org/zwave-js/-/zwave-js-15.2.1.tgz",
+      "integrity": "sha512-Gf7LEnjUvZu8XsGtnLTmkKw+e2AOx42q6CEjMMR82AbUeoYLRv/zVJlDaZsbvqKn821gfPmlKq/VlA9D3aKjWQ==",
       "license": "MIT",
       "dependencies": {
         "@alcalzone/jsonl-db": "^3.1.1",
         "@andrewbranch/untar.js": "^1.0.3",
         "@homebridge/ciao": "^1.3.1",
-        "@zwave-js/cc": "15.1.2",
-        "@zwave-js/config": "15.1.2",
-        "@zwave-js/core": "15.1.2",
-        "@zwave-js/host": "15.1.2",
-        "@zwave-js/nvmedit": "15.1.2",
-        "@zwave-js/serial": "15.1.2",
-        "@zwave-js/shared": "15.1.2",
-        "@zwave-js/testing": "15.1.2",
+        "@zwave-js/cc": "15.2.1",
+        "@zwave-js/config": "15.2.1",
+        "@zwave-js/core": "15.2.1",
+        "@zwave-js/host": "15.2.1",
+        "@zwave-js/nvmedit": "15.2.1",
+        "@zwave-js/serial": "15.2.1",
+        "@zwave-js/shared": "15.2.1",
+        "@zwave-js/testing": "15.2.1",
         "alcalzone-shared": "^5.0.0",
         "ansi-colors": "^4.1.3",
         "ky": "^1.7.2",

--- a/package.json
+++ b/package.json
@@ -114,7 +114,7 @@
     "vuetify": "^2.7.2",
     "winston": "^3.13.0",
     "winston-daily-rotate-file": "^5.0.0",
-    "zwave-js": "^15.1.3",
+    "zwave-js": "^15.2.1",
     "zxing-wasm": "^1.2.15"
   },
   "devDependencies": {

--- a/src/App.vue
+++ b/src/App.vue
@@ -434,12 +434,9 @@ import {
 	socketEvents,
 	inboundEvents as socketActions,
 } from '@server/lib/SocketEvents'
-import {
-	getEnumMemberName,
-	SecurityBootstrapFailure,
-	FirmwareUpdateStatus,
-	InclusionState,
-} from 'zwave-js/safe'
+import { getEnumMemberName } from '@zwave-js/shared'
+import { FirmwareUpdateStatus } from '@zwave-js/cc'
+import { SecurityBootstrapFailure, InclusionState } from 'zwave-js/safe'
 import DialogNodesManager from '@/components/dialogs/DialogNodesManager.vue'
 import { uuid } from './lib/utils'
 

--- a/src/App.vue
+++ b/src/App.vue
@@ -436,7 +436,7 @@ import {
 } from '@server/lib/SocketEvents'
 import { getEnumMemberName } from '@zwave-js/shared'
 import { FirmwareUpdateStatus } from '@zwave-js/cc'
-import { SecurityBootstrapFailure, InclusionState } from 'zwave-js/safe'
+import { SecurityBootstrapFailure, InclusionState } from 'zwave-js'
 import DialogNodesManager from '@/components/dialogs/DialogNodesManager.vue'
 import { uuid } from './lib/utils'
 

--- a/src/components/Confirm.vue
+++ b/src/components/Confirm.vue
@@ -225,7 +225,7 @@
 </template>
 
 <script>
-import { tryParseDSKFromQRCodeString } from '@zwave-js/core/safe'
+import { tryParseDSKFromQRCodeString } from '@zwave-js/core'
 import 'vue-prism-editor/dist/prismeditor.min.css' // import the styles somewhere
 
 // import highlighting library (you can use any library you want just return html string)

--- a/src/components/custom/BgRssiChart.vue
+++ b/src/components/custom/BgRssiChart.vue
@@ -10,7 +10,7 @@
 <script>
 import uPlot from 'uplot'
 import 'uplot/dist/uPlot.min.css'
-import { isRssiError } from 'zwave-js/safe'
+import { isRssiError } from '@zwave-js/core'
 
 // eslint-disable-next-line no-unused-vars
 function touchZoomPlugin(opts) {

--- a/src/components/custom/NodePanel.vue
+++ b/src/components/custom/NodePanel.vue
@@ -399,8 +399,9 @@ import {
 	protocolDataRateToString,
 	isRssiError,
 	rssiToString,
-} from 'zwave-js/safe'
-import { Protocols, zwaveDataRateToString } from '@zwave-js/core/safe'
+	Protocols,
+	zwaveDataRateToString,
+} from '@zwave-js/core'
 import draggable from 'vuedraggable'
 
 import { Routes } from '../../router/index.js'

--- a/src/components/custom/ZwaveGraph.vue
+++ b/src/components/custom/ZwaveGraph.vue
@@ -296,8 +296,8 @@ import {
 	protocolDataRateToString,
 	rssiToString,
 	isRssiError,
-} from 'zwave-js/safe'
-import { RouteKind } from '@zwave-js/core/safe'
+	RouteKind,
+} from '@zwave-js/core'
 import { uuid, arraysEqual } from '../../lib/utils'
 import useBaseStore from '../../stores/base.js'
 import { mapState } from 'pinia'

--- a/src/components/dialogs/DialogAssociation.vue
+++ b/src/components/dialogs/DialogAssociation.vue
@@ -124,12 +124,12 @@
 </template>
 
 <script>
-import { Protocols } from '@zwave-js/core/safe'
+import { Protocols } from '@zwave-js/core'
 import { mapState } from 'pinia'
 import useBaseStore from '../../stores/base.js'
 import { getAssociationAddress } from '../../lib/utils'
-import { AssociationCheckResult } from '@zwave-js/cc/safe'
-import { getEnumMemberName } from 'zwave-js/safe'
+import { AssociationCheckResult } from '@zwave-js/cc'
+import { getEnumMemberName } from '@zwave-js/shared'
 import InstancesMixin from '../../mixins/InstancesMixin.js'
 
 export default {

--- a/src/components/dialogs/DialogHealthCheck.vue
+++ b/src/components/dialogs/DialogHealthCheck.vue
@@ -411,13 +411,13 @@
 
 <script>
 import { copy } from '@/lib/utils'
-import { getEnumMemberName } from 'zwave-js/safe'
-import { Powerlevel } from '@zwave-js/cc/safe'
+import { getEnumMemberName } from '@zwave-js/shared'
+import { Powerlevel } from '@zwave-js/cc'
 import { mapActions, mapState } from 'pinia'
+import { Protocols } from '@zwave-js/core'
 
 import useBaseStore from '../../stores/base.js'
 import InstancesMixin from '../../mixins/InstancesMixin.js'
-import { Protocols } from '@zwave-js/core/safe'
 
 export default {
 	components: {},

--- a/src/components/dialogs/DialogNodesManager.vue
+++ b/src/components/dialogs/DialogNodesManager.vue
@@ -679,7 +679,7 @@ import {
 	validTopic,
 } from '../../lib/utils.js'
 import useBaseStore from '../../stores/base.js'
-import { InclusionStrategy, SecurityBootstrapFailure } from 'zwave-js/safe'
+import { InclusionStrategy, SecurityBootstrapFailure } from 'zwave-js'
 import InstancesMixin from '../../mixins/InstancesMixin.js'
 
 export default {

--- a/src/components/dialogs/DialogNodesManager.vue
+++ b/src/components/dialogs/DialogNodesManager.vue
@@ -670,7 +670,7 @@
 
 <script>
 import { mapState } from 'pinia'
-import { tryParseDSKFromQRCodeString } from '@zwave-js/core/safe'
+import { tryParseDSKFromQRCodeString } from '@zwave-js/core'
 
 import {
 	parseSecurityClasses,

--- a/src/components/nodes-table/AssociationGroups.vue
+++ b/src/components/nodes-table/AssociationGroups.vue
@@ -79,8 +79,8 @@ import { mapState, mapActions } from 'pinia'
 
 import useBaseStore from '../../stores/base.js'
 import InstancesMixin from '../../mixins/InstancesMixin.js'
-import { getEnumMemberName } from 'zwave-js/safe'
-import { AssociationCheckResult } from '@zwave-js/cc/safe'
+import { getEnumMemberName } from '@zwave-js/shared'
+import { AssociationCheckResult } from '@zwave-js/cc'
 import { getAssociationAddress } from '../../lib/utils'
 
 export default {

--- a/src/components/nodes-table/ExpandedNode.vue
+++ b/src/components/nodes-table/ExpandedNode.vue
@@ -327,8 +327,8 @@ import InstancesMixin from '../../mixins/InstancesMixin.js'
 import {
 	SetValueStatus,
 	setValueWasUnsupervisedOrSucceeded,
-} from '@zwave-js/cc/safe'
-import { Protocols } from '@zwave-js/core/safe'
+} from '@zwave-js/cc'
+import { Protocols } from '@zwave-js/core'
 
 export default {
 	props: {

--- a/src/components/nodes-table/NodeDetails.vue
+++ b/src/components/nodes-table/NodeDetails.vue
@@ -382,10 +382,9 @@
 import { mapState, mapActions } from 'pinia'
 import { validTopic } from '../../lib/utils'
 import { maxLRPowerLevels } from '../../lib/items'
-import { ConfigValueFormat } from '@zwave-js/core/safe'
 import useBaseStore from '../../stores/base.js'
 import InstancesMixin from '../../mixins/InstancesMixin.js'
-import { isUnsupervisedOrSucceeded } from '@zwave-js/core/safe'
+import { isUnsupervisedOrSucceeded, ConfigValueFormat } from '@zwave-js/core'
 
 export default {
 	props: {

--- a/src/components/nodes-table/NodeScheduler.vue
+++ b/src/components/nodes-table/NodeScheduler.vue
@@ -83,8 +83,8 @@ import { mapActions } from 'pinia'
 
 import useBaseStore from '../../stores/base.js'
 import InstancesMixin from '../../mixins/InstancesMixin.js'
-import { getEnumMemberName } from 'zwave-js/safe'
-import { ScheduleEntryLockWeekday } from '@zwave-js/cc/safe'
+import { getEnumMemberName } from '@zwave-js/shared'
+import { ScheduleEntryLockWeekday } from '@zwave-js/cc'
 import { padNumber, copy } from '../../lib/utils.js'
 
 const months = [

--- a/src/lib/items.js
+++ b/src/lib/items.js
@@ -1,5 +1,9 @@
-import { RFRegion, Protocols } from 'zwave-js/safe'
-import { ZnifferLRChannelConfig, ZnifferRegion } from '@zwave-js/core/safe'
+import {
+	ZnifferLRChannelConfig,
+	ZnifferRegion,
+	RFRegion,
+	Protocols,
+} from '@zwave-js/core'
 
 export const rfRegions = Object.keys(RFRegion)
 	.filter((k) => isNaN(k))

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -2,16 +2,13 @@ import {
 	isValidDSK,
 	Protocols,
 	znifferProtocolDataRateToString,
-} from '@zwave-js/core/safe'
-import colors from 'vuetify/lib/util/colors'
-
-import {
 	isRssiError,
 	rssiToString,
-	getEnumMemberName,
-	ZWaveFrameType,
-	LongRangeFrameType,
-} from 'zwave-js/safe'
+} from '@zwave-js/core'
+import colors from 'vuetify/lib/util/colors'
+
+import { getEnumMemberName } from '@zwave-js/shared'
+import { ZWaveFrameType, LongRangeFrameType } from 'zwave-js/safe'
 import { znifferRegions } from './items'
 import { mdiZWave } from '@mdi/js'
 

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -8,7 +8,7 @@ import {
 import colors from 'vuetify/lib/util/colors'
 
 import { getEnumMemberName } from '@zwave-js/shared'
-import { ZWaveFrameType, LongRangeFrameType } from 'zwave-js/safe'
+import { ZWaveFrameType, LongRangeFrameType } from 'zwave-js'
 import { znifferRegions } from './items'
 import { mdiZWave } from '@mdi/js'
 

--- a/src/views/SmartStart.vue
+++ b/src/views/SmartStart.vue
@@ -317,7 +317,7 @@
 	</v-container>
 </template>
 <script>
-import { tryParseDSKFromQRCodeString, Protocols } from '@zwave-js/core/safe'
+import { tryParseDSKFromQRCodeString, Protocols } from '@zwave-js/core'
 import { mapActions } from 'pinia'
 import {
 	parseSecurityClasses,

--- a/src/views/Zniffer.vue
+++ b/src/views/Zniffer.vue
@@ -380,7 +380,7 @@
 </template>
 <script>
 import { ZWaveFrameType, LongRangeFrameType } from 'zwave-js/safe'
-import { Protocols, RFRegion } from '@zwave-js/core/safe'
+import { Protocols, RFRegion } from '@zwave-js/core'
 import { socketEvents } from '@server/lib/SocketEvents'
 
 import { mapState, mapActions } from 'pinia'

--- a/src/views/Zniffer.vue
+++ b/src/views/Zniffer.vue
@@ -379,7 +379,7 @@
 	</v-container>
 </template>
 <script>
-import { ZWaveFrameType, LongRangeFrameType } from 'zwave-js/safe'
+import { ZWaveFrameType, LongRangeFrameType } from 'zwave-js'
 import { Protocols, RFRegion } from '@zwave-js/core'
 import { socketEvents } from '@server/lib/SocketEvents'
 

--- a/vite.config.mjs
+++ b/vite.config.mjs
@@ -53,9 +53,6 @@ export default defineConfig(({ mode }) => {
 				workbox: {
 					globIgnores: ['**/api/**'],
 				},
-				injectManifest: {
-					maximumFileSizeToCacheInBytes: 2500000,
-				},
 				manifest: {
 					name: process.env.VITE_TITLE,
 					description: process.env.VITE_TITLE,


### PR DESCRIPTION
I'm planning to eliminate those entrypoints in the next major release. They are no longer necessary, since `zwave-js` and all its submodules are browser-compatible now.