### PR TITLE
feat: update zwave-js to 15.3.0, always add event handlers after `driver ready` event

### DIFF
--- a/api/lib/ZwaveClient.ts
+++ b/api/lib/ZwaveClient.ts
@@ -747,7 +747,6 @@ class ZwaveClient extends TypedEventEmitter<ZwaveClientEventCallbacks> {
 	}
 	private _inclusionState: InclusionState = undefined
 
-	private _controllerListenersAdded: boolean = false
 	public get driverReady() {
 		return this.driver && this._driverReady && !this.closed
 	}
@@ -1179,7 +1178,6 @@ class ZwaveClient extends TypedEventEmitter<ZwaveClientEventCallbacks> {
 		if (this._driver) {
 			await this._driver.destroy()
 			this._driver = null
-			this._controllerListenersAdded = false
 		}
 
 		if (!keepListeners) {
@@ -2285,7 +2283,6 @@ class ZwaveClient extends TypedEventEmitter<ZwaveClientEventCallbacks> {
 			// init driver here because if connect fails the driver is destroyed
 			// this could throw so include in the try/catch
 			this._driver = new Driver(this.cfg.port, zwaveOptions)
-			this._controllerListenersAdded = false
 			this._driver.on('error', this._onDriverError.bind(this))
 			this._driver.on('driver ready', this._onDriverReady.bind(this))
 			this._driver.on('all nodes ready', this._onScanComplete.bind(this))
@@ -4414,51 +4411,33 @@ class ZwaveClient extends TypedEventEmitter<ZwaveClientEventCallbacks> {
 				/* ignore */
 			})
 
-			if (!this._controllerListenersAdded) {
-				this._controllerListenersAdded = true
-				this.driver.controller
-					.on(
-						'inclusion started',
-						this._onInclusionStarted.bind(this),
-					)
-					.on(
-						'exclusion started',
-						this._onExclusionStarted.bind(this),
-					)
-					.on(
-						'inclusion stopped',
-						this._onInclusionStopped.bind(this),
-					)
-					.on(
-						'exclusion stopped',
-						this._onExclusionStopped.bind(this),
-					)
-					.on(
-						'inclusion state changed',
-						this._onInclusionStateChanged.bind(this),
-					)
-					.on('inclusion failed', this._onInclusionFailed.bind(this))
-					.on('exclusion failed', this._onExclusionFailed.bind(this))
-					.on('node found', this._onNodeFound.bind(this))
-					.on('node added', this._onNodeAdded.bind(this))
-					.on('node removed', this._onNodeRemoved.bind(this))
-					.on(
-						'rebuild routes progress',
-						this._onRebuildRoutesProgress.bind(this),
-					)
-					.on(
-						'rebuild routes done',
-						this._onRebuildRoutesDone.bind(this),
-					)
-					.on(
-						'statistics updated',
-						this._onControllerStatisticsUpdated.bind(this),
-					)
-					.on(
-						'status changed',
-						this._onControllerStatusChanged.bind(this),
-					)
-			}
+			this.driver.controller
+				.on('inclusion started', this._onInclusionStarted.bind(this))
+				.on('exclusion started', this._onExclusionStarted.bind(this))
+				.on('inclusion stopped', this._onInclusionStopped.bind(this))
+				.on('exclusion stopped', this._onExclusionStopped.bind(this))
+				.on(
+					'inclusion state changed',
+					this._onInclusionStateChanged.bind(this),
+				)
+				.on('inclusion failed', this._onInclusionFailed.bind(this))
+				.on('exclusion failed', this._onExclusionFailed.bind(this))
+				.on('node found', this._onNodeFound.bind(this))
+				.on('node added', this._onNodeAdded.bind(this))
+				.on('node removed', this._onNodeRemoved.bind(this))
+				.on(
+					'rebuild routes progress',
+					this._onRebuildRoutesProgress.bind(this),
+				)
+				.on('rebuild routes done', this._onRebuildRoutesDone.bind(this))
+				.on(
+					'statistics updated',
+					this._onControllerStatisticsUpdated.bind(this),
+				)
+				.on(
+					'status changed',
+					this._onControllerStatusChanged.bind(this),
+				)
 		} catch (error) {
 			// Fixes freak error in "driver ready" handler #1309
 			logger.error(error.message)

--- a/package-lock.json
+++ b/package-lock.json
@@ -60,7 +60,7 @@
         "vuetify": "^2.7.2",
         "winston": "^3.13.0",
         "winston-daily-rotate-file": "^5.0.0",
-        "zwave-js": "^15.2.1",
+        "zwave-js": "^15.3.0",
         "zxing-wasm": "^1.2.15"
       },
       "bin": {
@@ -4246,14 +4246,14 @@
       }
     },
     "node_modules/@zwave-js/cc": {
-      "version": "15.2.1",
-      "resolved": "https://registry.npmjs.org/@zwave-js/cc/-/cc-15.2.1.tgz",
-      "integrity": "sha512-/qp/an1T6c3vv6Egytt3RUkF2FY6OPaBmv7Vs511Dn6z3sa2umuHQPiZoC01G3Ck9/FSOaEU43/UyMLfdYlY2w==",
+      "version": "15.3.0",
+      "resolved": "https://registry.npmjs.org/@zwave-js/cc/-/cc-15.3.0.tgz",
+      "integrity": "sha512-WWP+WLNGrRrTDr8kkFFy4nsEe0fevFntcFy85eWFIs3BewXtvLkiPqWwfwt2ZfhAdwY9PBt0Mr/WojbAQjaEaQ==",
       "license": "MIT",
       "dependencies": {
-        "@zwave-js/core": "15.2.1",
-        "@zwave-js/host": "15.2.1",
-        "@zwave-js/shared": "15.2.1",
+        "@zwave-js/core": "15.3.0",
+        "@zwave-js/host": "15.3.0",
+        "@zwave-js/shared": "15.3.0",
         "alcalzone-shared": "^5.0.0",
         "ansi-colors": "^4.1.3",
         "reflect-metadata": "^0.2.2"
@@ -4275,13 +4275,13 @@
       }
     },
     "node_modules/@zwave-js/config": {
-      "version": "15.2.1",
-      "resolved": "https://registry.npmjs.org/@zwave-js/config/-/config-15.2.1.tgz",
-      "integrity": "sha512-LvY2T5PeOujgD9byqqBnxbTwC+wTE8SY61Ce8zGCjsLSFHRA5TNmU8OXoZC3RmOcR2Cq7NTbjGM7I8CrT+M2bw==",
+      "version": "15.3.0",
+      "resolved": "https://registry.npmjs.org/@zwave-js/config/-/config-15.3.0.tgz",
+      "integrity": "sha512-+BMbKJNjkjKzSixMy+6M+D3FQRi7f3MFGQo/I3SWjOettF7aDzk7yvE+roZnYKKCukH7r0ryFYSctb7YpWh19A==",
       "license": "MIT",
       "dependencies": {
-        "@zwave-js/core": "15.2.1",
-        "@zwave-js/shared": "15.2.1",
+        "@zwave-js/core": "15.3.0",
+        "@zwave-js/shared": "15.3.0",
         "alcalzone-shared": "^5.0.0",
         "ansi-colors": "^4.1.3",
         "json-logic-js": "^2.0.5",
@@ -4307,13 +4307,13 @@
       }
     },
     "node_modules/@zwave-js/core": {
-      "version": "15.2.1",
-      "resolved": "https://registry.npmjs.org/@zwave-js/core/-/core-15.2.1.tgz",
-      "integrity": "sha512-DyJI5DnFHtWzN20NLKwJX2HdbYLJCqe6BHXf3At1bA4yHVTYt7cuE1w/elf+gwHGy94RpbCdJ5/+ILFSCSc1/A==",
+      "version": "15.3.0",
+      "resolved": "https://registry.npmjs.org/@zwave-js/core/-/core-15.3.0.tgz",
+      "integrity": "sha512-UZuRmRtqfWgw17h76F7aBOJho+IZAxfzCfsQdT+0J0VGWmwdmEmEuCoBfXi55ReShKAz8jH50smy9GaCg6Y4KQ==",
       "license": "MIT",
       "dependencies": {
         "@alcalzone/jsonl-db": "^3.1.1",
-        "@zwave-js/shared": "15.2.1",
+        "@zwave-js/shared": "15.3.0",
         "alcalzone-shared": "^5.0.0",
         "ansi-colors": "^4.1.3",
         "dayjs": "^1.11.13",
@@ -4357,14 +4357,14 @@
       }
     },
     "node_modules/@zwave-js/host": {
-      "version": "15.2.1",
-      "resolved": "https://registry.npmjs.org/@zwave-js/host/-/host-15.2.1.tgz",
-      "integrity": "sha512-Yv9p/4zdd7HmbaCRODdMrGw+L/nLP5uH2iLt5ttg6Ol15RGDOQ1MoQQLbcgAn6pVVwQruigKr9iouDXjIKp5pw==",
+      "version": "15.3.0",
+      "resolved": "https://registry.npmjs.org/@zwave-js/host/-/host-15.3.0.tgz",
+      "integrity": "sha512-6ONrzZTyQrke1aGG2wiwrZxdBXzJ3PNQFX8iGs1A3TyYXNkFad07s08QMPTEFAVAN4OBrC6PbRmjsIleUW8jSw==",
       "license": "MIT",
       "dependencies": {
-        "@zwave-js/config": "15.2.1",
-        "@zwave-js/core": "15.2.1",
-        "@zwave-js/shared": "15.2.1",
+        "@zwave-js/config": "15.3.0",
+        "@zwave-js/core": "15.3.0",
+        "@zwave-js/shared": "15.3.0",
         "alcalzone-shared": "^5.0.0"
       },
       "engines": {
@@ -4402,13 +4402,13 @@
       }
     },
     "node_modules/@zwave-js/nvmedit": {
-      "version": "15.2.1",
-      "resolved": "https://registry.npmjs.org/@zwave-js/nvmedit/-/nvmedit-15.2.1.tgz",
-      "integrity": "sha512-xjsfEHFR0WGu58hQsRTGh7db+fSXKMJkFVwI+8bzO+jo8G+YBcB99JaUNiR4fSoV5QKavo1zpf6+TzpaU1MIwQ==",
+      "version": "15.3.0",
+      "resolved": "https://registry.npmjs.org/@zwave-js/nvmedit/-/nvmedit-15.3.0.tgz",
+      "integrity": "sha512-zIxsnKX4MLupkmosn278IMjjnJ+maC1w2oWEiPnsNu32sWnGPjGz9LiGUmQgHd44ZSHjwhqD3vGbFi+hPLwy+A==",
       "license": "MIT",
       "dependencies": {
-        "@zwave-js/core": "15.2.1",
-        "@zwave-js/shared": "15.2.1",
+        "@zwave-js/core": "15.3.0",
+        "@zwave-js/shared": "15.3.0",
         "alcalzone-shared": "^5.0.0",
         "reflect-metadata": "^0.2.2",
         "semver": "^7.6.3",
@@ -4536,16 +4536,16 @@
       }
     },
     "node_modules/@zwave-js/serial": {
-      "version": "15.2.1",
-      "resolved": "https://registry.npmjs.org/@zwave-js/serial/-/serial-15.2.1.tgz",
-      "integrity": "sha512-zZ0/6bVmpzPdvDl8x8D5Ocl13o9YW20p0XorERXBo9rlmLgxfKhX+9sSyuLqVvHl17mFl6hw0slDAIE3vhYZsg==",
+      "version": "15.3.0",
+      "resolved": "https://registry.npmjs.org/@zwave-js/serial/-/serial-15.3.0.tgz",
+      "integrity": "sha512-Wf9cBcle0l2QA58MEKnBbpOnBRqLQS559e6+R/vXeppkbmQ6A/SWWbjApQQLgRe9AEKstvd+pXQOYuqqAsqGgA==",
       "license": "MIT",
       "dependencies": {
         "@serialport/stream": "^13.0.0",
-        "@zwave-js/cc": "15.2.1",
-        "@zwave-js/core": "15.2.1",
-        "@zwave-js/host": "15.2.1",
-        "@zwave-js/shared": "15.2.1",
+        "@zwave-js/cc": "15.3.0",
+        "@zwave-js/core": "15.3.0",
+        "@zwave-js/host": "15.3.0",
+        "@zwave-js/shared": "15.3.0",
         "alcalzone-shared": "^5.0.0",
         "serialport": "^13.0.0",
         "winston": "^3.17.0"
@@ -4609,9 +4609,9 @@
       }
     },
     "node_modules/@zwave-js/shared": {
-      "version": "15.2.1",
-      "resolved": "https://registry.npmjs.org/@zwave-js/shared/-/shared-15.2.1.tgz",
-      "integrity": "sha512-apjZj4DOj5dMQiM/Muu062Zd54uIaaa5zyxFP8nc8t0xAkSTkGN26MgEkhGtRAspv16iHSI6O1ZII6BTIKK8lw==",
+      "version": "15.3.0",
+      "resolved": "https://registry.npmjs.org/@zwave-js/shared/-/shared-15.3.0.tgz",
+      "integrity": "sha512-9r/laLelOc65sE2UX1YtKkZy7OPMmG4oiPBIcw7K7xgW8eRxYxmfafNWIFYi788VjYIEOi9VtCe1Ry8DBTYlnw==",
       "license": "MIT",
       "dependencies": {
         "alcalzone-shared": "^5.0.0",
@@ -4634,15 +4634,15 @@
       }
     },
     "node_modules/@zwave-js/testing": {
-      "version": "15.2.1",
-      "resolved": "https://registry.npmjs.org/@zwave-js/testing/-/testing-15.2.1.tgz",
-      "integrity": "sha512-BTbQhfYOVANuMm7iKL0XQaKYPtjEqovZnxyRadKum68Oj3vhYco5gZrbtIw8iwUlREtj4hurq/Ch+Ra2CsSqbw==",
+      "version": "15.3.0",
+      "resolved": "https://registry.npmjs.org/@zwave-js/testing/-/testing-15.3.0.tgz",
+      "integrity": "sha512-rtKwG7QrXeAIRqvk03rODRBBlmvrEZerkUIShIREF+JToOcfE9xHyoj5W9dTdhZ3S1I0bTq0bxsOOhil1Qha5w==",
       "license": "MIT",
       "dependencies": {
-        "@zwave-js/core": "15.2.1",
-        "@zwave-js/host": "15.2.1",
-        "@zwave-js/serial": "15.2.1",
-        "@zwave-js/shared": "15.2.1",
+        "@zwave-js/core": "15.3.0",
+        "@zwave-js/host": "15.3.0",
+        "@zwave-js/serial": "15.3.0",
+        "@zwave-js/shared": "15.3.0",
         "alcalzone-shared": "^5.0.0",
         "ansi-colors": "^4.1.3"
       },
@@ -20384,22 +20384,22 @@
       }
     },
     "node_modules/zwave-js": {
-      "version": "15.2.1",
-      "resolved": "https://registry.npmjs.org/zwave-js/-/zwave-js-15.2.1.tgz",
-      "integrity": "sha512-Gf7LEnjUvZu8XsGtnLTmkKw+e2AOx42q6CEjMMR82AbUeoYLRv/zVJlDaZsbvqKn821gfPmlKq/VlA9D3aKjWQ==",
+      "version": "15.3.0",
+      "resolved": "https://registry.npmjs.org/zwave-js/-/zwave-js-15.3.0.tgz",
+      "integrity": "sha512-sQymF2I+Lda4V/kaIKjR6me9xh29E1ZEjy17naonHoZ2XLBDnEtteb6E2KjSpolydu4oGgmV7IUjzrUMvxkPAA==",
       "license": "MIT",
       "dependencies": {
         "@alcalzone/jsonl-db": "^3.1.1",
         "@andrewbranch/untar.js": "^1.0.3",
         "@homebridge/ciao": "^1.3.1",
-        "@zwave-js/cc": "15.2.1",
-        "@zwave-js/config": "15.2.1",
-        "@zwave-js/core": "15.2.1",
-        "@zwave-js/host": "15.2.1",
-        "@zwave-js/nvmedit": "15.2.1",
-        "@zwave-js/serial": "15.2.1",
-        "@zwave-js/shared": "15.2.1",
-        "@zwave-js/testing": "15.2.1",
+        "@zwave-js/cc": "15.3.0",
+        "@zwave-js/config": "15.3.0",
+        "@zwave-js/core": "15.3.0",
+        "@zwave-js/host": "15.3.0",
+        "@zwave-js/nvmedit": "15.3.0",
+        "@zwave-js/serial": "15.3.0",
+        "@zwave-js/shared": "15.3.0",
+        "@zwave-js/testing": "15.3.0",
         "alcalzone-shared": "^5.0.0",
         "ansi-colors": "^4.1.3",
         "ky": "^1.7.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@kvaster/zwavejs-prom": "^0.0.3",
         "@mdi/js": "7.4.47",
         "@zwave-js/log-transport-json": "^3.0.0",
-        "@zwave-js/server": "^3.0.0",
+        "@zwave-js/server": "^3.0.1",
         "ansi_up": "^6.0.2",
         "archiver": "^7.0.1",
         "axios": "^1.7.2",
@@ -4567,9 +4567,9 @@
       }
     },
     "node_modules/@zwave-js/server": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@zwave-js/server/-/server-3.0.0.tgz",
-      "integrity": "sha512-1IKnG9ssAr4lsffxAKgEpLB3rqkJqb4XUhpCavmncbu4YNuk5kAnMupqBTpo3l0ajUwxfF43HAWODOHoUQb2Zg==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@zwave-js/server/-/server-3.0.1.tgz",
+      "integrity": "sha512-wegPMQu6QPW2a2iIrkOZbrrdNdTlE04/B8qqJfeJ0m5tmeFb5WVXA3vnO/IIuMROfmVDMte839o2sDfif5FCfg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@homebridge/ciao": "^1.1.7",
@@ -4584,7 +4584,7 @@
         "node": ">= 20"
       },
       "peerDependencies": {
-        "zwave-js": "^15.0.1"
+        "zwave-js": "^15.3.0"
       }
     },
     "node_modules/@zwave-js/server/node_modules/ws": {

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "@kvaster/zwavejs-prom": "^0.0.3",
     "@mdi/js": "7.4.47",
     "@zwave-js/log-transport-json": "^3.0.0",
-    "@zwave-js/server": "^3.0.0",
+    "@zwave-js/server": "^3.0.1",
     "ansi_up": "^6.0.2",
     "archiver": "^7.0.1",
     "axios": "^1.7.2",

--- a/package.json
+++ b/package.json
@@ -114,7 +114,7 @@
     "vuetify": "^2.7.2",
     "winston": "^3.13.0",
     "winston-daily-rotate-file": "^5.0.0",
-    "zwave-js": "^15.2.1",
+    "zwave-js": "^15.3.0",
     "zxing-wasm": "^1.2.15"
   },
   "devDependencies": {


### PR DESCRIPTION
As of Z-Wave JS 15.3.0, receiving the `driver ready` event always implies a new controller instance, therefore old event handlers no longer exist. This PR makes the necessary changes.