### PR TITLE
fix(ui): typo in restart prompt

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1002,7 +1002,7 @@ export default {
 		async restart() {
 			const result = await this.confirm(
 				'Restart',
-				'Are you sure you want to restart the ZUI?',
+				'Are you sure you want to restart ZUI?',
 				'warning',
 				{
 					width: 400,


### PR DESCRIPTION
While not necessarily incorrect when expanded (the zwave-js user interface), "the ZUI" sounds poorly translated, and if ZUI is considered as a proper noun (actually expanding to Z-Wave JS UI), then the existing wording is grammatically incorrect (think "Are you sure you want to restart the Windows?").