### PR TITLE
feat(ui): support system preference color scheme

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -465,7 +465,7 @@ export default {
 			'inited',
 		]),
 		...mapState(useBaseStore, {
-			darkMode: (store) => store.ui.darkMode,
+			darkMode: (store) => store.uiState.darkMode,
 			navTabs: (store) => store.ui.navTabs,
 		}),
 		menu() {
@@ -1646,23 +1646,13 @@ export default {
 			{ once: true },
 		)
 
-		const settings = useBaseStore().settings
-
 		// system dark mode
-		const systemThemeDark = !!window.matchMedia(
-			'(prefers-color-scheme: dark)',
-		).matches
+		const darkMode = useBaseStore().uiState.darkMode
 
-		// set the dark mode to the system dark mode if it's different
-		if (settings.load('dark') === undefined) {
-			useBaseStore().setDarkMode(systemThemeDark)
-		} else {
-			// load the theme from localstorage
-			// this is needed to prevent the theme switch on load
-			// this will be overriden by settings value once `initSettings`
-			// base store method is called
-			this.$vuetify.theme.dark = settings.load('dark', false)
-		}
+		// this is needed to prevent the theme switch on load
+		// this will be overriden by settings value once `initSettings`
+		// base store method is called
+		this.$vuetify.theme.dark = darkMode
 
 		useBaseStore().$onAction(({ name, args }) => {
 			if (name === 'showSnackbar') {

--- a/src/components/custom/ColorScheme.vue
+++ b/src/components/custom/ColorScheme.vue
@@ -12,6 +12,9 @@
 
 <script>
 import { colorSchemes } from '../../lib/colorScheme'
+import useBaseStore from '../../stores/base.js'
+
+import { mapState, mapActions } from 'pinia'
 
 export default {
 	props: {
@@ -21,10 +24,6 @@ export default {
 		prependIcon: {
 			type: String,
 		},
-		value: {
-			type: String,
-			default: 'system',
-		},
 	},
 	data() {
 		return {
@@ -32,14 +31,20 @@ export default {
 		}
 	},
 	computed: {
+		...mapState(useBaseStore, {
+			colorScheme: (store) => store.ui.colorScheme,
+		}),
 		internalColorScheme: {
 			get() {
-				return this.value
+				return this.colorScheme
 			},
 			set(value) {
-				this.$emit('input', value)
+				this.setColorScheme(value)
 			},
 		},
+	},
+	methods: {
+		...mapActions(useBaseStore, ['setColorScheme']),
 	},
 }
 </script>

--- a/src/components/custom/ColorScheme.vue
+++ b/src/components/custom/ColorScheme.vue
@@ -1,0 +1,47 @@
+<template>
+	<v-select
+		hint="Force dark/light mode or select color scheme automatically based on the system preference"
+		persistent-hint
+		label="Color scheme"
+		:hide-details="hideDetails"
+		:items="colorSchemes"
+		:prepend-icon="prependIcon"
+		v-model="internalColorScheme"
+	></v-select>
+</template>
+
+<script>
+import { colorSchemes } from '../../lib/colorScheme'
+
+export default {
+	props: {
+		hideDetails: {
+			type: Boolean,
+		},
+		prependIcon: {
+			type: String,
+		},
+		value: {
+			type: String,
+			default: 'system',
+		},
+	},
+	data() {
+		return {
+			colorSchemes,
+		}
+	},
+	computed: {
+		internalColorScheme: {
+			get() {
+				return this.value
+			},
+			set(value) {
+				this.$emit('input', value)
+			},
+		},
+	},
+}
+</script>
+
+<style></style>

--- a/src/lib/colorScheme.js
+++ b/src/lib/colorScheme.js
@@ -1,0 +1,70 @@
+/**
+ * @typedef {('dark' | 'light' | 'system')} ColorScheme
+ */
+
+/**
+ * @typedef {boolean} DarkMode
+ */
+
+/**
+ * The valid {@link ColorScheme}s that can be used.
+ */
+export const colorSchemes = ['dark', 'light', 'system']
+
+/**
+ * Maps a {@link ColorScheme} to its corresponding {@link DarkMode} value.
+ * Will lookup the preferred value when {@link colorScheme} is `'system'`
+ *
+ * @param {ColorScheme} colorScheme
+ * @returns {DarkMode}
+ */
+export const colorSchemeToDarkMode = (colorScheme) => {
+	switch (colorScheme) {
+		case 'dark':
+			return true
+
+		case 'light':
+			return false
+
+		case 'system':
+			return prefersColorSchemeDark.matches
+	}
+}
+
+/**
+ * Loads the {@link ColorScheme} from the {@link settings}.
+ *
+ * If {@link ColorScheme} is not in the {@link settings},
+ * this will fallback to migrating from {@link DarkMode}.
+ *
+ * @param {Settings} settings
+ * @returns {ColorScheme}
+ */
+export const loadColorScheme = (settings) => {
+	const darkMode = settings.load('darkMode', undefined)
+	let defaultColorScheme
+	switch (darkMode) {
+		case false:
+			defaultColorScheme = 'light'
+			break
+
+		case true:
+			defaultColorScheme = 'dark'
+			break
+
+		case undefined:
+			defaultColorScheme = 'system'
+			break
+	}
+
+	return settings.load('colorScheme', defaultColorScheme)
+}
+
+/**
+ * Tracks whether the current color scheme should be dark.
+ *
+ * @type {MediaQueryList}
+ */
+export const prefersColorSchemeDark = window.matchMedia(
+	'(prefers-color-scheme: dark)',
+)

--- a/src/lib/colorScheme.js
+++ b/src/lib/colorScheme.js
@@ -41,14 +41,14 @@ export const colorSchemeToDarkMode = (colorScheme) => {
  * @returns {ColorScheme}
  */
 export const loadColorScheme = (settings) => {
-	const darkMode = settings.load('darkMode', undefined)
+	const darkMode = settings.load('dark', undefined)
 	let defaultColorScheme
 	switch (darkMode) {
-		case false:
+		case 'false':
 			defaultColorScheme = 'light'
 			break
 
-		case true:
+		case 'true':
 			defaultColorScheme = 'dark'
 			break
 

--- a/src/stores/base.js
+++ b/src/stores/base.js
@@ -529,7 +529,7 @@ const useBaseStore = defineStore('base', {
 		initColorScheme() {
 			prefersColorSchemeDark.addEventListener('change', (event) => {
 				// Bail if the color scheme is not set by the system.
-				if (this.ui.colorScheme != 'system') {
+				if (this.ui.colorScheme !== 'system') {
 					return
 				}
 

--- a/src/stores/base.js
+++ b/src/stores/base.js
@@ -1,4 +1,9 @@
 import { defineStore } from 'pinia'
+import {
+	colorSchemeToDarkMode,
+	loadColorScheme,
+	prefersColorSchemeDark,
+} from '../lib/colorScheme'
 import { $set, deepEqual } from '../lib/utils'
 import logger from '../lib/logger'
 
@@ -141,10 +146,13 @@ const useBaseStore = defineStore('base', {
 			lrChannelConfig: false,
 		},
 		ui: {
-			darkMode: settings.load('dark', false),
+			colorScheme: loadColorScheme(settings),
 			navTabs: settings.load('navTabs', false),
 			compactMode: settings.load('compact', false),
 			streamerMode: settings.load('streamerMode', false),
+		},
+		uiState: {
+			darkMode: colorSchemeToDarkMode(loadColorScheme(settings)),
 		},
 	}),
 	getters: {
@@ -510,11 +518,27 @@ const useBaseStore = defineStore('base', {
 				Object.assign(this.gateway, conf.gateway || {})
 				Object.assign(this.backup, conf.backup || {})
 				Object.assign(this.ui, conf.ui || {})
-
-				// ensure local storage is in sync with the store
-				// to prevent theme switch on startup
-				this.setDarkMode(this.ui.darkMode)
 			}
+		},
+		/**
+		 * Initialize the color scheme by:
+		 * - Setting up an event listener for preferred color scheme changes.
+		 *     This will set the dark mode only if `ui.colorScheme` is `'system'`.
+		 * - Setting the color scheme and dark mode to the value in settings.
+		 */
+		initColorScheme() {
+			prefersColorSchemeDark.addEventListener('change', (event) => {
+				// Bail if the color scheme is not set by the system.
+				if (this.ui.colorScheme != 'system') {
+					return
+				}
+
+				this.setDarkMode(event.matches)
+			})
+
+			// ensure local storage is in sync with the store
+			// to prevent theme switch on startup
+			this.setColorScheme(this.ui.colorScheme)
 		},
 		initPorts(ports) {
 			if (ports) {
@@ -574,6 +598,7 @@ const useBaseStore = defineStore('base', {
 				}
 
 				this.initSettings(data.settings)
+				this.initColorScheme()
 				this.initPorts(data.serial_ports)
 				this.initScales(data.scales)
 				this.initDevices(data.devices)
@@ -581,10 +606,18 @@ const useBaseStore = defineStore('base', {
 				this.inited = true
 			}
 		},
+		/**
+		 * Sets the {@link ColorScheme} and updates the {@link DarkMode} accordingly.
+		 * @param {ColorScheme} value
+		 */
+		setColorScheme(value) {
+			settings.store('colorScheme', value)
+			this.ui.colorScheme = value
+			this.setDarkMode(colorSchemeToDarkMode(value))
+		},
 		setDarkMode(value) {
-			settings.store('dark', value)
 			// the `darkMode` watcher in App.vue will change vuetify theme
-			this.ui.darkMode = value
+			this.uiState.darkMode = value
 
 			const metaThemeColor = document.querySelector(
 				'meta[name=theme-color]',

--- a/src/views/Login.vue
+++ b/src/views/Login.vue
@@ -59,7 +59,6 @@
 						<color-scheme
 							prepend-icon="null"
 							hide-details
-							v-model="internalColorScheme"
 						></color-scheme>
 					</v-form>
 				</v-card-text>
@@ -97,7 +96,7 @@ import { Routes } from '@/router'
 import useBaseStore from '../stores/base.js'
 import logger from '../lib/logger'
 
-import { mapState, mapActions } from 'pinia'
+import { mapActions } from 'pinia'
 
 const log = logger.get('Login')
 
@@ -121,19 +120,6 @@ export default {
 				},
 			},
 		}
-	},
-	computed: {
-		...mapState(useBaseStore, {
-			colorScheme: (store) => store.ui.colorScheme,
-		}),
-		internalColorScheme: {
-			get() {
-				return this.colorScheme
-			},
-			set(value) {
-				this.setColorScheme(value)
-			},
-		},
 	},
 	watch: {
 		error: function (newValue) {
@@ -169,7 +155,7 @@ export default {
 		}
 	},
 	methods: {
-		...mapActions(useBaseStore, ['initColorScheme', 'setColorScheme']),
+		...mapActions(useBaseStore, ['initColorScheme']),
 		isLocalStorageSupported() {
 			const testKey = 'test'
 			const storage = window.localStorage

--- a/src/views/Login.vue
+++ b/src/views/Login.vue
@@ -56,14 +56,11 @@
 							hide-details
 							label="Remember Me"
 						></v-checkbox>
-						<v-select
+						<color-scheme
 							prepend-icon="null"
 							hide-details
-							persistent-hint
-							label="Color scheme"
-							:items="colorSchemes"
 							v-model="internalColorScheme"
-						></v-select>
+						></color-scheme>
 					</v-form>
 				</v-card-text>
 				<v-card-actions class="justify-center">
@@ -97,7 +94,6 @@
 <script>
 import ConfigApis from '@/apis/ConfigApis'
 import { Routes } from '@/router'
-import { colorSchemes } from '../lib/colorScheme'
 import useBaseStore from '../stores/base.js'
 import logger from '../lib/logger'
 
@@ -106,6 +102,9 @@ import { mapState, mapActions } from 'pinia'
 const log = logger.get('Login')
 
 export default {
+	components: {
+		ColorScheme: () => import('@/components/custom/ColorScheme.vue'),
+	},
 	data() {
 		return {
 			username: '',
@@ -121,7 +120,6 @@ export default {
 					return !!value || 'This field is required.'
 				},
 			},
-			colorSchemes,
 		}
 	},
 	computed: {

--- a/src/views/Login.vue
+++ b/src/views/Login.vue
@@ -56,13 +56,14 @@
 							hide-details
 							label="Remember Me"
 						></v-checkbox>
-						<v-checkbox
+						<v-select
 							prepend-icon="null"
 							hide-details
 							persistent-hint
-							label="Dark mode"
-							v-model="internalDarkMode"
-						></v-checkbox>
+							label="Color scheme"
+							:items="colorSchemes"
+							v-model="internalColorScheme"
+						></v-select>
 					</v-form>
 				</v-card-text>
 				<v-card-actions class="justify-center">
@@ -96,6 +97,7 @@
 <script>
 import ConfigApis from '@/apis/ConfigApis'
 import { Routes } from '@/router'
+import { colorSchemes } from '../lib/colorScheme'
 import useBaseStore from '../stores/base.js'
 import logger from '../lib/logger'
 
@@ -119,18 +121,19 @@ export default {
 					return !!value || 'This field is required.'
 				},
 			},
+			colorSchemes,
 		}
 	},
 	computed: {
 		...mapState(useBaseStore, {
-			darkMode: (store) => store.ui.darkMode,
+			colorScheme: (store) => store.ui.colorScheme,
 		}),
-		internalDarkMode: {
+		internalColorScheme: {
 			get() {
-				return this.darkMode
+				return this.colorScheme
 			},
 			set(value) {
-				this.setDarkMode(value)
+				this.setColorScheme(value)
 			},
 		},
 	},
@@ -159,6 +162,8 @@ export default {
 			} else {
 				localStorage.removeItem('user')
 			}
+
+			this.initColorScheme()
 		} else {
 			this.error = true
 			this.error_type = 'error'
@@ -166,7 +171,7 @@ export default {
 		}
 	},
 	methods: {
-		...mapActions(useBaseStore, ['setDarkMode']),
+		...mapActions(useBaseStore, ['initColorScheme', 'setColorScheme']),
 		isLocalStorageSupported() {
 			const testKey = 'test'
 			const storage = window.localStorage

--- a/src/views/Settings.vue
+++ b/src/views/Settings.vue
@@ -33,13 +33,9 @@
 					<v-expansion-panel-content>
 						<v-row class="mb-5">
 							<v-col cols="12" sm="6">
-								<v-select
-									hint="Force dark/light mode or select color scheme automatically based on the system preference"
-									persistent-hint
-									label="Color scheme"
-									:items="colorSchemes"
+								<color-scheme
 									v-model="internalColorScheme"
-								></v-select>
+								></color-scheme>
 							</v-col>
 							<v-col cols="12" sm="6">
 								<v-switch
@@ -2072,7 +2068,6 @@
 import { mapActions, mapState } from 'pinia'
 import ConfigApis from '@/apis/ConfigApis'
 import { parse } from 'native-url'
-import { colorSchemes } from '../lib/colorScheme'
 import { wait, copy, isUndef, deepEqual } from '../lib/utils'
 import { rfRegions, znifferRegions, maxLRPowerLevels } from '../lib/items'
 import cronstrue from 'cronstrue'
@@ -2087,6 +2082,7 @@ export default {
 	name: 'Settings',
 	mixins: [InstancesMixin],
 	components: {
+		ColorScheme: () => import('@/components/custom/ColorScheme.vue'),
 		DialogGatewayValue: () =>
 			import('@/components/dialogs/DialogGatewayValue.vue'),
 		fileInput: () => import('@/components/custom/file-input.vue'),
@@ -2368,7 +2364,6 @@ export default {
 					)
 				},
 			},
-			colorSchemes,
 		}
 	},
 	methods: {

--- a/src/views/Settings.vue
+++ b/src/views/Settings.vue
@@ -33,12 +33,13 @@
 					<v-expansion-panel-content>
 						<v-row class="mb-5">
 							<v-col cols="12" sm="6">
-								<v-switch
-									hint="Enable dark mode"
+								<v-select
+									hint="Force dark/light mode or select color scheme automatically based on the system preference"
 									persistent-hint
-									label="Dark mode"
-									v-model="internalDarkMode"
-								></v-switch>
+									label="Color scheme"
+									:items="colorSchemes"
+									v-model="internalColorScheme"
+								></v-select>
 							</v-col>
 							<v-col cols="12" sm="6">
 								<v-switch
@@ -2030,7 +2031,7 @@
 			space-be
 			class="sticky-buttons py-3 px-4"
 			:style="{
-				backgroundColor: internalDarkMode ? '#272727' : '#f5f5f5',
+				backgroundColor: darkMode ? '#272727' : '#f5f5f5',
 			}"
 		>
 			<v-btn class="mr-2" small color="error" @click="resetConfig">
@@ -2071,6 +2072,7 @@
 import { mapActions, mapState } from 'pinia'
 import ConfigApis from '@/apis/ConfigApis'
 import { parse } from 'native-url'
+import { colorSchemes } from '../lib/colorScheme'
 import { wait, copy, isUndef, deepEqual } from '../lib/utils'
 import { rfRegions, znifferRegions, maxLRPowerLevels } from '../lib/items'
 import cronstrue from 'cronstrue'
@@ -2098,12 +2100,12 @@ export default {
 		},
 	},
 	computed: {
-		internalDarkMode: {
+		internalColorScheme: {
 			get() {
-				return this.darkMode
+				return this.colorScheme
 			},
 			set(value) {
-				this.setDarkMode(value)
+				this.setColorScheme(value)
 			},
 		},
 		internalNavTabs: {
@@ -2213,7 +2215,8 @@ export default {
 			'ui',
 		]),
 		...mapState(useBaseStore, {
-			darkMode: (store) => store.ui.darkMode,
+			colorScheme: (store) => store.ui.colorScheme,
+			darkMode: (store) => store.uiState.darkMode,
 			navTabs: (store) => store.ui.navTabs,
 			streamerMode: (store) => store.ui.streamerMode,
 		}),
@@ -2365,11 +2368,12 @@ export default {
 					)
 				},
 			},
+			colorSchemes,
 		}
 	},
 	methods: {
 		...mapActions(useBaseStore, [
-			'setDarkMode',
+			'setColorScheme',
 			'setNavTabs',
 			'setStreamerMode',
 			'initSettings',
@@ -2678,7 +2682,7 @@ export default {
 			this.newBackup = copy(this.backup)
 
 			if (this.prevUi) {
-				this.internalDarkMode = this.prevUi.darkMode
+				this.internalColorScheme = this.prevUi.colorScheme
 				this.internalNavTabs = this.prevUi.navTabs
 				this.internalStreamerMode = this.prevUi.streamerMode
 			} else {

--- a/src/views/Settings.vue
+++ b/src/views/Settings.vue
@@ -33,9 +33,7 @@
 					<v-expansion-panel-content>
 						<v-row class="mb-5">
 							<v-col cols="12" sm="6">
-								<color-scheme
-									v-model="internalColorScheme"
-								></color-scheme>
+								<color-scheme />
 							</v-col>
 							<v-col cols="12" sm="6">
 								<v-switch


### PR DESCRIPTION
## Context

We migrate from only supporting an explicit dark or light color scheme to also supporting whatever the current system preference is for the color scheme.

This allows folks to change their color scheme at the operating system level (whether they do it automatically or manually) and have that setting be reflected in Z-Wave JS UI. This also means that different device preferences should follow what the device has configured (e.g. a desktop might always be in dark mode, while a mobile device changes based on the time of day).

This is my first time contributing to `zwave-js-ui`, and I have limited experience with Vue. So apologies if I've done something wrong, or a bit off. Let me know if you have any suggestions/alternatives to the implementation.

Fixes https://github.com/zwave-js/zwave-js-ui/issues/3607

## Screenshots

I've attached some screenshots. I'm not very attached to the copy or design here. So I'm down to make whatever changes you'd prefer (so long as I still understand it 😅).

### Login

<details>
<summary>Login - dark color scheme</summary>
<img width="1822" alt="z-wave-js-ui-login-dark" src="https://github.com/user-attachments/assets/816b7dbd-721d-47cd-b757-b2db97d26db9" />
</details>

<details>
<summary>Login - light color scheme</summary>
<img width="1822" alt="z-wave-js-ui-login-light" src="https://github.com/user-attachments/assets/b92efa4d-c8cd-444e-a90f-fccc40906d4b" />
</details>

<details>
<summary>Login - system color scheme</summary>
<img width="1822" alt="z-wave-js-ui-login-system" src="https://github.com/user-attachments/assets/594b51b8-f328-4a03-b822-bde0903d791a" />
</details>

<details>
<summary>Login - system color scheme - dark preference</summary>
<img width="1822" alt="z-wave-js-ui-login-system-dark" src="https://github.com/user-attachments/assets/b6821bb0-2efc-44dc-9de6-66b6a5fe1444" />
</details>

<details>
<summary>Login - system color scheme - light preference</summary>
<img width="1822" alt="z-wave-js-ui-login-system-light" src="https://github.com/user-attachments/assets/75c8c074-540c-4159-b1de-b1bc244d8646" />
</details>

### Settings

<details>
<summary>Settings - dark color scheme</summary>
<img width="1822" alt="z-wave-js-ui-settings-dark" src="https://github.com/user-attachments/assets/948dadf3-17c9-4190-b466-8ef352531eba" />
</details>

<details>
<summary>Settings - light color scheme</summary>
<img width="1822" alt="z-wave-js-ui-settings-light" src="https://github.com/user-attachments/assets/dce09414-edc9-4f7e-ab8e-2bfeac4b30ae" />
</details>

<details>
<summary>Settings - system color scheme</summary>
<img width="1822" alt="z-wave-js-ui-settings-system" src="https://github.com/user-attachments/assets/388f0bad-1975-4a37-8ee2-5848d7c40ce2" />
</details>

<details>
<summary>Settings - system color scheme - dark preference</summary>
<img width="1822" alt="z-wave-js-ui-settings-system-dark" src="https://github.com/user-attachments/assets/bd90a1a3-6977-4b83-b069-dd8579f40baa" />
</details>

<details>
<summary>Settings - system color scheme - light preference</summary>
<img width="1822" alt="z-wave-js-ui-settings-system-light" src="https://github.com/user-attachments/assets/f12b308e-3ba3-465e-a584-0e474dfb4e53" />
</details>