### PR TITLE
feat: make RF region setting mandatory, enable auto-powerlevel by default

### DIFF
--- a/api/config/store.ts
+++ b/api/config/store.ts
@@ -32,8 +32,14 @@ const store: Record<StoreKeys, StoreFile> = {
 			zwave: {
 				deviceConfigPriorityDir,
 				enableSoftReset: true,
+				rf: {
+					maxLongRangePowerlevel: 'auto',
+					txPower: {
+						powerlevel: 'auto',
+					},
+				},
 			},
-		},
+		} satisfies Settings,
 	},
 	scenes: { file: 'scenes.json', default: [] },
 	nodes: { file: 'nodes.json', default: {} },

--- a/src/lib/items.js
+++ b/src/lib/items.js
@@ -16,6 +16,26 @@ export const rfRegions = Object.keys(RFRegion)
 	}))
 	.sort((a, b) => a.text.localeCompare(b.text))
 
+export const settingsRfRegions = Object.keys(RFRegion)
+	.filter((k) => isNaN(k))
+	// Filter out regions that are not suitable for manual selection
+	.filter((key) => {
+		return (
+			// Cannot be set:
+			RFRegion[key] !== RFRegion.Unknown &&
+			RFRegion[key] !== RFRegion['Default (EU)'] &&
+			// Not supported by old controllers and Z-Wave JS selects them
+			// automatically when Long Range is available:
+			RFRegion[key] !== RFRegion['USA (Long Range)'] &&
+			RFRegion[key] !== RFRegion['Europe (Long Range)']
+		)
+	})
+	.map((key) => ({
+		text: key,
+		value: RFRegion[key],
+	}))
+	.sort((a, b) => a.text.localeCompare(b.text))
+
 export const znifferRegions = Object.keys(ZnifferRegion)
 	.filter((k) => isNaN(k))
 	.map((key) => ({

--- a/src/stores/base.js
+++ b/src/stores/base.js
@@ -37,9 +37,9 @@ const useBaseStore = defineStore('base', {
 			logLevel: 'debug',
 			rf: {
 				region: undefined,
-				maxLongRangePowerlevel: undefined,
+				maxLongRangePowerlevel: 'auto',
 				txPower: {
-					powerlevel: undefined,
+					powerlevel: 'auto',
 					measured0dBm: undefined,
 				},
 			},

--- a/src/stores/base.js
+++ b/src/stores/base.js
@@ -514,14 +514,6 @@ const useBaseStore = defineStore('base', {
 					this.zwave.rf.txPower = {}
 				}
 
-				if (!this.zwave.rf.maxLongRangePowerlevel) {
-					this.zwave.rf.maxLongRangePowerlevel = 'auto'
-				}
-
-				if (!this.zwave.rf.txPower.powerlevel) {
-					this.zwave.rf.txPower.powerlevel = 'auto'
-				}
-
 				Object.assign(this.mqtt, conf.mqtt || {})
 				Object.assign(this.zniffer, conf.zniffer || {})
 				Object.assign(this.gateway, conf.gateway || {})

--- a/src/stores/base.js
+++ b/src/stores/base.js
@@ -513,6 +513,15 @@ const useBaseStore = defineStore('base', {
 				if (!this.zwave.rf.txPower) {
 					this.zwave.rf.txPower = {}
 				}
+
+				if (!this.zwave.rf.maxLongRangePowerlevel) {
+					this.zwave.rf.maxLongRangePowerlevel = 'auto'
+				}
+
+				if (!this.zwave.rf.txPower.powerlevel) {
+					this.zwave.rf.txPower.powerlevel = 'auto'
+				}
+
 				Object.assign(this.mqtt, conf.mqtt || {})
 				Object.assign(this.zniffer, conf.zniffer || {})
 				Object.assign(this.gateway, conf.gateway || {})

--- a/src/stores/base.js
+++ b/src/stores/base.js
@@ -514,6 +514,16 @@ const useBaseStore = defineStore('base', {
 					this.zwave.rf.txPower = {}
 				}
 
+				// for some reason this could be set to empty strings so
+				// json store will not override them when using `merge`
+				if (!this.zwave.rf.maxLongRangePowerlevel) {
+					this.zwave.rf.maxLongRangePowerlevel = 'auto'
+				}
+
+				if (!this.zwave.rf.txPower.powerlevel) {
+					this.zwave.rf.txPower.powerlevel = 'auto'
+				}
+
 				Object.assign(this.mqtt, conf.mqtt || {})
 				Object.assign(this.zniffer, conf.zniffer || {})
 				Object.assign(this.gateway, conf.gateway || {})

--- a/src/views/Settings.vue
+++ b/src/views/Settings.vue
@@ -799,9 +799,10 @@
 											<v-select
 												label="RF Region"
 												persistent-hint
-												hint="Will be applied on every startup if the current region of your Z-Wave controller differs. Leave this empty to use the default region of your stick. Not all controllers support changing the region."
+												hint="Will be used to automatically configure your controller for the region you are in. Not all controllers support changing the RF region."
 												:items="rfRegions"
-												clearable
+												:rules="[rules.required]"
+												required
 												v-model="newZwave.rf.region"
 											>
 											</v-select>
@@ -2116,7 +2117,11 @@ import { mapActions, mapState } from 'pinia'
 import ConfigApis from '@/apis/ConfigApis'
 import { parse } from 'native-url'
 import { wait, copy, isUndef, deepEqual } from '../lib/utils'
-import { rfRegions, znifferRegions, maxLRPowerLevels } from '../lib/items'
+import {
+	settingsRfRegions,
+	znifferRegions,
+	maxLRPowerLevels,
+} from '../lib/items'
 import cronstrue from 'cronstrue'
 import useBaseStore from '../stores/base'
 
@@ -2271,7 +2276,7 @@ export default {
 	},
 	data() {
 		return {
-			rfRegions,
+			rfRegions: settingsRfRegions,
 			znifferRegions,
 			maxLRPowerLevels,
 			valid_zwave: true,

--- a/src/views/Settings.vue
+++ b/src/views/Settings.vue
@@ -879,9 +879,8 @@
 												:rules="[validTxPower]"
 											></v-text-field>
 										</v-col>
-									</v-row>
-									<v-row class="mt-0">
-										<v-col cols="6">
+
+										<v-col cols="12" sm="6">
 											<v-select
 												label="Maximum LR Power Level"
 												persistent-hint


### PR DESCRIPTION
This is the first step to help users with configuring controllers for their region a bit easier than right now.

The RF region setting is now mandatory, so there are no surprises when switching controllers or setting up a new one that defaults to a different region.
Auto-powerlevel is now enabled by default, because nobody should have to deal with powerlevels anyways.