### PR TITLE
feat: use default RF region from settings for OTA update check

### DIFF
--- a/src/components/custom/FirmwareUpdates.vue
+++ b/src/components/custom/FirmwareUpdates.vue
@@ -29,7 +29,12 @@
 					>
 					</v-checkbox>
 				</v-row>
-				<v-row justify="center" class="pt-2 text-center" dense>
+				<v-row
+					v-if="controllerNode.RFRegion === undefined"
+					justify="center"
+					class="pt-2 text-center"
+					dense
+				>
 					<v-alert
 						type="info"
 						dense
@@ -41,7 +46,7 @@
 							{{
 								invalidRfRegion
 									? 'To get region-specific firmware updates, you need to configure your current region in the settings.'
-									: `Firmware updates include updates specific to ${zwave.rf.region}. If this is not correct, you can change it in the settings.`
+									: `Firmware updates include updates specific to ${RFRegion[zwave.rf.region]}. If this is not correct, you can change it in the settings.`
 							}}
 						</small>
 					</v-alert>
@@ -164,7 +169,7 @@
 import useBaseStore from '../../stores/base.js'
 import { mapActions, mapState } from 'pinia'
 import InstancesMixin from '../../mixins/InstancesMixin.js'
-import { rfRegions } from '../../lib/items.js'
+import { RFRegion } from '@zwave-js/core'
 
 export default {
 	components: {},
@@ -189,7 +194,7 @@ export default {
 	mixins: [InstancesMixin],
 	data() {
 		return {
-			rfRegions,
+			RFRegion,
 			rfRegion: null,
 			fwUpdates: [],
 			loading: false,

--- a/src/components/custom/FirmwareUpdates.vue
+++ b/src/components/custom/FirmwareUpdates.vue
@@ -28,22 +28,23 @@
 						class="ml-2 my-auto"
 					>
 					</v-checkbox>
-					<v-select
+					<v-alert
 						v-if="
 							controllerNode &&
-							controllerNode.RFRegion === undefined
+							controllerNode.RFRegion === undefined &&
+							!zwave.rf.region
 						"
-						style="max-width: 200px"
+						type="warning"
+						dense
 						class="ml-2 mb-2"
-						label="Rf Region"
-						hide-details
-						:items="rfRegions"
-						v-model="rfRegion"
+						style="max-width: 400px"
 					>
-						<template v-slot:prepend>
-							<v-icon>signal_cellular_alt</v-icon>
-						</template>
-					</v-select>
+						<small>
+							<v-icon small>settings</v-icon>
+							Configure your RF region in the settings to get
+							region-specific firmware updates.
+						</small>
+					</v-alert>
 				</v-row>
 			</v-col>
 
@@ -197,7 +198,7 @@ export default {
 		}
 	},
 	computed: {
-		...mapState(useBaseStore, ['controllerNode']),
+		...mapState(useBaseStore, ['controllerNode', 'zwave']),
 		filteredUpdates() {
 			return this.fwUpdates.filter(
 				(u) => !u.downgrade || (u.downgrade && this.showDowngrades),
@@ -218,9 +219,10 @@ export default {
 
 			if (
 				this.controllerNode &&
-				this.controllerNode.RFRegion === undefined
+				this.controllerNode.RFRegion === undefined &&
+				this.zwave.rf.region
 			) {
-				options.rfRegion = this.rfRegion
+				options.rfRegion = this.zwave.rf.region
 			}
 
 			const response = await this.app.apiRequest(

--- a/src/components/custom/FirmwareUpdates.vue
+++ b/src/components/custom/FirmwareUpdates.vue
@@ -28,21 +28,21 @@
 						class="ml-2 my-auto"
 					>
 					</v-checkbox>
+				</v-row>
+				<v-row justify="center" class="pt-2 text-center" dense>
 					<v-alert
-						v-if="
-							controllerNode &&
-							controllerNode.RFRegion === undefined &&
-							!zwave.rf.region
-						"
-						type="warning"
+						type="info"
 						dense
+						text
 						class="ml-2 mb-2"
 						style="max-width: 400px"
 					>
 						<small>
-							<v-icon small>settings</v-icon>
-							Configure your RF region in the settings to get
-							region-specific firmware updates.
+							{{
+								invalidRfRegion
+									? 'To get region-specific firmware updates, you need to configure your current region in the settings.'
+									: `Firmware updates include updates specific to ${zwave.rf.region}. If this is not correct, you can change it in the settings.`
+							}}
 						</small>
 					</v-alert>
 				</v-row>
@@ -202,6 +202,13 @@ export default {
 		filteredUpdates() {
 			return this.fwUpdates.filter(
 				(u) => !u.downgrade || (u.downgrade && this.showDowngrades),
+			)
+		},
+		invalidRfRegion() {
+			return (
+				this.controllerNode &&
+				this.controllerNode.RFRegion === undefined &&
+				!this.zwave.rf.region
 			)
 		},
 	},

--- a/src/components/nodes-table/OTAUpdates.vue
+++ b/src/components/nodes-table/OTAUpdates.vue
@@ -27,22 +27,23 @@
 						class="ml-2 my-auto"
 					>
 					</v-checkbox>
-					<v-select
+					<v-alert
 						v-if="
 							controllerNode &&
-							controllerNode.RFRegion === undefined
+							controllerNode.RFRegion === undefined &&
+							!zwave.rf.region
 						"
-						style="max-width: 200px"
+						type="warning"
+						dense
 						class="ml-2 mb-2"
-						label="Rf Region"
-						hide-details
-						:items="rfRegions"
-						v-model="rfRegion"
+						style="max-width: 400px"
 					>
-						<template v-slot:prepend>
-							<v-icon>signal_cellular_alt</v-icon>
-						</template>
-					</v-select>
+						<small>
+							<v-icon small>settings</v-icon>
+							Configure your RF region in the settings to get
+							region-specific firmware updates.
+						</small>
+					</v-alert>
 				</v-row>
 			</v-col>
 
@@ -158,7 +159,6 @@
 import useBaseStore from '../../stores/base.js'
 import { mapActions, mapState } from 'pinia'
 import InstancesMixin from '../../mixins/InstancesMixin.js'
-import { rfRegions } from '../../lib/items.js'
 
 export default {
 	components: {},
@@ -169,8 +169,6 @@ export default {
 	mixins: [InstancesMixin],
 	data() {
 		return {
-			rfRegions,
-			rfRegion: null,
 			fwUpdates: [],
 			loading: false,
 			includePrereleases: false,
@@ -178,7 +176,7 @@ export default {
 		}
 	},
 	computed: {
-		...mapState(useBaseStore, ['controllerNode']),
+		...mapState(useBaseStore, ['controllerNode', 'zwave']),
 		filteredUpdates() {
 			return this.fwUpdates.filter(
 				(u) => !u.downgrade || (u.downgrade && this.showDowngrades),
@@ -199,9 +197,10 @@ export default {
 
 			if (
 				this.controllerNode &&
-				this.controllerNode.RFRegion === undefined
+				this.controllerNode.RFRegion === undefined &&
+				this.zwave.rf.region
 			) {
-				options.rfRegion = this.rfRegion
+				options.rfRegion = this.zwave.rf.region
 			}
 
 			const response = await this.app.apiRequest(
@@ -237,11 +236,11 @@ export default {
 					`<p>Are you sure you want to ${
 						update.downgrade ? 'downgrade' : 'upgrade'
 					} node to <b>v${update.version}</b>?</p>
-										
+
 					<p><strong>We don't take any responsibility if devices upgraded using Z-Wave JS don't work after an update. Always double-check that the correct update is about to be installed</strong></p>
-					
+
 					<p>This will download the desired firmware update from the <a href="https://github.com/zwave-js/firmware-updates/">Z-Wave JS firmware update service</a> and start an over-the-air (OTA) firmware update for the given node.</p>
-	
+
 					`,
 					update.downgrade ? 'error' : 'warning',
 					{


### PR DESCRIPTION
This is a followup to #4277 and replaces the region selector on the OTA page with a hint to configure the region in the settings.

When the current controller region is not known, the region from the settings is now used instead.

Unfortunately, I can't test that as I don't have a controller that does not support changing the region.