### PR TITLE
feat: download Zniffer capture after saving

### DIFF
--- a/api/lib/ZnifferManager.ts
+++ b/api/lib/ZnifferManager.ts
@@ -16,6 +16,7 @@ import { logsDir, storeDir } from '../config/app'
 import { buffer2hex, joinPath, parseSecurityKeys } from './utils'
 import { isDocker } from './utils'
 import { basename } from 'path'
+import { readFile } from 'fs/promises'
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const loglevels = require('triple-beam').configs.npm.levels
@@ -336,9 +337,14 @@ export default class ZnifferManager extends TypedEventEmitter<ZnifferManagerEven
 		logger.info(`Saving capture to ${filePath}`)
 		await this.zniffer.saveCaptureToFile(filePath)
 		logger.info('Capture saved')
+
+		// Read the saved file to return its content for download
+		const data = await readFile(filePath)
+
 		return {
 			path: filePath,
 			name: basename(filePath),
+			data: data,
 		}
 	}
 }

--- a/src/views/Zniffer.vue
+++ b/src/views/Zniffer.vue
@@ -1095,6 +1095,9 @@ export default {
 					`Capture "${result.name}" created in store`,
 					'success',
 				)
+				// Trigger download of the Zniffer capture
+				const fileName = result.name.replace('.zlf', '')
+				this.app.exportConfiguration(result.data, fileName, 'zlf')
 			}
 		},
 		async loadCapture() {


### PR DESCRIPTION
Unlike NVM backups, Zniffer captures were not automatically downloaded. This PR changes that.