### PR TITLE
feat: implement unified JSON/text logging format

### DIFF
--- a/api/lib/Gateway.ts
+++ b/api/lib/Gateway.ts
@@ -191,6 +191,7 @@ export type GatewayConfig = {
 	logEnabled?: boolean
 	logLevel?: LogLevel
 	logToFile?: boolean
+	logFormat?: 'text' | 'json'
 	values?: GatewayValue[]
 	jobs?: ScheduledJob[]
 	plugins?: string[]

--- a/src/views/Settings.vue
+++ b/src/views/Settings.vue
@@ -138,6 +138,20 @@
 										md="4"
 										v-if="newGateway.logEnabled"
 									>
+										<v-select
+											:items="logFormats"
+											v-model="newGateway.logFormat"
+											label="Log Format"
+											hint="Choose between human-readable text or structured JSON logging"
+											persistent-hint
+										></v-select>
+									</v-col>
+									<v-col
+										cols="12"
+										sm="6"
+										md="4"
+										v-if="newGateway.logEnabled"
+									>
 										<v-switch
 											hint="Store logs in a file. Default: store/zwave-js-ui_%DATE%.log"
 											persistent-hint
@@ -2268,6 +2282,10 @@ export default {
 				{ title: 'Verbose', value: 'verbose' },
 				{ title: 'Debug', value: 'debug' },
 				{ title: 'Silly', value: 'silly' },
+			],
+			logFormats: [
+				{ title: 'Text (Human-readable)', value: 'text' },
+				{ title: 'JSON (Structured)', value: 'json' },
 			],
 			headers: [
 				{ title: 'Device', key: 'device' },

--- a/test/lib/logger.test.ts
+++ b/test/lib/logger.test.ts
@@ -3,6 +3,7 @@ import * as utils from '../../api/lib/utils'
 import { logsDir } from '../../api/config/app'
 import {
 	customTransports,
+	customFormat,
 	defaultLogFile,
 	ModuleLogger,
 	sanitizedConfig,
@@ -175,6 +176,26 @@ describe('logger.js', () => {
 			// Test post-conditions:
 			expect(logger1.level).to.equal('error')
 			expect(logger2.level).to.equal('warn')
+		})
+	})
+
+	describe('customFormat()', () => {
+		it('should return format object when logFormat is json', () => {
+			const format = customFormat(false, 'json')
+			expect(format).to.be.an('object')
+			expect(format).to.have.property('transform')
+		})
+
+		it('should return format object when logFormat is text', () => {
+			const format = customFormat(true, 'text')
+			expect(format).to.be.an('object')
+			expect(format).to.have.property('transform')
+		})
+
+		it('should return format object when logFormat is undefined', () => {
+			const format = customFormat(true, undefined)
+			expect(format).to.be.an('object')
+			expect(format).to.have.property('transform')
 		})
 	})
 })


### PR DESCRIPTION
This provides a unified logging system where users can switch between human-readable text logs and structured JSON logs across all output destinations: console, files, and WebSocket/UI debug view.

- Add logFormat setting to Gateway config (text/json)
- Update UI logger to respect global logFormat setting
- Add log format selector in Settings UI
- Update Debug view to handle both text and JSON log formats
- Implement driver logging configuration for JSON mode
- Use DailyRotateFile for JSON file transport to maintain symlink functionality
- Redirect driver internal file transport to /dev/null in JSON mode. See details below.
- Add WebSocket streaming for both text and JSON formats
- Add basic tests for logging format functionality


Why do I write a /dev/null file in JSON mode?

The zwave-js driver's internal logic creates a console transport when` (isTTY && !logToFile)` is true, but we needed` logToFile: true` to prevent console output in JSON mode. However, setting` logToFile: true` also creates an unwanted text file transport that writes to the same filename as our JSON logs, causing duplicate/conflicting file output.
Solution: I redirected the driver's internal file transport to `/dev/null` using `filename: /dev/null` in the driver's `logConfig`, which satisfies the driver's internal logic (preventing console transport creation) while discarding the unwanted text file output, allowing our custom JSON file transport to handle the actual file logging cleanly.
