### PR TITLE
feat: on-demand plugin installation system

### DIFF
--- a/api/app.ts
+++ b/api/app.ts
@@ -43,6 +43,8 @@ import { createPlugin } from './lib/CustomPlugin.ts'
 import { inboundEvents, socketEvents } from './lib/SocketEvents.ts'
 import * as utils from './lib/utils.ts'
 import backupManager from './lib/BackupManager.ts'
+import pluginManager from './lib/PluginManager.ts'
+import { pluginRegistry } from './lib/PluginRegistry.ts'
 import {
 	getExternallyManagedPaths,
 	loadExternalSettings,
@@ -420,10 +422,16 @@ async function startGateway(settings: Settings) {
 	const pluginsConfig = settings.gateway?.plugins ?? null
 	pluginsRouter = express.Router()
 
+	await pluginManager.init()
+
 	// load custom plugins
 	if (pluginsConfig && Array.isArray(pluginsConfig)) {
 		for (const plugin of pluginsConfig) {
 			try {
+				// Auto-install npm plugins on-demand
+				await pluginManager.install(plugin)
+
+				const resolvedPath = pluginManager.resolvePlugin(plugin)
 				const pluginName = path.basename(plugin)
 				const pluginsContext = {
 					zwave,
@@ -431,7 +439,7 @@ async function startGateway(settings: Settings) {
 					app: pluginsRouter,
 					logger: loggers.module(pluginName),
 				}
-				const constructor = (await import(plugin))
+				const constructor = (await import(resolvedPath))
 					.default as PluginConstructor
 				const instance = createPlugin(
 					constructor,
@@ -1113,6 +1121,7 @@ app.get('/api/settings', apisLimiter, isAuthenticated, function (req, res) {
 	const data = {
 		success: true,
 		settings,
+		pluginRegistry,
 		devices: gw?.zwave?.devices ?? {},
 		scales: scales,
 		sslDisabled: sslDisabled(),
@@ -1366,6 +1375,54 @@ app.post(
 		} catch (error) {
 			restarting = false
 			logger.error(error)
+			res.json({ success: false, message: error.message })
+		}
+	},
+)
+
+// update plugins
+app.post(
+	'/api/plugins/update',
+	apisLimiter,
+	isAuthenticated,
+	async function (req, res) {
+		try {
+			const { name } = req.body || {}
+			await pluginManager.update(name || undefined)
+			res.json({
+				success: true,
+				message: name
+					? `Plugin ${name} updated successfully`
+					: 'All plugins updated successfully',
+			})
+		} catch (error) {
+			logger.error('Plugin update failed', error)
+			res.json({ success: false, message: error.message })
+		}
+	},
+)
+
+// uninstall plugin
+app.post(
+	'/api/plugins/uninstall',
+	apisLimiter,
+	isAuthenticated,
+	async function (req, res) {
+		try {
+			const { name } = req.body || {}
+			if (!name) {
+				return res.json({
+					success: false,
+					message: 'Plugin name is required',
+				})
+			}
+			await pluginManager.uninstall(name)
+			res.json({
+				success: true,
+				message: `Plugin ${name} uninstalled successfully`,
+			})
+		} catch (error) {
+			logger.error('Plugin uninstall failed', error)
 			res.json({ success: false, message: error.message })
 		}
 	},

--- a/api/lib/PluginManager.ts
+++ b/api/lib/PluginManager.ts
@@ -1,0 +1,159 @@
+import { execFile } from 'node:child_process'
+import { readFile, writeFile } from 'node:fs/promises'
+import path from 'node:path'
+import { storeDir } from '../config/app.ts'
+import { ensureDir } from './utils.ts'
+import { module } from './logger.ts'
+
+const logger = module('PluginManager')
+
+// npm scoped and unscoped package name pattern
+const NPM_PACKAGE_NAME_RE =
+	/^(@[a-z0-9-~][a-z0-9-._~]*\/)?[a-z0-9-~][a-z0-9-._~]*$/
+
+const INSTALL_TIMEOUT = 120_000
+
+class PluginManager {
+	private pluginsDir: string
+	private packageJsonPath: string
+	private installing = new Set<string>()
+
+	constructor() {
+		this.pluginsDir = path.join(storeDir, '.plugins')
+		this.packageJsonPath = path.join(this.pluginsDir, 'package.json')
+	}
+
+	async init(): Promise<void> {
+		await ensureDir(this.pluginsDir)
+
+		try {
+			await readFile(this.packageJsonPath, 'utf-8')
+		} catch {
+			await writeFile(
+				this.packageJsonPath,
+				JSON.stringify(
+					{ name: 'zwavejsui-plugins', private: true },
+					null,
+					2,
+				),
+			)
+		}
+	}
+
+	isPathPlugin(plugin: string): boolean {
+		return (
+			plugin.startsWith('/') ||
+			plugin.startsWith('.') ||
+			plugin.startsWith('~')
+		)
+	}
+
+	validatePackageName(name: string): boolean {
+		return NPM_PACKAGE_NAME_RE.test(name)
+	}
+
+	async getInstalledPlugins(): Promise<Record<string, string>> {
+		try {
+			const pkg = JSON.parse(
+				await readFile(this.packageJsonPath, 'utf-8'),
+			)
+			return pkg.dependencies ?? {}
+		} catch {
+			return {}
+		}
+	}
+
+	async install(packageName: string): Promise<void> {
+		if (this.isPathPlugin(packageName)) {
+			return
+		}
+
+		if (!this.validatePackageName(packageName)) {
+			throw new Error(`Invalid npm package name: ${packageName}`)
+		}
+
+		if (this.installing.has(packageName)) {
+			logger.warn(
+				`Plugin ${packageName} is already being installed, skipping`,
+			)
+			return
+		}
+
+		// Skip if already installed
+		const installed = await this.getInstalledPlugins()
+		if (installed[packageName]) {
+			logger.info(`Plugin ${packageName} already installed, skipping`)
+			return
+		}
+
+		this.installing.add(packageName)
+
+		try {
+			logger.info(`Installing plugin ${packageName}...`)
+			await this.npmExec(['install', '--save', packageName])
+			logger.info(`Plugin ${packageName} installed successfully`)
+		} finally {
+			this.installing.delete(packageName)
+		}
+	}
+
+	async update(packageName?: string): Promise<void> {
+		const args = ['update']
+		if (packageName) {
+			if (!this.validatePackageName(packageName)) {
+				throw new Error(`Invalid npm package name: ${packageName}`)
+			}
+			args.push(packageName)
+		}
+
+		logger.info(
+			`Updating plugin${packageName ? ` ${packageName}` : 's'}...`,
+		)
+		await this.npmExec(args)
+		logger.info('Plugin update completed')
+	}
+
+	async uninstall(packageName: string): Promise<void> {
+		if (!this.validatePackageName(packageName)) {
+			throw new Error(`Invalid npm package name: ${packageName}`)
+		}
+
+		logger.info(`Uninstalling plugin ${packageName}...`)
+		await this.npmExec(['uninstall', packageName])
+		logger.info(`Plugin ${packageName} uninstalled successfully`)
+	}
+
+	resolvePlugin(plugin: string): string {
+		if (this.isPathPlugin(plugin)) {
+			return plugin
+		}
+
+		return path.join(this.pluginsDir, 'node_modules', plugin)
+	}
+
+	private npmExec(args: string[]): Promise<string> {
+		return new Promise((resolve, reject) => {
+			execFile(
+				'npm',
+				args,
+				{ cwd: this.pluginsDir, timeout: INSTALL_TIMEOUT },
+				(error, stdout, stderr) => {
+					if (error) {
+						logger.error(
+							`npm ${args[0]} failed: ${stderr || error.message}`,
+						)
+						reject(
+							new Error(
+								`npm ${args[0]} failed: ${stderr || error.message}`,
+							),
+						)
+					} else {
+						resolve(stdout)
+					}
+				},
+			)
+		})
+	}
+}
+
+export default new PluginManager()

--- a/api/lib/PluginRegistry.ts
+++ b/api/lib/PluginRegistry.ts
@@ -1,0 +1,18 @@
+export interface PluginRegistryEntry {
+	name: string
+	label: string
+	description: string
+}
+
+export const pluginRegistry: PluginRegistryEntry[] = [
+	{
+		name: '@ongit/zwavejsui-prom-exporter',
+		label: 'Prometheus Exporter (ongit)',
+		description: 'Prometheus metrics exporter for Z-Wave JS UI',
+	},
+	{
+		name: '@kvaster/zwavejs-prom',
+		label: 'Prometheus Exporter (kvaster)',
+		description: 'Prometheus metrics for Z-Wave JS',
+	},
+]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -54,8 +54,11 @@ RUN npm prune --omit=dev && \
 
 # add plugin support, space separated
 ARG plugins
-RUN if [ ! -z "$plugins" ]; \
-    then echo "Installing plugins ${plugins}"; npm install ${plugins} ; fi
+RUN if [ ! -z "$plugins" ]; then \
+    mkdir -p store/.plugins && \
+    cd store/.plugins && \
+    echo '{"name":"zwavejsui-plugins","private":true}' > package.json && \
+    npm install ${plugins}; fi
 
 # when update devices arg is set update config files from zwavejs repo
 ARG updateDevices

--- a/docker/Dockerfile.debian
+++ b/docker/Dockerfile.debian
@@ -37,8 +37,11 @@ RUN npm prune --production && \
 
 # add plugin support, space separated
 ARG plugins
-RUN if [ ! -z "$plugins" ]; \
-    then echo "Installing plugins ${plugins}"; npm install ${plugins} ; fi
+RUN if [ ! -z "$plugins" ]; then \
+    mkdir -p store/.plugins && \
+    cd store/.plugins && \
+    echo '{"name":"zwavejsui-plugins","private":true}' > package.json && \
+    npm install ${plugins}; fi
 
 # when update devices arg is set update config files from zwavejs repo
 ARG updateDevices

--- a/docs/guide/plugins.md
+++ b/docs/guide/plugins.md
@@ -11,10 +11,16 @@ A plugin is loaded using ES dynamic `import()` and must export a **default class
 - `app`: Express router (scoped to the plugin)
 - `logger`: A logger instance to log things in console/file based on logger general settings
 
-To add a plugin, go to the UI **Settings -> General -> Plugins** and enter either:
+To add a plugin, go to the UI **Settings -> General -> Plugins** and either:
 
-- An **absolute path** to a local plugin directory (e.g. `/usr/src/app/store/plugins/my-plugin`)
-- A **package name** if the plugin is installed as an npm package
+- Select an **npm plugin** from the dropdown (it will be auto-installed on save)
+- Type an **absolute path** to a local plugin directory (e.g. `/usr/src/app/store/plugins/my-plugin`) and press enter
+
+When you save settings, npm plugins are automatically installed into the `store/.plugins` directory. This keeps plugins separate from the app's own `node_modules`.
+
+### Updating plugins
+
+Click the **Update Plugins** button next to the plugin selector in Settings to update all installed npm plugins to their latest versions.
 
 ## Plugin Interface
 
@@ -66,6 +72,14 @@ export default class MyPlugin {
 
 When running Z-Wave JS UI in Docker, the working directory is `/usr/src/app`. Plugins stored under the `store` directory persist across container restarts.
 
+### Using npm plugins
+
+npm plugins are automatically installed into `store/.plugins` when selected in the UI and saved. No manual installation is needed. You can also pre-install plugins at build time using the `plugins` Docker build argument:
+
+```bash
+docker build --build-arg plugins="@kvaster/zwavejs-prom @ongit/zwavejsui-prom-exporter" -f docker/Dockerfile -t zwavejs/zwave-js-ui .
+```
+
 ### Using a local plugin
 
 1. Create a `plugins` directory inside your store volume:
@@ -107,5 +121,6 @@ Then reference the plugin path as `/usr/src/app/plugins/my-plugin` in the settin
 
 Here is a list of currently available plugins:
 
-- [Prometheus metrics plugin](https://github.com/kvaster/zwavejs-prom)
+- [`@ongit/zwavejsui-prom-exporter`](https://www.npmjs.com/package/@ongit/zwavejsui-prom-exporter) - Prometheus metrics exporter for Z-Wave JS UI
+- [`@kvaster/zwavejs-prom`](https://github.com/kvaster/zwavejs-prom) - Prometheus metrics for Z-Wave JS
 - [Telegram alert plugin](https://github.com/kvaster/zwavejs-alert)

--- a/package.json
+++ b/package.json
@@ -78,7 +78,6 @@
   "dependencies": {
     "@esm2cjs/escape-string-regexp": "^5.0.0",
     "@jamescoyle/vue-icon": "^0.1.2",
-    "@kvaster/zwavejs-prom": "^0.0.3",
     "@mdi/js": "7.4.47",
     "@zwave-js/log-transport-json": "^3.0.0",
     "@zwave-js/server": "^3.2.1",

--- a/src/apis/ConfigApis.js
+++ b/src/apis/ConfigApis.js
@@ -212,4 +212,13 @@ export default {
 		const response = await request.post('/debug/cancel')
 		return response.data
 	},
+	// ---- PLUGINS -----
+	async updatePlugins(name) {
+		const response = await request.post('/plugins/update', { name })
+		return response.data
+	},
+	async uninstallPlugin(name) {
+		const response = await request.post('/plugins/uninstall', { name })
+		return response.data
+	},
 }

--- a/src/stores/base.js
+++ b/src/stores/base.js
@@ -114,6 +114,7 @@ const useBaseStore = defineStore('base', {
 			convertRSSI: false,
 			defaultFrequency: undefined,
 		},
+		pluginRegistry: [],
 		devices: [],
 		gateway: {
 			type: 0,
@@ -622,6 +623,7 @@ const useBaseStore = defineStore('base', {
 				this.initScales(data.scales)
 				this.initDevices(data.devices)
 				this.managedExternally = data.managedExternally || []
+				this.pluginRegistry = data.pluginRegistry || []
 
 				this.inited = true
 			}

--- a/src/views/Settings.vue
+++ b/src/views/Settings.vue
@@ -118,15 +118,32 @@
 											hint="You can select a plugin from the list or write the path to your custom plugin and press enter"
 											persistent-hint
 											label="Plugins"
-											:items="[
-												'@varet/zj2m-prom-exporter',
-												'@kvaster/zwavejs-prom',
-											]"
+											:items="pluginRegistry"
+											item-title="label"
+											item-value="name"
 											multiple
 											chips
 											closable-chips
 											v-model="newGateway.plugins"
 										></v-combobox>
+									</v-col>
+									<v-col
+										cols="12"
+										sm="6"
+										md="4"
+										class="d-flex align-center"
+									>
+										<v-btn
+											color="primary"
+											:loading="updatingPlugins"
+											:disabled="
+												!newGateway.plugins ||
+												newGateway.plugins.length === 0
+											"
+											@click="updatePlugins"
+										>
+											Update Plugins
+										</v-btn>
 									</v-col>
 									<v-col cols="12" sm="6" md="4">
 										<v-switch
@@ -2374,6 +2391,7 @@ export default {
 			'serial_ports',
 			'scales',
 			'ui',
+			'pluginRegistry',
 			'isSettingManagedExternally',
 		]),
 		allClassicSecurityKeysManagedExternally() {
@@ -2448,6 +2466,7 @@ export default {
 			dialogValue: false,
 			sslDisabled: false,
 			saving: false,
+			updatingPlugins: false,
 			loadingSerialPorts: false,
 			serialPortsFetched: false,
 			prevUi: null,
@@ -2596,6 +2615,22 @@ export default {
 			'init',
 			'showSnackbar',
 		]),
+		async updatePlugins() {
+			this.updatingPlugins = true
+			try {
+				const response = await ConfigApis.updatePlugins()
+				this.showSnackbar(
+					response.message || 'Plugins updated',
+					response.success ? 'success' : 'error',
+				)
+			} catch (error) {
+				this.showSnackbar(
+					error.message || 'Failed to update plugins',
+					'error',
+				)
+			}
+			this.updatingPlugins = false
+		},
 		copyKeysZniffer() {
 			this.newZniffer.securityKeys = copy(this.newZwave.securityKeys)
 			this.newZniffer.securityKeysLongRange = copy(


### PR DESCRIPTION
## Summary

- Add a `PluginManager` singleton that installs npm plugins on-demand into `storeDir/.plugins/` when settings are saved, keeping plugins separate from the app's own `node_modules`
- Add a `PluginRegistry` as a single source of truth for known plugins, shared between backend and frontend
- Replace the hardcoded plugin dropdown in Settings with a registry-based list and add an "Update Plugins" button
- Update Dockerfiles to install build-arg plugins into `store/.plugins` instead of app `node_modules`
- Remove `@kvaster/zwavejs-prom` from bundled dependencies (now auto-installed on demand)
- Add `@ongit/zwavejsui-prom-exporter` to the plugin registry

## Test plan

- [ ] Open Settings, verify plugin registry items appear in the Plugins dropdown with human-readable labels
- [ ] Select `@kvaster/zwavejs-prom`, save settings — verify `.plugins` directory is created under store with `package.json` and `node_modules`
- [ ] Verify plugin loads successfully (check server logs)
- [ ] Click "Update Plugins" button, verify snackbar shows success message
- [ ] Test absolute path plugin still works (backward compatibility)
- [ ] Docker build with `--build-arg plugins="@kvaster/zwavejs-prom"` installs into `store/.plugins`

🤖 Generated with [Claude Code](https://claude.com/claude-code)