### PR TITLE
feat(mqtt-discovery): add suggested_area from node location

### DIFF
--- a/api/lib/Gateway.ts
+++ b/api/lib/Gateway.ts
@@ -187,6 +187,7 @@ export type GatewayConfig = {
 	entityTemplate?: string
 	hassDiscovery?: boolean
 	discoveryPrefix?: string
+	useLocationAsSuggestedArea?: boolean
 	logEnabled?: boolean
 	logLevel?: LogLevel
 	logToFile?: boolean
@@ -217,6 +218,7 @@ interface DeviceInfo {
 	model: string
 	name: string
 	sw_version: string
+	suggested_area?: string
 }
 
 export default class Gateway {
@@ -2496,7 +2498,7 @@ export default class Gateway {
 	 * Get the device Object to send in discovery payload
 	 */
 	private _deviceInfo(node: ZUINode, nodeName: string): DeviceInfo {
-		return {
+		const deviceInfo: DeviceInfo = {
 			identifiers: [
 				UID_DISCOVERY_PREFIX + this._zwave.homeHex + '_node' + node.id,
 			],
@@ -2505,6 +2507,13 @@ export default class Gateway {
 			name: nodeName,
 			sw_version: node.firmwareVersion || utils.getVersion(),
 		}
+
+		const suggestedArea = node.loc?.trim()
+		if (this.config.useLocationAsSuggestedArea && suggestedArea) {
+			deviceInfo.suggested_area = suggestedArea
+		}
+
+		return deviceInfo
 	}
 
 	private setDiscoveryAvailability(

--- a/docs/homeassistant/homeassistant-mqtt.md
+++ b/docs/homeassistant/homeassistant-mqtt.md
@@ -14,6 +14,7 @@ To enable this method, you must set the flag **MQTT Discovery** in the Home Assi
 Configuration steps:
 
 - In your **Z-Wave JS UI** settings, [Home Assistant](/usage/setup?id=home-assistant) section, enable the `MQTT discovery` flag and enable the **retain** flag in the [MQTT](/usage/setup?id=mqtt) section. That flag is suggested to ensure that, once discovered, each device has the last published value available on startup (otherwise you have to wait for a value change).
+- Optionally enable `Use node location as suggested area` if you want the Z-Wave node `Location` to be published as Home Assistant `device.suggested_area`.
 
 > [!NOTE]
 > Beginning with version `4.0.0`, the default birth/will topic is `homeassistant/status` in order to reflect the default birth/will of Home Assistant, which changed in version `0.113`.
@@ -52,6 +53,9 @@ The devices will loose all of customizations after a restart **unless** you stor
 ### Rediscover Node
 
 If you update the node name/location, you must also rediscover the values of this node to ensure they have the correct topics. To do this, press `REDISCOVER NODE` at the top of the **Home Assistant - Devices** table (check previous picture)
+
+> [!NOTE]
+> Home Assistant treats `suggested_area` as a discovery-time hint. Republishing discovery after changing a node location can update the MQTT payload, but Home Assistant may ignore the new `suggested_area` for devices that already exist or already have an assigned area.
 
 ### Edit existing component
 

--- a/docs/usage/setup.md
+++ b/docs/usage/setup.md
@@ -279,6 +279,7 @@ Enable this to use Z-Wave JS UI as only a Control Panel
 - **MQTT discovery**: Enable this to use MQTT discovery. This is an alternative to the official integration. (more about this [here](/guide/homeassistant))
 - **Discovery Prefix**: The prefix to use to send MQTT discovery messages to Home Assistant
 - **Retain Discovery**: Set retain flag to true in discovery messages
+- **Use node location as suggested area**: Adds the node `Location` to the Home Assistant MQTT discovery `device.suggested_area` field
 - **Manual Discovery**: Don't automatically send the discovery payloads when a device is discovered
 - **Entity name template**: Custom Entity name based on placeholders. Default is `%ln_%o`
   - `%ln`: Node location with name `<location-?><name>`

--- a/src/stores/base.js
+++ b/src/stores/base.js
@@ -124,6 +124,7 @@ const useBaseStore = defineStore('base', {
 			nodeNames: true,
 			hassDiscovery: false,
 			discoveryPrefix: 'homeassistant',
+			useLocationAsSuggestedArea: false,
 			logEnabled: false,
 			logLevel: 'debug',
 			logToFile: false,

--- a/src/views/Settings.vue
+++ b/src/views/Settings.vue
@@ -2111,6 +2111,19 @@
 										v-if="newGateway.hassDiscovery"
 									>
 										<v-switch
+											label="Use node location as suggested area"
+											hint="Adds Home Assistant MQTT discovery device.suggested_area using the node Location field."
+											v-model="
+												newGateway.useLocationAsSuggestedArea
+											"
+											persistent-hint
+										></v-switch>
+									</v-col>
+									<v-col
+										cols="6"
+										v-if="newGateway.hassDiscovery"
+									>
+										<v-switch
 											label="Manual discovery"
 											hint="Don't automatically send the discovery payloads when a device is discovered"
 											v-model="newGateway.manualDiscovery"

--- a/test/lib/Gateway.test.ts
+++ b/test/lib/Gateway.test.ts
@@ -74,4 +74,66 @@ describe('#Gateway', () => {
 			})
 		})
 	})
+
+	describe('#_deviceInfo()', () => {
+		beforeEach(() => {
+			gw['_zwave'] = { homeHex: 'abcdef01' } as any
+		})
+
+		const baseNode = {
+			id: 7,
+			manufacturer: 'Zooz',
+			productDescription: 'Dimmer Switch',
+			productLabel: 'ZEN77',
+			firmwareVersion: '1.2.3',
+		} as ZUINode
+
+		it('omits suggested_area by default', () => {
+			const deviceInfo = gw['_deviceInfo'](
+				{ ...baseNode, loc: 'Kitchen' },
+				'Kitchen Dimmer',
+			)
+
+			expect(deviceInfo).to.not.have.property('suggested_area')
+		})
+
+		it('sets suggested_area when enabled and location exists', () => {
+			const gwWithSuggestedArea = new Gateway(
+				{ type: 0, useLocationAsSuggestedArea: true },
+				null as any,
+				null as any,
+			)
+			gwWithSuggestedArea['_zwave'] = { homeHex: 'abcdef01' } as any
+
+			const deviceInfo = gwWithSuggestedArea['_deviceInfo'](
+				{ ...baseNode, loc: 'Kitchen' },
+				'Kitchen Dimmer',
+			)
+
+			expect(deviceInfo.suggested_area).to.equal('Kitchen')
+			closeWatchers()
+		})
+
+		it('trims suggested_area and omits blank locations', () => {
+			const gwWithSuggestedArea = new Gateway(
+				{ type: 0, useLocationAsSuggestedArea: true },
+				null as any,
+				null as any,
+			)
+			gwWithSuggestedArea['_zwave'] = { homeHex: 'abcdef01' } as any
+
+			const trimmed = gwWithSuggestedArea['_deviceInfo'](
+				{ ...baseNode, loc: '  Kitchen  ' },
+				'Kitchen Dimmer',
+			)
+			const blank = gwWithSuggestedArea['_deviceInfo'](
+				{ ...baseNode, loc: '   ' },
+				'Kitchen Dimmer',
+			)
+
+			expect(trimmed.suggested_area).to.equal('Kitchen')
+			expect(blank).to.not.have.property('suggested_area')
+			closeWatchers()
+		})
+	})
 })


### PR DESCRIPTION
This fixes https://github.com/zwave-js/zwave-js-ui/issues/4047

## Summary

This PR adds an optional Home Assistant MQTT discovery enhancement that publishes a node's Z-Wave `Location` as `device.suggested_area`.

The feature is exposed as a new setting under the existing Home Assistant / MQTT Discovery section and is disabled by default, so current behavior does not change unless explicitly enabled.

## What Changed

- Added a new gateway setting: `useLocationAsSuggestedArea`
- Added a Settings UI toggle:
  - `Use node location as suggested area`
- Updated MQTT discovery payload generation so that, when enabled:
  - `node.loc` is trimmed
  - non-empty values are published as `device.suggested_area`
  - empty or missing locations are ignored