### PR TITLE
feat(ui): vuetify config + design tokens for dashboard rework

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,10 @@
       "license": "MIT",
       "dependencies": {
         "@esm2cjs/escape-string-regexp": "^5.0.0",
+        "@fontsource/roboto": "^5.2.10",
+        "@fontsource/roboto-mono": "^5.2.9",
         "@kvaster/zwavejs-prom": "^0.0.3",
+        "@vuetify/v0": "~1.0.0-alpha.5",
         "@zwave-js/log-transport-json": "^3.0.0",
         "@zwave-js/server": "^3.8.0",
         "archiver": "^7.0.1",
@@ -2477,6 +2480,24 @@
         "node": ">=14"
       }
     },
+    "node_modules/@fontsource/roboto": {
+      "version": "5.2.10",
+      "resolved": "https://registry.npmjs.org/@fontsource/roboto/-/roboto-5.2.10.tgz",
+      "integrity": "sha512-8HlA5FtSfz//oFSr2eL7GFXAiE7eIkcGOtx7tjsLKq+as702x9+GU7K95iDeWFapHC4M2hv9RrpXKRTGGBI8Zg==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
+      }
+    },
+    "node_modules/@fontsource/roboto-mono": {
+      "version": "5.2.9",
+      "resolved": "https://registry.npmjs.org/@fontsource/roboto-mono/-/roboto-mono-5.2.9.tgz",
+      "integrity": "sha512-iIeSyrRGoM15uIWqXslW1K9UFnUYfnCFNrNoWjXE0huO1L+hM0Jst0KNLuRc7P21xPpGL0bZouzYSX0Em9eyWg==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
+      }
+    },
     "node_modules/@homebridge/ciao": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/@homebridge/ciao/-/ciao-1.3.5.tgz",
@@ -3159,6 +3180,19 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@js-temporal/polyfill": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@js-temporal/polyfill/-/polyfill-0.5.1.tgz",
+      "integrity": "sha512-hloP58zRVCRSpgDxmqCWJNlizAlUgJFqG2ypq79DCvyv9tHjRYMDOcPFjzfl/A1/YxDvRCZz8wvZvmapQnKwFQ==",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "jsbi": "^4.3.0"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/@kvaster/zwavejs-prom": {
@@ -5320,6 +5354,48 @@
       "peerDependencies": {
         "vue": "^3.0.0",
         "vuetify": "^3.0.0"
+      }
+    },
+    "node_modules/@vuetify/v0": {
+      "version": "1.0.0-alpha.5",
+      "resolved": "https://registry.npmjs.org/@vuetify/v0/-/v0-1.0.0-alpha.5.tgz",
+      "integrity": "sha512-WVCHpsUWWswBmGLTlG5ec1aDgpfW/kCeBeFnaXG60Azeq1Sm8ADdSZU9JmjNvSenrYCDlHIRHvm5iUnKQJzvfQ==",
+      "license": "MIT",
+      "optionalDependencies": {
+        "@js-temporal/polyfill": "0.5.1"
+      },
+      "peerDependencies": {
+        "@adobe/leonardo-contrast-colors": ">=1.0.0",
+        "@ant-design/colors": ">=7.0.0",
+        "@flagsmith/flagsmith": "^11.0.0",
+        "@material/material-color-utilities": ">=0.3.0",
+        "launchdarkly-js-client-sdk": "^3.0.0",
+        "posthog-js": "^1.0.0",
+        "vue": ">=3.5.0",
+        "vue-i18n": ">=10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@adobe/leonardo-contrast-colors": {
+          "optional": true
+        },
+        "@ant-design/colors": {
+          "optional": true
+        },
+        "@flagsmith/flagsmith": {
+          "optional": true
+        },
+        "@material/material-color-utilities": {
+          "optional": true
+        },
+        "launchdarkly-js-client-sdk": {
+          "optional": true
+        },
+        "posthog-js": {
+          "optional": true
+        },
+        "vue-i18n": {
+          "optional": true
+        }
       }
     },
     "node_modules/@yao-pkg/pkg": {
@@ -13295,6 +13371,13 @@
       "bin": {
         "js-yaml": "bin/js-yaml.js"
       }
+    },
+    "node_modules/jsbi": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/jsbi/-/jsbi-4.3.2.tgz",
+      "integrity": "sha512-9fqMSQbhJykSeii05nxKl4m6Eqn2P6rOlYiS+C5Dr/HPIU/7yZxu5qzbs40tgaFORiw2Amd0mirjxatXYMkIew==",
+      "license": "Apache-2.0",
+      "optional": true
     },
     "node_modules/jsesc": {
       "version": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -77,7 +77,10 @@
   ],
   "dependencies": {
     "@esm2cjs/escape-string-regexp": "^5.0.0",
+    "@fontsource/roboto": "^5.2.10",
+    "@fontsource/roboto-mono": "^5.2.9",
     "@kvaster/zwavejs-prom": "^0.0.3",
+    "@vuetify/v0": "~1.0.0-alpha.5",
     "@zwave-js/log-transport-json": "^3.0.0",
     "@zwave-js/server": "^3.8.0",
     "archiver": "^7.0.1",

--- a/src/assets/css/tokens.css
+++ b/src/assets/css/tokens.css
@@ -48,13 +48,12 @@
 	--zw-font: 'Roboto', system-ui, sans-serif;
 	--zw-mono: 'Roboto Mono', ui-monospace, monospace;
 
-	/* Type-scale tokens (handoff: design-system.jsx:45-55).
-	   Composed as the `font` CSS shorthand — `<weight> <size> <family>`
-	   — so a consumer applies a whole role in one declaration. Notes:
+	/* Type-scale tokens. Composed as the `font` CSS shorthand —
+	   `<weight> <size> <family>` — so a consumer applies a whole role
+	   in one declaration. Notes:
 	   - line-height, letter-spacing, and text-transform are NOT
-	     included; the handoff doesn't specify line-heights and several
-	     roles override letter-spacing / text-transform per atom.
-	     Set those alongside the `font:` call where needed.
+	     included; several roles override those per atom. Set them
+	     alongside the `font:` call where needed.
 	   - `font:` resets line-height to `normal` per spec, so add an
 	     explicit `line-height:` after the var() if a consumer needs one. */
 	--zw-text-h-l: 600 22px var(--zw-font); /* card primary value */
@@ -122,10 +121,10 @@
 	--tone-fg: var(--zw-danger);
 }
 
-/* `info` mirrors `accent` per the handoff (PillA tone=info renders
-   with the accent tint at the atom level). Kept as a distinct class
-   so call sites can express intent and a future redesign can split
-   the two without touching consumers. */
+/* `info` mirrors `accent` — info-toned surfaces render with the
+   accent tint. Kept as a distinct class so call sites can express
+   intent and a future redesign can split the two without touching
+   consumers. */
 .zw-tone-info {
 	--tone-bg: var(--zw-accent-soft);
 	--tone-fg: var(--zw-accent-dark);

--- a/src/assets/css/tokens.css
+++ b/src/assets/css/tokens.css
@@ -1,40 +1,73 @@
 /* Z-Wave JS UI design tokens
-   Material palette + typography + radii + elevation + keyframes.
-   Authoritative reference: .design-handoff/project/design-system.jsx
-   and Dashboard merged.html. All tokens live on :root — no scope
-   classes. CSS ported from the handoff renames --a-* / --b-* to --zw-*. */
+   The --zw-* names stay stable as the dashboard's vocabulary; the
+   values read from Vuetify0's emitted theme variables so light/dark
+   theme switching cascades automatically. Authoritative palette lives
+   in src/plugins/palette.ts.
+
+   Vuetify0's stylesheet adapter (configured with `rgb: true`) emits
+   each registered theme color as decomposed RGB channels
+   (`--v0-primary: 25, 118, 210`) under a `[data-theme="<id>"]` scope,
+   so we wrap them in rgb()/rgba() here. Alpha-based neutrals
+   (--zw-fg, --zw-line, etc.) compose rgba() with --v0-on-surface,
+   which flips between black (light) and white (dark) on theme change.
+
+   Keyframes are theme-agnostic so they stay raw CSS. */
 
 :root {
 	/* ── Color · primary ─────────────────────────────────────── */
-	--zw-accent: #1976d2;
-	--zw-accent-dark: #1565c0;
-	--zw-accent-soft: #e3f2fd;
+	--zw-accent: rgb(var(--v0-primary));
+	--zw-accent-dark: rgb(var(--v0-primary-darken-1));
+	--zw-accent-soft: rgb(var(--v0-primary-soft));
 
 	/* ── Color · status ──────────────────────────────────────── */
-	--zw-ok: #43a047;
-	--zw-warning: #fb8c00;
-	--zw-warn-soft: #fff3e0;
-	--zw-danger: #e53935;
-	--zw-danger-soft: #ffebee;
-	--zw-asleep: #9a8db7;
+	--zw-ok: rgb(var(--v0-success));
+	--zw-warning: rgb(var(--v0-warning));
+	--zw-warn-soft: rgb(var(--v0-warn-soft));
+	--zw-danger: rgb(var(--v0-error));
+	--zw-danger-soft: rgb(var(--v0-danger-soft));
+	--zw-asleep: rgb(var(--v0-asleep));
 
 	/* ── Color · neutral ─────────────────────────────────────── */
-	--zw-bg: #f5f5f5;
-	--zw-bg-soft: #fafafa;
-	--zw-card: #ffffff;
-	--zw-fg: rgba(0, 0, 0, 0.87);
-	--zw-muted: rgba(0, 0, 0, 0.54);
-	--zw-fg-soft: rgba(0, 0, 0, 0.6);
-	--zw-line: rgba(0, 0, 0, 0.12);
-	--zw-line-soft: rgba(0, 0, 0, 0.08);
-	--zw-line2: rgba(0, 0, 0, 0.18);
-	--zw-chip-bg: rgba(0, 0, 0, 0.06);
-	--zw-chip-fg: rgba(0, 0, 0, 0.65);
-	--zw-row-hover: rgba(25, 118, 210, 0.04);
+	--zw-bg: rgb(var(--v0-background));
+	--zw-bg-soft: rgb(var(--v0-background-soft));
+	--zw-card: rgb(var(--v0-surface));
+
+	/* Alpha-based — on-surface is black in light theme, white in dark.
+	   These automatically flip when the user switches themes. */
+	--zw-fg: rgba(var(--v0-on-surface), 0.87);
+	--zw-muted: rgba(var(--v0-on-surface), 0.54);
+	--zw-fg-soft: rgba(var(--v0-on-surface), 0.6);
+	--zw-line: rgba(var(--v0-on-surface), 0.12);
+	--zw-line-soft: rgba(var(--v0-on-surface), 0.08);
+	--zw-line2: rgba(var(--v0-on-surface), 0.18);
+	--zw-chip-bg: rgba(var(--v0-on-surface), 0.06);
+	--zw-chip-fg: rgba(var(--v0-on-surface), 0.65);
+	--zw-row-hover: rgba(var(--v0-primary), 0.04);
 
 	/* ── Typography ──────────────────────────────────────────── */
 	--zw-font: 'Roboto', system-ui, sans-serif;
 	--zw-mono: 'Roboto Mono', ui-monospace, monospace;
+
+	/* Type-scale tokens (handoff: design-system.jsx:45-55).
+	   Composed as the `font` CSS shorthand — `<weight> <size> <family>`
+	   — so a consumer applies a whole role in one declaration. Notes:
+	   - line-height, letter-spacing, and text-transform are NOT
+	     included; the handoff doesn't specify line-heights and several
+	     roles override letter-spacing / text-transform per atom.
+	     Set those alongside the `font:` call where needed.
+	   - `font:` resets line-height to `normal` per spec, so add an
+	     explicit `line-height:` after the var() if a consumer needs one. */
+	--zw-text-h-l: 600 22px var(--zw-font); /* card primary value */
+	--zw-text-h-m: 600 16px var(--zw-font); /* drawer titles, page sections */
+	--zw-text-h-s: 600 15px var(--zw-font); /* card-grid section headers */
+	--zw-text-body: 500 14px var(--zw-font); /* device names, nav rows */
+	--zw-text-body-s: 400 13px var(--zw-font); /* search input, dense rows */
+	--zw-text-label: 600 12px var(--zw-font); /* buttons (upper), tab labels */
+	--zw-text-caption: 400 11px var(--zw-font); /* subtitles, hints, pills */
+	--zw-text-overline: 700 10px var(--zw-font); /* section overlines, table headers (UPPER) */
+	--zw-text-mono-mid: 500 12px var(--zw-mono); /* home IDs, counters */
+	--zw-text-mono-small: 500 11px var(--zw-mono); /* node IDs, footers */
+	--zw-text-mono-micro: 600 10px var(--zw-mono); /* pill text, column headers (UPPER) */
 
 	/* ── Radii ───────────────────────────────────────────────── */
 	--zw-radius-xs: 3px;
@@ -46,12 +79,70 @@
 	--zw-radius-pill: 999px;
 
 	/* ── Elevation ───────────────────────────────────────────── */
+	/* Shadow colour reads from --v0-on-surface so light-mode keeps the
+	   Material black drop-shadow and dark mode tints with the white
+	   on-surface channel — same role (visual lift) in either theme. */
 	--zw-e0: none;
-	--zw-e1: 0 1px 2px rgba(0, 0, 0, 0.04);
-	--zw-e2: 0 1px 3px rgba(0, 0, 0, 0.12), 0 1px 2px rgba(0, 0, 0, 0.08);
-	--zw-e4: 0 3px 6px rgba(0, 0, 0, 0.16), 0 3px 6px rgba(0, 0, 0, 0.1);
-	--zw-e8: 0 6px 20px rgba(0, 0, 0, 0.16), 0 2px 4px rgba(0, 0, 0, 0.08);
-	--zw-e-drawer: -12px 0 32px rgba(0, 0, 0, 0.12);
+	--zw-e1: 0 1px 2px rgba(var(--v0-on-surface), 0.04);
+	--zw-e2: 0 1px 3px rgba(var(--v0-on-surface), 0.12),
+		0 1px 2px rgba(var(--v0-on-surface), 0.08);
+	--zw-e4: 0 3px 6px rgba(var(--v0-on-surface), 0.16),
+		0 3px 6px rgba(var(--v0-on-surface), 0.1);
+	--zw-e8: 0 6px 20px rgba(var(--v0-on-surface), 0.16),
+		0 2px 4px rgba(var(--v0-on-surface), 0.08);
+	--zw-e-drawer: -12px 0 32px rgba(var(--v0-on-surface), 0.12);
+}
+
+/* ── Tone palette ────────────────────────────────────────────── */
+/* Each tone sets a (--tone-bg, --tone-fg) pair that ZwPill / ZwChip
+   read in their base rules. Keeps the seven-row tone table in one
+   place instead of repeating it per atom. */
+.zw-tone-neutral {
+	--tone-bg: var(--zw-chip-bg);
+	--tone-fg: var(--zw-chip-fg);
+}
+
+.zw-tone-accent {
+	--tone-bg: var(--zw-accent-soft);
+	--tone-fg: var(--zw-accent-dark);
+}
+
+.zw-tone-ok {
+	--tone-bg: rgba(var(--v0-success), 0.12);
+	--tone-fg: var(--zw-ok);
+}
+
+.zw-tone-warn {
+	--tone-bg: var(--zw-warn-soft);
+	--tone-fg: var(--zw-warning);
+}
+
+.zw-tone-danger {
+	--tone-bg: var(--zw-danger-soft);
+	--tone-fg: var(--zw-danger);
+}
+
+/* `info` mirrors `accent` per the handoff (PillA tone=info renders
+   with the accent tint at the atom level). Kept as a distinct class
+   so call sites can express intent and a future redesign can split
+   the two without touching consumers. */
+.zw-tone-info {
+	--tone-bg: var(--zw-accent-soft);
+	--tone-fg: var(--zw-accent-dark);
+}
+
+.zw-tone-asleep {
+	--tone-bg: rgba(var(--v0-asleep), 0.18);
+	--tone-fg: var(--zw-asleep);
+}
+
+/* ── Focus ring ─────────────────────────────────────────────── */
+/* Shared focus-visible treatment for interactive atoms. Override
+   --zw-focus-offset on the consumer when a different offset is
+   needed (ZwToggle uses 2px to clear the 999-px track). */
+.zw-focus-ring:focus-visible {
+	outline: 2px solid var(--zw-accent);
+	outline-offset: var(--zw-focus-offset, 1px);
 }
 
 /* ── Keyframes (semantic names, ported from --a-* / --b-* ───── */

--- a/src/assets/css/tokens.css
+++ b/src/assets/css/tokens.css
@@ -1,0 +1,132 @@
+/* Z-Wave JS UI design tokens
+   Material palette + typography + radii + elevation + keyframes.
+   Authoritative reference: .design-handoff/project/design-system.jsx
+   and Dashboard merged.html. All tokens live on :root — no scope
+   classes. CSS ported from the handoff renames --a-* / --b-* to --zw-*. */
+
+:root {
+	/* ── Color · primary ─────────────────────────────────────── */
+	--zw-accent: #1976d2;
+	--zw-accent-dark: #1565c0;
+	--zw-accent-soft: #e3f2fd;
+
+	/* ── Color · status ──────────────────────────────────────── */
+	--zw-ok: #43a047;
+	--zw-warning: #fb8c00;
+	--zw-warn-soft: #fff3e0;
+	--zw-danger: #e53935;
+	--zw-danger-soft: #ffebee;
+	--zw-asleep: #9a8db7;
+
+	/* ── Color · neutral ─────────────────────────────────────── */
+	--zw-bg: #f5f5f5;
+	--zw-bg-soft: #fafafa;
+	--zw-card: #ffffff;
+	--zw-fg: rgba(0, 0, 0, 0.87);
+	--zw-muted: rgba(0, 0, 0, 0.54);
+	--zw-fg-soft: rgba(0, 0, 0, 0.6);
+	--zw-line: rgba(0, 0, 0, 0.12);
+	--zw-line-soft: rgba(0, 0, 0, 0.08);
+	--zw-line2: rgba(0, 0, 0, 0.18);
+	--zw-chip-bg: rgba(0, 0, 0, 0.06);
+	--zw-chip-fg: rgba(0, 0, 0, 0.65);
+	--zw-row-hover: rgba(25, 118, 210, 0.04);
+
+	/* ── Typography ──────────────────────────────────────────── */
+	--zw-font: 'Roboto', system-ui, sans-serif;
+	--zw-mono: 'Roboto Mono', ui-monospace, monospace;
+
+	/* ── Radii ───────────────────────────────────────────────── */
+	--zw-radius-xs: 3px;
+	--zw-radius-sm: 4px;
+	--zw-radius-md: 6px;
+	--zw-radius-lg: 8px;
+	--zw-radius-xl: 10px;
+	--zw-radius-xxl: 12px;
+	--zw-radius-pill: 999px;
+
+	/* ── Elevation ───────────────────────────────────────────── */
+	--zw-e0: none;
+	--zw-e1: 0 1px 2px rgba(0, 0, 0, 0.04);
+	--zw-e2: 0 1px 3px rgba(0, 0, 0, 0.12), 0 1px 2px rgba(0, 0, 0, 0.08);
+	--zw-e4: 0 3px 6px rgba(0, 0, 0, 0.16), 0 3px 6px rgba(0, 0, 0, 0.1);
+	--zw-e8: 0 6px 20px rgba(0, 0, 0, 0.16), 0 2px 4px rgba(0, 0, 0, 0.08);
+	--zw-e-drawer: -12px 0 32px rgba(0, 0, 0, 0.12);
+}
+
+/* ── Keyframes (semantic names, ported from --a-* / --b-* ───── */
+
+@keyframes zw-pulse {
+	0%, 100% {
+		opacity: 1;
+	}
+	50% {
+		opacity: 0.35;
+	}
+}
+
+@keyframes zw-fade-in {
+	from {
+		opacity: 0;
+	}
+	to {
+		opacity: 1;
+	}
+}
+
+@keyframes zw-slide-in-right {
+	from {
+		transform: translateX(20px);
+		opacity: 0;
+	}
+	to {
+		transform: none;
+		opacity: 1;
+	}
+}
+
+/* L→R shimmer over the filled portion of a progress bar.
+   The sweep takes ~1.3s of the 4s cycle; the rest of the cycle parks
+   it off-screen so the shimmer reads as an occasional pulse rather
+   than a continuous scroll. Ported from `b-row-shimmer`. */
+@keyframes zw-shimmer {
+	0% {
+		transform: translateX(0);
+	}
+	32% {
+		transform: translateX(350%);
+	}
+	100% {
+		transform: translateX(350%);
+	}
+}
+
+/* Card-view ring heartbeat that matches the row shimmer rhythm.
+   Ported from `b-ring-shimmer`. */
+@keyframes zw-ring-shimmer {
+	0% {
+		opacity: 1;
+	}
+	16% {
+		opacity: 0.45;
+	}
+	32% {
+		opacity: 1;
+	}
+	100% {
+		opacity: 1;
+	}
+}
+
+/* Body baseline — the canvas under the dashboard's chrome.
+   Vuetify scopes its font on `.v-application`; we set it on body too
+   so static pages and the legacy shell inherit the same baseline. */
+body {
+	font-family: var(--zw-font);
+	background: var(--zw-bg);
+}
+
+/* ── Utility class · monospace font ──────────────────────────── */
+.font-mono {
+	font-family: var(--zw-mono);
+}

--- a/src/main.js
+++ b/src/main.js
@@ -1,6 +1,7 @@
 import { createApp } from 'vue'
 import pinia from './plugins/pinia'
-import vuetify from './plugins/vuetify' // path to vuetify export
+import vuetify0 from './plugins/vuetify0'
+import vuetify from './plugins/vuetify' // legacy — removed once Phase 6 lands
 import router from './router'
 import App from './App.vue'
 import { registerSW } from 'virtual:pwa-register'
@@ -41,6 +42,7 @@ const updateSW = registerSW({
 const app = createApp(App)
 
 app.use(pinia)
+vuetify0(app)
 app.use(vuetify)
 app.use(router)
 

--- a/src/main.js
+++ b/src/main.js
@@ -4,7 +4,23 @@ import vuetify from './plugins/vuetify' // path to vuetify export
 import router from './router'
 import App from './App.vue'
 import { registerSW } from 'virtual:pwa-register'
-// Custom assets CSS JS
+
+// Self-host the dashboard typography. Each @fontsource weight CSS ships
+// @font-face rules with unicode-range per subset (latin / latin-ext /
+// cyrillic / greek / vietnamese / math / symbols), so the browser only
+// downloads the WOFF2s that match the rendered glyphs — same lazy-subset
+// behaviour the Google Fonts CDN was providing, but bundled.
+import '@fontsource/roboto/400.css'
+import '@fontsource/roboto/500.css'
+import '@fontsource/roboto/600.css'
+import '@fontsource/roboto/700.css'
+import '@fontsource/roboto-mono/400.css'
+import '@fontsource/roboto-mono/500.css'
+import '@fontsource/roboto-mono/600.css'
+
+// Custom assets CSS JS — tokens.css must load after vuetify's stylesheet
+// (imported transitively from ./plugins/vuetify) so our :root tokens win.
+import './assets/css/tokens.css'
 import './assets/css/main.css'
 
 const updateSW = registerSW({

--- a/src/plugins/palette.ts
+++ b/src/plugins/palette.ts
@@ -1,0 +1,83 @@
+// Single source of truth for the dashboard color palette.
+//
+// Imported by:
+// - src/plugins/vuetify0.ts → exposed as --v0-<name> CSS variables that
+//   src/assets/css/tokens.css reads to compose the --zw-* vocabulary
+// - src/plugins/vuetify.js → wired into Vuetify 3's theme system so legacy
+//   pages keep picking up the same palette while they're still on Vuetify 3
+//
+// The two destinations MUST stay in lockstep. Add new colors here, never
+// inline them in either plugin file.
+
+// The handoff's colour tables (design-system.jsx:17-37) have no
+// `secondary` or `info` entry — the only "secondary" mentioned is the
+// muted FG ramp (already covered by --zw-fg-soft) and the info-toned
+// pill is implemented as an accent alias at the atom layer. Both keys
+// were dropped from this palette; no call site in src/ references them.
+export type Palette = Record<string, string> & {
+	primary: string
+	'primary-darken-1': string
+	'primary-soft': string
+	success: string
+	warning: string
+	'warn-soft': string
+	error: string
+	'error-darken-1': string
+	'danger-soft': string
+	asleep: string
+	surface: string
+	background: string
+	'background-soft': string
+	'on-surface': string
+	'on-background': string
+	// `on-<accent>` keys exist so atoms can derive contrast text from V0
+	// channel vars (e.g. `rgb(var(--v0-on-primary))`) and stay correct in
+	// dark mode — flipping to a literal `#fff` would defeat that.
+	'on-primary': string
+	// Kept for backwards compatibility with the legacy app.
+	purple: string
+}
+
+export const lightColors: Palette = {
+	primary: '#1976D2',
+	'primary-darken-1': '#1565C0',
+	'primary-soft': '#E3F2FD',
+	success: '#43A047',
+	warning: '#FB8C00',
+	'warn-soft': '#FFF3E0',
+	error: '#E53935',
+	'error-darken-1': '#C62828',
+	'danger-soft': '#FFEBEE',
+	asleep: '#9A8DB7',
+	surface: '#FFFFFF',
+	background: '#F5F5F5',
+	'background-soft': '#FAFAFA',
+	'on-surface': '#000000',
+	'on-background': '#000000',
+	'on-primary': '#FFFFFF',
+	purple: '#BA68C8',
+}
+
+// Dark palette is a placeholder — full dark-mode design is a separate pass.
+// Keys MUST all exist or Vuetify 3 throws when a component asks for them, and
+// V0 silently drops them. Alpha-based --zw-* tokens flip automatically because
+// on-surface flips to white here.
+export const darkColors: Palette = {
+	primary: '#1976D2',
+	'primary-darken-1': '#1565C0',
+	'primary-soft': '#0D2A3E',
+	success: '#43A047',
+	warning: '#FB8C00',
+	'warn-soft': '#3A2F18',
+	error: '#E53935',
+	'error-darken-1': '#EF5350',
+	'danger-soft': '#3A1F1F',
+	asleep: '#9A8DB7',
+	surface: '#1E1E1E',
+	background: '#121212',
+	'background-soft': '#1A1A1A',
+	'on-surface': '#FFFFFF',
+	'on-background': '#FFFFFF',
+	'on-primary': '#FFFFFF',
+	purple: '#BA68C8',
+}

--- a/src/plugins/palette.ts
+++ b/src/plugins/palette.ts
@@ -10,10 +10,18 @@
 // inline them in either plugin file.
 
 // The handoff's colour tables (design-system.jsx:17-37) have no
-// `secondary` or `info` entry — the only "secondary" mentioned is the
-// muted FG ramp (already covered by --zw-fg-soft) and the info-toned
-// pill is implemented as an accent alias at the atom layer. Both keys
-// were dropped from this palette; no call site in src/ references them.
+// `secondary` entry — the only "secondary" mentioned is the muted FG
+// ramp, already covered by --zw-fg-soft. The key is omitted here.
+//
+// `info` is NOT in the handoff palette either — info-toned pills/badges
+// are implemented as an accent alias at the atom layer (see
+// .zw-tone-info in tokens.css). It is kept here purely for backwards
+// compatibility with the LEGACY dashboard, which still uses
+// `<v-alert type="info">` (FirmwareUpdates.vue, NodeDetails.vue,
+// TemplateWizard.vue, Zniffer.vue). Vuetify 3 maps an alert's `type`
+// onto the theme color of the same name, so dropping `info` would
+// break those alerts. REMOVE this key once dashboard-neo lands and
+// the legacy v-alert call sites are gone.
 export type Palette = Record<string, string> & {
 	primary: string
 	'primary-darken-1': string
@@ -34,6 +42,8 @@ export type Palette = Record<string, string> & {
 	// channel vars (e.g. `rgb(var(--v0-on-primary))`) and stay correct in
 	// dark mode — flipping to a literal `#fff` would defeat that.
 	'on-primary': string
+	// Legacy-only — see header comment. Remove with dashboard-neo.
+	info: string
 	// Kept for backwards compatibility with the legacy app.
 	purple: string
 }
@@ -55,6 +65,7 @@ export const lightColors: Palette = {
 	'on-surface': '#000000',
 	'on-background': '#000000',
 	'on-primary': '#FFFFFF',
+	info: '#1976D2',
 	purple: '#BA68C8',
 }
 
@@ -79,5 +90,6 @@ export const darkColors: Palette = {
 	'on-surface': '#FFFFFF',
 	'on-background': '#FFFFFF',
 	'on-primary': '#FFFFFF',
+	info: '#1976D2',
 	purple: '#BA68C8',
 }

--- a/src/plugins/palette.ts
+++ b/src/plugins/palette.ts
@@ -9,19 +9,17 @@
 // The two destinations MUST stay in lockstep. Add new colors here, never
 // inline them in either plugin file.
 
-// The handoff's colour tables (design-system.jsx:17-37) have no
-// `secondary` entry — the only "secondary" mentioned is the muted FG
-// ramp, already covered by --zw-fg-soft. The key is omitted here.
+// No `secondary` key: the only secondary tone in the system is the
+// muted FG ramp, already covered by --zw-fg-soft.
 //
-// `info` is NOT in the handoff palette either — info-toned pills/badges
-// are implemented as an accent alias at the atom layer (see
-// .zw-tone-info in tokens.css). It is kept here purely for backwards
-// compatibility with the LEGACY dashboard, which still uses
-// `<v-alert type="info">` (FirmwareUpdates.vue, NodeDetails.vue,
-// TemplateWizard.vue, Zniffer.vue). Vuetify 3 maps an alert's `type`
-// onto the theme color of the same name, so dropping `info` would
-// break those alerts. REMOVE this key once dashboard-neo lands and
-// the legacy v-alert call sites are gone.
+// `info` exists ONLY for backwards compatibility with the legacy
+// dashboard's `<v-alert type="info">` call sites (FirmwareUpdates.vue,
+// NodeDetails.vue, TemplateWizard.vue, Zniffer.vue). Vuetify 3 maps an
+// alert's `type` onto the theme color of the same name, so dropping
+// `info` would break those alerts. The new dashboard implements
+// info-toned surfaces as an accent alias at the atom layer (see
+// .zw-tone-info in tokens.css). REMOVE this key once dashboard-neo
+// lands and the legacy v-alert call sites are gone.
 export type Palette = Record<string, string> & {
 	primary: string
 	'primary-darken-1': string

--- a/src/plugins/vuetify.js
+++ b/src/plugins/vuetify.js
@@ -1,12 +1,59 @@
 // src/plugins/vuetify.js
+//
+// Vuetify configuration for the unified Material palette and dashboard
+// component defaults. Pairs with src/assets/css/tokens.css which exposes
+// the same vocabulary as CSS custom properties on :root.
+//
+// IMPORTANT: import order — `vuetify/styles` must come BEFORE tokens.css
+// so our token overrides win. tokens.css is imported in src/main.js.
 
 import { createVuetify } from 'vuetify'
 import 'vuetify/styles'
 import { aliases, md } from 'vuetify/iconsets/md'
-import 'material-design-icons-iconfont/dist/material-design-icons.css' // Ensure you are using css-loader
+import 'material-design-icons-iconfont/dist/material-design-icons.css'
 
-const inputVariant = 'underlined'
-const defaultColor = 'primary'
+const lightColors = {
+	primary: '#1976D2',
+	'primary-darken-1': '#1565C0',
+	'primary-soft': '#E3F2FD',
+	secondary: '#1976D2',
+	success: '#43A047',
+	warning: '#FB8C00',
+	'warn-soft': '#FFF3E0',
+	error: '#E53935',
+	'danger-soft': '#FFEBEE',
+	info: '#1976D2',
+	asleep: '#9A8DB7',
+	surface: '#FFFFFF',
+	background: '#F5F5F5',
+	'background-soft': '#FAFAFA',
+	'on-surface': 'rgba(0,0,0,0.87)',
+	'on-surface-variant': 'rgba(0,0,0,0.54)',
+	// Kept for backwards compatibility with the legacy app.
+	purple: '#BA68C8',
+}
+
+// Dark palette is placeholder — full dark-mode design is a separate pass.
+// The keys MUST exist or Vuetify throws when a component asks for them.
+const darkColors = {
+	primary: '#1976D2',
+	'primary-darken-1': '#1565C0',
+	'primary-soft': '#0D2A3E',
+	secondary: '#1976D2',
+	success: '#43A047',
+	warning: '#FB8C00',
+	'warn-soft': '#3A2F18',
+	error: '#E53935',
+	'danger-soft': '#3A1F1F',
+	info: '#1976D2',
+	asleep: '#9A8DB7',
+	surface: '#1E1E1E',
+	background: '#121212',
+	'background-soft': '#1A1A1A',
+	'on-surface': 'rgba(255,255,255,0.87)',
+	'on-surface-variant': 'rgba(255,255,255,0.6)',
+	purple: '#BA68C8',
+}
 
 export default createVuetify({
 	icons: {
@@ -19,47 +66,129 @@ export default createVuetify({
 	theme: {
 		defaultTheme: 'light',
 		themes: {
-			dark: {
-				colors: {
-					purple: '#BA68C8',
-				},
-			},
-			light: {
-				colors: {
-					purple: '#BA68C8',
-				},
-			},
+			light: { colors: lightColors },
+			dark: { colors: darkColors },
 		},
 	},
-	// Set default variants for backward compatibility
+	display: {
+		// Align with CardsBody grid math: 480 / 760 / 1100 / 1380 cutoffs
+		// yield 1/2/3/4/5 card columns without conditional CSS.
+		thresholds: {
+			xs: 480,
+			sm: 760,
+			md: 1100,
+			lg: 1380,
+			xl: 1920,
+		},
+	},
 	defaults: {
-		VSwitch: { color: defaultColor },
-		VCheckbox: { color: defaultColor },
-		VRadioGroup: { color: defaultColor },
+		VBtn: {
+			variant: 'flat',
+			density: 'comfortable',
+			rounded: 'md',
+		},
+		VBtnToggle: {
+			mandatory: true,
+			density: 'compact',
+			variant: 'flat',
+			divided: false,
+		},
+		VCard: {
+			elevation: 2,
+			rounded: 'sm',
+			hover: true,
+		},
+		VChip: {
+			variant: 'tonal',
+			size: 'small',
+			rounded: 'pill',
+		},
+		VSwitch: {
+			color: 'primary',
+			inset: true,
+			density: 'compact',
+			hideDetails: true,
+		},
+		VProgressLinear: {
+			color: 'primary',
+			bgColor: 'primary',
+			bgOpacity: 0.18,
+			height: 4,
+			rounded: true,
+		},
 		VTextField: {
-			variant: inputVariant,
-			color: defaultColor,
-		},
-		VAutocomplete: {
-			variant: inputVariant,
-		},
-		VTextarea: {
-			variant: inputVariant,
+			variant: 'outlined',
+			density: 'compact',
+			hideDetails: 'auto',
+			color: 'primary',
 		},
 		VSelect: {
-			variant: inputVariant,
+			variant: 'outlined',
+			density: 'compact',
+			hideDetails: 'auto',
+		},
+		VAutocomplete: {
+			variant: 'outlined',
+			density: 'compact',
+			hideDetails: 'auto',
 		},
 		VCombobox: {
-			variant: inputVariant,
+			variant: 'outlined',
+			density: 'compact',
+			hideDetails: 'auto',
 		},
 		VNumberInput: {
-			variant: inputVariant,
+			variant: 'outlined',
+			density: 'compact',
+			hideDetails: 'auto',
+		},
+		VTextarea: {
+			variant: 'outlined',
+			density: 'compact',
+			hideDetails: 'auto',
 		},
 		VFileInput: {
-			variant: inputVariant,
+			variant: 'outlined',
+			density: 'compact',
+			hideDetails: 'auto',
 		},
-		VBtn: {
-			variant: 'text',
+		VCheckbox: {
+			color: 'primary',
+		},
+		VRadioGroup: {
+			color: 'primary',
+		},
+		VTabs: {
+			sliderColor: 'primary',
+			density: 'compact',
+			alignTabs: 'start',
+		},
+		VNavigationDrawer: {
+			color: 'surface',
+			border: 0,
+		},
+		VAppBar: {
+			flat: true,
+			density: 'compact',
+			color: 'surface',
+		},
+		VList: {
+			density: 'compact',
+			nav: true,
+		},
+		VListItem: {
+			density: 'compact',
+		},
+		VMenu: {
+			transition: 'fade-transition',
+			offset: 6,
+			location: 'bottom end',
+		},
+		VTooltip: {
+			location: 'bottom',
+		},
+		VDialog: {
+			transition: 'fade-transition',
 		},
 	},
 })

--- a/src/plugins/vuetify.js
+++ b/src/plugins/vuetify.js
@@ -12,48 +12,12 @@ import 'vuetify/styles'
 import { aliases, md } from 'vuetify/iconsets/md'
 import 'material-design-icons-iconfont/dist/material-design-icons.css'
 
-const lightColors = {
-	primary: '#1976D2',
-	'primary-darken-1': '#1565C0',
-	'primary-soft': '#E3F2FD',
-	secondary: '#1976D2',
-	success: '#43A047',
-	warning: '#FB8C00',
-	'warn-soft': '#FFF3E0',
-	error: '#E53935',
-	'danger-soft': '#FFEBEE',
-	info: '#1976D2',
-	asleep: '#9A8DB7',
-	surface: '#FFFFFF',
-	background: '#F5F5F5',
-	'background-soft': '#FAFAFA',
-	'on-surface': 'rgba(0,0,0,0.87)',
-	'on-surface-variant': 'rgba(0,0,0,0.54)',
-	// Kept for backwards compatibility with the legacy app.
-	purple: '#BA68C8',
-}
-
-// Dark palette is placeholder — full dark-mode design is a separate pass.
-// The keys MUST exist or Vuetify throws when a component asks for them.
-const darkColors = {
-	primary: '#1976D2',
-	'primary-darken-1': '#1565C0',
-	'primary-soft': '#0D2A3E',
-	secondary: '#1976D2',
-	success: '#43A047',
-	warning: '#FB8C00',
-	'warn-soft': '#3A2F18',
-	error: '#E53935',
-	'danger-soft': '#3A1F1F',
-	info: '#1976D2',
-	asleep: '#9A8DB7',
-	surface: '#1E1E1E',
-	background: '#121212',
-	'background-soft': '#1A1A1A',
-	'on-surface': 'rgba(255,255,255,0.87)',
-	'on-surface-variant': 'rgba(255,255,255,0.6)',
-	purple: '#BA68C8',
-}
+// Palette is shared with the V0 theme plugin via src/plugins/palette.ts.
+// Both `light` and `dark` keys must exist or Vuetify throws when a
+// component asks for a missing color. `on-surface` is intentionally pure
+// black / white so the design's alpha-stepped neutrals
+// (`rgba(0,0,0,0.87)`, …) presume an unmixed channel.
+import { lightColors, darkColors } from './palette'
 
 export default createVuetify({
 	icons: {

--- a/src/plugins/vuetify0.ts
+++ b/src/plugins/vuetify0.ts
@@ -1,0 +1,36 @@
+// Vuetify0 (@vuetify/v0) theme plugin — emits the dashboard's color palette
+// as --v0-<name> CSS variables on a stylesheet that scopes to
+// [data-theme="<id>"]. The variables are RGB-decomposed channels (rgb: true),
+// so src/assets/css/tokens.css can compose them via rgb()/rgba() — matching
+// the channel form the dashboard's --zw-* tokens already use.
+//
+// V0 is the headless successor to Vuetify 3 ("Vuetify 5 will be built on
+// v0"). New dashboard components target V0 primitives directly; Vuetify 3
+// remains installed only to host legacy routes during the rework, and is
+// removed once every legacy page has migrated.
+
+import { createThemePlugin, V0StyleSheetThemeAdapter } from '@vuetify/v0'
+import type { App } from 'vue'
+
+import { lightColors, darkColors } from './palette.ts'
+
+const themePlugin = createThemePlugin({
+	default: 'light',
+	themes: {
+		light: { dark: false, colors: lightColors },
+		dark: { dark: true, colors: darkColors },
+	},
+	adapter: new V0StyleSheetThemeAdapter({
+		prefix: 'v0',
+	}),
+	rgb: true,
+	// `data-theme` goes on <html> so the [data-theme="<id>"] CSS selector
+	// the adapter scopes its --v0-* variables under is visible from :root
+	// downward. tokens.css's --zw-* tokens are declared on :root and read
+	// the --v0-* values directly, so they need them to resolve there.
+	target: 'html',
+})
+
+export default function vuetify0(app: App): void {
+	app.use(themePlugin)
+}


### PR DESCRIPTION
This PR is the first of many that will modernize the frontend design of Z-Wave JS UI:

<img width="1148" height="941" alt="grafik" src="https://github.com/user-attachments/assets/27852513-f81e-4c04-8f4c-43308ef65bc3" />

The current PR sets up the design tokens (--zw-*) and Vuetify defaults that the rest of the dashboard rework builds on, so the atoms and components arriving in later commits can just consume the vocabulary instead of redeclaring colours, radii, and component chrome at every call site. Also switches the legacy input family from underlined to outlined+compact so the old pages already look at home next to the new dashboard while we migrate.

This PR also starts the transition to vuetify0 as a headless UI framework, which makes maintaining a custom design language much easier.