### PR TITLE
feat(ui): add Lucide icon set

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@fontsource/roboto-mono": "^5.2.9",
         "@kvaster/zwavejs-prom": "^0.0.3",
         "@vuetify/v0": "~1.0.0-alpha.5",
+        "@lucide/vue": "^1.16.0",
         "@zwave-js/log-transport-json": "^3.0.0",
         "@zwave-js/server": "^3.8.0",
         "archiver": "^7.0.1",
@@ -528,7 +529,6 @@
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
       "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -538,7 +538,6 @@
       "version": "7.28.5",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
       "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -587,7 +586,6 @@
       "version": "7.28.5",
       "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.5.tgz",
       "integrity": "sha512-KKBU1VGYR7ORr3At5HAtUQ+TV3SzRCXmA/8OdDZiLDBIZxVyzXuztPjfLd3BV1PRAQGCMWWSHYhL0F8d5uHBDQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/types": "^7.28.5"
@@ -1778,7 +1776,6 @@
       "version": "7.28.5",
       "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.5.tgz",
       "integrity": "sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-string-parser": "^7.27.1",
@@ -3168,7 +3165,6 @@
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
@@ -3209,6 +3205,15 @@
       "resolved": "https://registry.npmjs.org/@leichtgewicht/ip-codec/-/ip-codec-2.0.5.tgz",
       "integrity": "sha512-Vo+PSpZG2/fmgmiNzYK9qWRh8h/CHrwD0mo1h1DzL4yzHNSfWYujGTYsWGreD000gcgmZ7K4Ys6Tx9TxtsKdDw==",
       "license": "MIT"
+    },
+    "node_modules/@lucide/vue": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/@lucide/vue/-/vue-1.16.0.tgz",
+      "integrity": "sha512-kiHx0fe49DMjQuvNaEOu9Jou6u9FwdqQ8xbZIKlD47sXrOI8g59kIeeQL42NBLI4AvO+UJsbaPX0hEK/4rHSBQ==",
+      "license": "ISC",
+      "peerDependencies": {
+        "vue": ">=3.0.1"
+      }
     },
     "node_modules/@mdi/js": {
       "version": "7.4.47",
@@ -5201,7 +5206,6 @@
       "version": "3.5.24",
       "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.24.tgz",
       "integrity": "sha512-eDl5H57AOpNakGNAkFDH+y7kTqrQpJkZFXhWZQGyx/5Wh7B1uQYvcWkvZi11BDhscPgj8N7XV3oRwiPnx1Vrig==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/parser": "^7.28.5",
@@ -5215,7 +5219,6 @@
       "version": "3.5.24",
       "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.24.tgz",
       "integrity": "sha512-1QHGAvs53gXkWdd3ZMGYuvQFXHW4ksKWPG8HP8/2BscrbZ0brw183q2oNWjMrSWImYLHxHrx1ItBQr50I/q2zw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@vue/compiler-core": "3.5.24",
@@ -5226,7 +5229,6 @@
       "version": "3.5.24",
       "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.24.tgz",
       "integrity": "sha512-8EG5YPRgmTB+YxYBM3VXy8zHD9SWHUJLIGPhDovo3Z8VOgvP+O7UP5vl0J4BBPWYD9vxtBabzW1EuEZ+Cqs14g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/parser": "^7.28.5",
@@ -5244,7 +5246,6 @@
       "version": "3.5.24",
       "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.24.tgz",
       "integrity": "sha512-trOvMWNBMQ/odMRHW7Ae1CdfYx+7MuiQu62Jtu36gMLXcaoqKvAyh+P73sYG9ll+6jLB6QPovqoKGGZROzkFFg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@vue/compiler-dom": "3.5.24",
@@ -5291,7 +5292,6 @@
       "version": "3.5.24",
       "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.24.tgz",
       "integrity": "sha512-BM8kBhtlkkbnyl4q+HiF5R5BL0ycDPfihowulm02q3WYp2vxgPcJuZO866qa/0u3idbMntKEtVNuAUp5bw4teg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@vue/shared": "3.5.24"
@@ -5301,7 +5301,6 @@
       "version": "3.5.24",
       "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.24.tgz",
       "integrity": "sha512-RYP/byyKDgNIqfX/gNb2PB55dJmM97jc9wyF3jK7QUInYKypK2exmZMNwnjueWwGceEkP6NChd3D2ZVEp9undQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@vue/reactivity": "3.5.24",
@@ -5312,7 +5311,6 @@
       "version": "3.5.24",
       "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.5.24.tgz",
       "integrity": "sha512-Z8ANhr/i0XIluonHVjbUkjvn+CyrxbXRIxR7wn7+X7xlcb7dJsfITZbkVOeJZdP8VZwfrWRsWdShH6pngMxRjw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@vue/reactivity": "3.5.24",
@@ -5325,7 +5323,6 @@
       "version": "3.5.24",
       "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.24.tgz",
       "integrity": "sha512-Yh2j2Y4G/0/4z/xJ1Bad4mxaAk++C2v4kaa8oSYTMJBJ00/ndPuxCnWeot0/7/qafQFLh5pr6xeV6SdMcE/G1w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@vue/compiler-ssr": "3.5.24",
@@ -5339,7 +5336,6 @@
       "version": "3.5.24",
       "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.24.tgz",
       "integrity": "sha512-9cwHL2EsJBdi8NY22pngYYWzkTDhld6fAD6jlaeloNGciNSJL6bLpbxVgXl96X00Jtc6YWQv96YA/0sxex/k1A==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@vuetify/loader-shared": {
@@ -8624,7 +8620,6 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/data-uri-to-buffer": {
@@ -9593,7 +9588,6 @@
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
       "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
-      "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.12"
@@ -10544,7 +10538,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
       "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/esutils": {
@@ -14094,7 +14087,6 @@
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
       "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
@@ -15434,7 +15426,6 @@
       "version": "3.3.11",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
       "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -16909,7 +16900,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/picomatch": {
@@ -17095,7 +17085,6 @@
       "version": "8.5.6",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
       "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -19189,7 +19178,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
       "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
-      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -20349,7 +20337,7 @@
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -21008,7 +20996,6 @@
       "version": "3.5.24",
       "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.24.tgz",
       "integrity": "sha512-uTHDOpVQTMjcGgrqFPSb8iO2m1DUvo+WbGqoXQz8Y1CeBYQ0FXf2z1gLRaBtHjlRz7zZUBHxjVB5VTLzYkvftg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@vue/compiler-dom": "3.5.24",

--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "@fontsource/roboto-mono": "^5.2.9",
     "@kvaster/zwavejs-prom": "^0.0.3",
     "@vuetify/v0": "~1.0.0-alpha.5",
+    "@lucide/vue": "^1.16.0",
     "@zwave-js/log-transport-json": "^3.0.0",
     "@zwave-js/server": "^3.8.0",
     "archiver": "^7.0.1",

--- a/src/lib/icons.ts
+++ b/src/lib/icons.ts
@@ -1,0 +1,96 @@
+// src/lib/icons.ts
+//
+// Central re-export of the dashboard's icon vocabulary.
+// One alias per handoff name (`.design-handoff/project/icons.jsx`),
+// suffixed `Icon` so call sites read `<AddIcon :size="ICON_SIZE.button" />`.
+//
+// Call sites import directly:
+//   import { AddIcon, ICON_SIZE } from '@/lib/icons'
+//
+// Lucide ships per-icon ESM entry points; Vite tree-shakes unused aliases.
+//
+// A few Lucide glyphs back two semantic roles in the handoff:
+//   - Sun → DimmerIcon (dimmable lights) and SunIcon (weather/illuminance)
+//   - Thermometer → ThermostatIcon (climate device) and TempIcon (sensor)
+// Kept as distinct aliases so call sites express intent — a future swap
+// to a dedicated glyph touches one line here, not every consumer.
+
+export {
+	Plus as AddIcon,
+	ArrowDown as ArrowDownIcon,
+	ArrowUp as ArrowUpIcon,
+	TriangleAlert as AlertIcon,
+	Battery as BatteryIcon,
+	Bell as BellIcon,
+	Blinds as ShadeIcon,
+	Lightbulb as BulbIcon,
+	ChartLine as GraphIcon,
+	Check as CheckIcon,
+	ChevronDown as ChevronDownIcon,
+	ChevronRight as ChevronRightIcon,
+	ChevronUp as ChevronUpIcon,
+	CircleCheck as StatusIcon,
+	ClipboardList as InterviewIcon,
+	Clock as ClockIcon,
+	Cpu as ControllerIcon,
+	DoorClosed as ContactIcon,
+	Download as DownloadIcon,
+	Droplet as LeakIcon,
+	Filter as FilterIcon,
+	House as LocationsIcon,
+	LayoutGrid as GridIcon,
+	Layers as SceneIcon,
+	Link as LinkIcon,
+	List as ListIcon,
+	Lock as LockIcon,
+	Menu as MenuIcon,
+	Moon as MoonIcon,
+	MoreHorizontal as MoreIcon,
+	Network as NetworkIcon,
+	Pencil as EditIcon,
+	Play as PlayIcon,
+	Plug as PlugIcon,
+	Power as PowerIcon,
+	QrCode as QrIcon,
+	Radio as MotionIcon,
+	RefreshCw as RefreshIcon,
+	Search as SearchIcon,
+	Settings as SettingsIcon,
+	Signal as SignalIcon,
+	SignalHigh as SignalHighIcon,
+	SignalLow as SignalLowIcon,
+	SignalMedium as SignalMedIcon,
+	Siren as SirenIcon,
+	Sun as DimmerIcon,
+	Sun as SunIcon,
+	Tablet as RemoteIcon,
+	Thermometer as ThermostatIcon,
+	Thermometer as TempIcon,
+	ToggleRight as SwitchIcon,
+	Trash2 as TrashIcon,
+	Type as TypeIcon,
+	Upload as UploadIcon,
+	X as XIcon,
+	Zap as ZapIcon,
+	Activity as PulseIcon,
+} from '@lucide/vue'
+
+/**
+ * Closed vocabulary of icon sizes used across the dashboard.
+ * Call sites read `<AddIcon :size="ICON_SIZE.button" />` — numeric
+ * literals are forbidden in dashboard components.
+ *
+ * Sharing a numeric value across aliases is fine (button covers three
+ * surfaces); adding a new numeric value is a design decision.
+ */
+export const ICON_SIZE = {
+	pill: 10, // pill leading glyph
+	chip: 11, // chip glyph, table-row inline icon, segmented glyph, columns-menu filter
+	sortArrow: 12, // header chevrons, sort-direction arrows
+	button: 14, // primary button leading icon, table-row archetype glyph, search-input prepend
+	nav: 16, // sidebar nav row, top-bar search glyph
+	topbar: 18, // top-bar icon buttons, menu icon, status icons, drawer close button
+	drawerHeader: 22, // drawer header icon stamp
+} as const
+
+export type IconSize = (typeof ICON_SIZE)[keyof typeof ICON_SIZE]

--- a/src/lib/icons.ts
+++ b/src/lib/icons.ts
@@ -1,15 +1,15 @@
 // src/lib/icons.ts
 //
-// Central re-export of the dashboard's icon vocabulary.
-// One alias per handoff name (`.design-handoff/project/icons.jsx`),
-// suffixed `Icon` so call sites read `<AddIcon :size="ICON_SIZE.button" />`.
+// Central re-export of the dashboard's icon vocabulary. Each Lucide
+// glyph is aliased to a semantic name suffixed `Icon` so call sites
+// read `<AddIcon :size="ICON_SIZE.button" />`.
 //
 // Call sites import directly:
 //   import { AddIcon, ICON_SIZE } from '@/lib/icons'
 //
 // Lucide ships per-icon ESM entry points; Vite tree-shakes unused aliases.
 //
-// A few Lucide glyphs back two semantic roles in the handoff:
+// A few Lucide glyphs back two semantic roles:
 //   - Sun → DimmerIcon (dimmable lights) and SunIcon (weather/illuminance)
 //   - Thermometer → ThermostatIcon (climate device) and TempIcon (sensor)
 // Kept as distinct aliases so call sites express intent — a future swap

--- a/src/lib/icons.ts
+++ b/src/lib/icons.ts
@@ -52,6 +52,7 @@ export {
 	Plug as PlugIcon,
 	Power as PowerIcon,
 	QrCode as QrIcon,
+	// Lucide has no PIR/motion glyph; Radio's waves come close though.
 	Radio as MotionIcon,
 	RefreshCw as RefreshIcon,
 	Search as SearchIcon,
@@ -59,7 +60,7 @@ export {
 	Signal as SignalIcon,
 	SignalHigh as SignalHighIcon,
 	SignalLow as SignalLowIcon,
-	SignalMedium as SignalMedIcon,
+	SignalMedium as SignalMediumIcon,
 	Siren as SirenIcon,
 	Sun as DimmerIcon,
 	Sun as SunIcon,
@@ -78,7 +79,7 @@ export {
 /**
  * Closed vocabulary of icon sizes used across the dashboard.
  * Call sites read `<AddIcon :size="ICON_SIZE.button" />` — numeric
- * literals are forbidden in dashboard components.
+ * literals should be avoided in dashboard components.
  *
  * Sharing a numeric value across aliases is fine (button covers three
  * surfaces); adding a new numeric value is a design decision.


### PR DESCRIPTION
Introduces Lucide icon ESM imports for the new dashboard, with named aliases and a closed ICON_SIZE vocabulary so call sites can't pick arbitrary pixel sizes. Material Icons stays registered for the legacy settings/dialog pages, so this only affects new dashboard components.