### PR TITLE
feat(ui): implement atomic dashboard components

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -58,6 +58,15 @@ export default defineConfig([
 		},
 	},
 	{
+		// Support linting Vue SFCs written in TypeScript
+		files: ['**/*.vue'],
+		languageOptions: {
+			parserOptions: {
+				parser: '@typescript-eslint/parser',
+			},
+		},
+	},
+	{
 		files: ['**/*.ts', '**/*.tsx'],
 
 		languageOptions: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@esm2cjs/escape-string-regexp": "^5.0.0",
         "@fontsource/roboto": "^5.2.10",
         "@fontsource/roboto-mono": "^5.2.9",
+        "@floating-ui/dom": "^1.7.6",
         "@kvaster/zwavejs-prom": "^0.0.3",
         "@vuetify/v0": "~1.0.0-alpha.5",
         "@lucide/vue": "^1.16.0",
@@ -2494,6 +2495,31 @@
       "funding": {
         "url": "https://github.com/sponsors/ayuhito"
       }
+    },
+    "node_modules/@floating-ui/core": {
+      "version": "1.7.5",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.5.tgz",
+      "integrity": "sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/utils": "^0.2.11"
+      }
+    },
+    "node_modules/@floating-ui/dom": {
+      "version": "1.7.6",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.6.tgz",
+      "integrity": "sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/core": "^1.7.5",
+        "@floating-ui/utils": "^0.2.11"
+      }
+    },
+    "node_modules/@floating-ui/utils": {
+      "version": "0.2.11",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.11.tgz",
+      "integrity": "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==",
+      "license": "MIT"
     },
     "node_modules/@homebridge/ciao": {
       "version": "1.3.5",

--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     "@esm2cjs/escape-string-regexp": "^5.0.0",
     "@fontsource/roboto": "^5.2.10",
     "@fontsource/roboto-mono": "^5.2.9",
+    "@floating-ui/dom": "^1.7.6",
     "@kvaster/zwavejs-prom": "^0.0.3",
     "@vuetify/v0": "~1.0.0-alpha.5",
     "@lucide/vue": "^1.16.0",

--- a/src/components/dashboard/atoms/ZwActivityReadout.vue
+++ b/src/components/dashboard/atoms/ZwActivityReadout.vue
@@ -33,43 +33,43 @@ import {
 	ICON_SIZE,
 } from '@/lib/icons'
 
-type TransientType = 'ota' | 'rebuild' | 'interview'
-interface Transient {
-	type: TransientType
+type ActivityType = 'ota' | 'rebuild' | 'interview'
+interface Activity {
+	type: ActivityType
 	label: string
 	progress?: number
 }
 
 const props = withDefaults(
 	defineProps<{
-		transient: Transient
+		activity: Activity
 		variant?: 'table' | 'card'
 	}>(),
 	{ variant: 'table' },
 )
 
-const TRANSIENT_ICON = {
+const ACTIVITY_ICON = {
 	ota: DownloadIcon,
 	rebuild: RefreshIcon,
 	interview: InterviewIcon,
 } as const
 
-const iconComp = computed(() => TRANSIENT_ICON[props.transient.type])
+const iconComp = computed(() => ACTIVITY_ICON[props.activity.type])
 
 // Progress is optional — when undefined the readout renders an
 // indeterminate sweep across the bar with no numeric label. A literal
 // placeholder (e.g. 30%) would be misleading, especially for OTA where
 // users watch the number.
 const pct = computed(() =>
-	props.transient.progress !== undefined
-		? Math.round(props.transient.progress * 100)
+	props.activity.progress !== undefined
+		? Math.round(props.activity.progress * 100)
 		: undefined,
 )
 
 const title = computed(() =>
 	pct.value !== undefined
-		? `${props.transient.label} · ${pct.value}%`
-		: props.transient.label,
+		? `${props.activity.label} · ${pct.value}%`
+		: props.activity.label,
 )
 </script>
 

--- a/src/components/dashboard/atoms/ZwBatteryMini.vue
+++ b/src/components/dashboard/atoms/ZwBatteryMini.vue
@@ -1,0 +1,85 @@
+<template>
+	<span v-if="pct != null" class="zw-bat" :data-level="level">
+		<span class="zw-bat__cell">
+			<span class="zw-bat__fill" :style="{ '--zw-bat-pct': pct }" />
+			<span class="zw-bat__nub" />
+		</span>
+		<span class="zw-bat__label">{{ pct }}%</span>
+	</span>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+
+const props = defineProps<{ pct?: number | null }>()
+
+// Three-state classifier drives both fill colour and (at 'low') the
+// label tint via CSS attribute selectors below — no per-instance style
+// allocation per battery row.
+const level = computed<'low' | 'mid' | 'ok' | null>(() => {
+	const v = props.pct
+	if (v == null) return null
+	if (v < 15) return 'low'
+	if (v < 30) return 'mid'
+	return 'ok'
+})
+</script>
+
+<style scoped>
+/* Type role is Mono Micro (handoff TYPE_SCALE at
+   design-system.jsx:55 — "pill text, column headers"); the battery
+   readout is a dense column-style annotation. */
+.zw-bat {
+	display: inline-flex;
+	align-items: center;
+	gap: 4px;
+	font: var(--zw-text-mono-micro);
+	font-variant-numeric: tabular-nums;
+}
+
+.zw-bat__cell {
+	position: relative;
+	width: 18px;
+	height: 9px;
+	border: 1px solid var(--zw-fg-soft);
+	border-radius: 1.5px;
+	box-sizing: border-box;
+}
+
+/* Inner cell is 16px wide; leave 1px inset so the fill never touches
+   the border. Clamp to 2px minimum so 1% still shows. */
+.zw-bat__fill {
+	position: absolute;
+	top: 1px;
+	bottom: 1px;
+	left: 1px;
+	border-radius: 0.5px;
+	width: max(2px, calc(var(--zw-bat-pct, 0) * 0.14px));
+}
+
+.zw-bat[data-level='ok'] .zw-bat__fill {
+	background: var(--zw-ok);
+}
+
+.zw-bat[data-level='mid'] .zw-bat__fill {
+	background: var(--zw-warning);
+}
+
+.zw-bat[data-level='low'] .zw-bat__fill {
+	background: var(--zw-danger);
+}
+
+.zw-bat[data-level='low'] .zw-bat__label {
+	color: var(--zw-danger);
+}
+
+.zw-bat__nub {
+	position: absolute;
+	top: 2px;
+	right: -3px;
+	width: 2px;
+	height: 4px;
+	background: var(--zw-fg-soft);
+	border-radius: 0 1px 1px 0;
+}
+</style>

--- a/src/components/dashboard/atoms/ZwBatteryMini.vue
+++ b/src/components/dashboard/atoms/ZwBatteryMini.vue
@@ -26,9 +26,8 @@ const level = computed<'low' | 'mid' | 'ok' | null>(() => {
 </script>
 
 <style scoped>
-/* Type role is Mono Micro (handoff TYPE_SCALE at
-   design-system.jsx:55 — "pill text, column headers"); the battery
-   readout is a dense column-style annotation. */
+/* Type role is Mono Micro — the battery readout is a dense
+   column-style annotation. */
 .zw-bat {
 	display: inline-flex;
 	align-items: center;

--- a/src/components/dashboard/atoms/ZwButton.vue
+++ b/src/components/dashboard/atoms/ZwButton.vue
@@ -15,12 +15,7 @@
 <script setup lang="ts">
 import { Button } from '@vuetify/v0'
 
-type Variant =
-	| 'primary'
-	| 'outline'
-	| 'destructive'
-	| 'ghost'
-	| 'mono-outline'
+type Variant = 'primary' | 'outline' | 'destructive' | 'ghost' | 'mono-outline'
 
 withDefaults(
 	defineProps<{

--- a/src/components/dashboard/atoms/ZwButton.vue
+++ b/src/components/dashboard/atoms/ZwButton.vue
@@ -1,0 +1,133 @@
+<template>
+	<Button.Root
+		class="zw-btn zw-focus-ring"
+		:class="[`zw-btn--${variant}`, `zw-btn--${size}`]"
+		:disabled="disabled"
+		@click="emit('click', $event)"
+	>
+		<span v-if="$slots.icon" class="zw-btn__icon">
+			<slot name="icon" />
+		</span>
+		<slot />
+	</Button.Root>
+</template>
+
+<script setup lang="ts">
+import { Button } from '@vuetify/v0'
+
+type Variant =
+	| 'primary'
+	| 'outline'
+	| 'destructive'
+	| 'ghost'
+	| 'mono-outline'
+
+withDefaults(
+	defineProps<{
+		variant?: Variant
+		size?: 'sm' | 'md'
+		disabled?: boolean
+	}>(),
+	{ variant: 'primary', size: 'md', disabled: false },
+)
+
+const emit = defineEmits<{ click: [MouseEvent] }>()
+</script>
+
+<style>
+/* Styles are unscoped because Vuetify0 primitives set inheritAttrs:false,
+   so Vue does not forward the parent's scoped data-v-* hash onto the
+   rendered <button>. Class names are BEM-namespaced under .zw-btn.
+   Each variant only sets the four --btn-* custom properties below;
+   the base rule applies them so chrome (radius, transition, focus
+   ring) stays declared once. */
+.zw-btn {
+	appearance: none;
+	cursor: pointer;
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	gap: 6px;
+	background: var(--btn-bg);
+	color: var(--btn-color);
+	border: 1px solid var(--btn-border, transparent);
+	box-shadow: var(--btn-shadow, none);
+	font-family: var(--zw-font);
+	font-weight: 600;
+	letter-spacing: 0.4px;
+	text-transform: uppercase;
+	border-radius: 6px;
+	transition:
+		background 0.12s,
+		border-color 0.12s,
+		color 0.12s,
+		box-shadow 0.12s;
+	white-space: nowrap;
+}
+
+.zw-btn[data-disabled='true'] {
+	opacity: 0.5;
+	pointer-events: none;
+}
+
+.zw-btn:hover:not([data-disabled='true']) {
+	background: var(--btn-bg-hover, var(--btn-bg));
+}
+
+.zw-btn--md {
+	padding: 7px 14px;
+	font-size: 12px;
+}
+
+.zw-btn--sm {
+	padding: 5px 10px;
+	font-size: 11px;
+}
+
+.zw-btn__icon {
+	display: inline-flex;
+	align-items: center;
+}
+
+.zw-btn--primary {
+	--btn-bg: var(--zw-accent);
+	--btn-bg-hover: var(--zw-accent-dark);
+	--btn-color: rgb(var(--v0-on-primary));
+	--btn-shadow: 0 1px 2px rgba(var(--v0-primary), 0.3);
+}
+
+.zw-btn--outline {
+	--btn-bg: var(--zw-card);
+	--btn-bg-hover: var(--zw-bg-soft);
+	--btn-color: rgba(var(--v0-on-surface), 0.78);
+	--btn-border: var(--zw-line);
+}
+
+.zw-btn--destructive {
+	--btn-bg: var(--zw-danger-soft);
+	--btn-bg-hover: rgba(var(--v0-danger-soft), 0.7);
+	--btn-color: rgb(var(--v0-error-darken-1));
+	--btn-border: rgba(var(--v0-error), 0.3);
+}
+
+.zw-btn--ghost {
+	--btn-bg: transparent;
+	--btn-bg-hover: rgba(var(--v0-on-surface), 0.04);
+	--btn-color: var(--zw-fg-soft);
+	text-transform: none;
+	letter-spacing: 0;
+	font-weight: 500;
+}
+
+/* node-details Advanced tab grid — mono caps on an outlined chip. */
+.zw-btn--mono-outline {
+	--btn-bg: var(--zw-card);
+	--btn-bg-hover: var(--zw-bg-soft);
+	--btn-color: var(--zw-fg);
+	--btn-border: var(--zw-line);
+	font-family: var(--zw-mono);
+	font-size: 11px;
+	font-weight: 500;
+	letter-spacing: 0.4px;
+}
+</style>

--- a/src/components/dashboard/atoms/ZwChip.vue
+++ b/src/components/dashboard/atoms/ZwChip.vue
@@ -1,0 +1,36 @@
+<template>
+	<span class="zw-chip" :class="`zw-tone-${tone}`">
+		<slot />
+	</span>
+</template>
+
+<script setup lang="ts">
+type ChipTone = 'neutral' | 'accent' | 'ok' | 'warn' | 'danger' | 'asleep'
+
+withDefaults(defineProps<{ tone?: ChipTone }>(), { tone: 'neutral' })
+</script>
+
+<style scoped>
+/* Tone background / foreground come from the shared .zw-tone-<name>
+   utility in tokens.css; this atom only owns shape, density, and the
+   accent variant's 1-px outline (per handoff). Type role is Mono
+   Micro (handoff design-system.jsx:55 — "pill text, column headers"). */
+.zw-chip {
+	display: inline-flex;
+	align-items: center;
+	gap: 4px;
+	white-space: nowrap;
+	padding: 1px 6px;
+	border-radius: 4px;
+	background: var(--tone-bg);
+	color: var(--tone-fg);
+	font: var(--zw-text-mono-micro);
+	line-height: 16px;
+	letter-spacing: 0.1px;
+	text-transform: none;
+}
+
+.zw-chip.zw-tone-accent {
+	border: 1px solid rgba(var(--v0-primary), 0.3);
+}
+</style>

--- a/src/components/dashboard/atoms/ZwChip.vue
+++ b/src/components/dashboard/atoms/ZwChip.vue
@@ -13,8 +13,7 @@ withDefaults(defineProps<{ tone?: ChipTone }>(), { tone: 'neutral' })
 <style scoped>
 /* Tone background / foreground come from the shared .zw-tone-<name>
    utility in tokens.css; this atom only owns shape, density, and the
-   accent variant's 1-px outline (per handoff). Type role is Mono
-   Micro (handoff design-system.jsx:55 — "pill text, column headers"). */
+   accent variant's 1-px outline. Type role is Mono Micro. */
 .zw-chip {
 	display: inline-flex;
 	align-items: center;

--- a/src/components/dashboard/atoms/ZwPill.vue
+++ b/src/components/dashboard/atoms/ZwPill.vue
@@ -26,8 +26,7 @@ withDefaults(
 <style scoped>
 /* Tone background / foreground come from the shared .zw-tone-<name>
    utility in tokens.css; this atom only owns shape and density.
-   Type role is Caption (handoff design-system.jsx:51 lists "pills"
-   under Caption); the sm variant overrides the size to 10px. */
+   Type role is Caption; the sm variant overrides the size to 10px. */
 .zw-pill {
 	display: inline-flex;
 	align-items: center;

--- a/src/components/dashboard/atoms/ZwPill.vue
+++ b/src/components/dashboard/atoms/ZwPill.vue
@@ -1,0 +1,52 @@
+<template>
+	<span class="zw-pill" :class="[`zw-tone-${tone}`, `zw-pill--${size}`]">
+		<slot />
+	</span>
+</template>
+
+<script setup lang="ts">
+type PillTone =
+	| 'neutral'
+	| 'accent'
+	| 'ok'
+	| 'warn'
+	| 'danger'
+	| 'info'
+	| 'asleep'
+
+withDefaults(
+	defineProps<{
+		tone?: PillTone
+		size?: 'sm' | 'md'
+	}>(),
+	{ tone: 'neutral', size: 'md' },
+)
+</script>
+
+<style scoped>
+/* Tone background / foreground come from the shared .zw-tone-<name>
+   utility in tokens.css; this atom only owns shape and density.
+   Type role is Caption (handoff design-system.jsx:51 lists "pills"
+   under Caption); the sm variant overrides the size to 10px. */
+.zw-pill {
+	display: inline-flex;
+	align-items: center;
+	gap: 4px;
+	white-space: nowrap;
+	background: var(--tone-bg);
+	color: var(--tone-fg);
+	font: var(--zw-text-caption);
+	line-height: 1;
+	letter-spacing: 0.1px;
+	border-radius: var(--zw-radius-pill);
+}
+
+.zw-pill--sm {
+	padding: 2px 6px;
+	font-size: 10px;
+}
+
+.zw-pill--md {
+	padding: 3px 8px;
+}
+</style>

--- a/src/components/dashboard/atoms/ZwSearchInput.vue
+++ b/src/components/dashboard/atoms/ZwSearchInput.vue
@@ -1,0 +1,80 @@
+<template>
+	<div class="zw-search">
+		<SearchIcon class="zw-search__icon" :size="ICON_SIZE.button" />
+		<input
+			type="search"
+			class="zw-search__input"
+			:value="modelValue"
+			:placeholder="placeholder"
+			:aria-label="ariaLabel"
+			@input="onInput"
+		/>
+	</div>
+</template>
+
+<script setup lang="ts">
+import { ICON_SIZE, SearchIcon } from '@/lib/icons'
+
+// Atom is locale-agnostic: callers pass already-translated strings for
+// placeholder and aria-label. No fallbacks here would silently leak EN.
+defineProps<{
+	modelValue: string
+	placeholder: string
+	ariaLabel: string
+}>()
+
+const emit = defineEmits<{ 'update:modelValue': [string] }>()
+
+function onInput(e: Event) {
+	emit('update:modelValue', (e.target as HTMLInputElement).value)
+}
+</script>
+
+<style scoped>
+.zw-search {
+	position: relative;
+	display: inline-flex;
+	width: 100%;
+	max-width: 420px;
+}
+
+.zw-search__icon {
+	position: absolute;
+	left: 12px;
+	top: 50%;
+	transform: translateY(-50%);
+	color: var(--zw-fg-soft);
+	pointer-events: none;
+}
+
+.zw-search__input {
+	width: 100%;
+	appearance: none;
+	border: 1px solid var(--zw-line);
+	border-radius: 6px;
+	padding: 7px 12px 7px 34px;
+	font-family: inherit;
+	font-size: 13px;
+	background: var(--zw-bg-soft);
+	color: var(--zw-fg);
+	outline: none;
+	transition:
+		border-color 0.12s,
+		background 0.12s;
+}
+
+.zw-search__input::placeholder {
+	color: var(--zw-fg-soft);
+}
+
+.zw-search__input:focus,
+.zw-search__input:focus-visible {
+	border-color: var(--zw-accent);
+	background: var(--zw-card);
+}
+
+/* Hide the native cancel-search button which clashes with the design. */
+.zw-search__input::-webkit-search-cancel-button {
+	appearance: none;
+}
+</style>

--- a/src/components/dashboard/atoms/ZwSegmented.vue
+++ b/src/components/dashboard/atoms/ZwSegmented.vue
@@ -1,0 +1,98 @@
+<template>
+	<Button.Group
+		class="zw-segmented"
+		:class="{ 'zw-segmented--compact': compact }"
+		:model-value="modelValue"
+		:mandatory="true"
+		@update:model-value="onSelect"
+	>
+		<Button.Root
+			v-for="opt in options"
+			:key="opt.value"
+			:value="opt.value"
+			class="zw-segmented__btn zw-focus-ring"
+		>
+			<component
+				:is="opt.icon"
+				v-if="opt.icon"
+				:size="ICON_SIZE.chip"
+			/>
+			<span v-if="!compact">{{ opt.label }}</span>
+		</Button.Root>
+	</Button.Group>
+</template>
+
+<script setup lang="ts">
+import { Button } from '@vuetify/v0'
+import type { Component } from 'vue'
+import { ICON_SIZE } from '@/lib/icons'
+
+interface SegmentedOption {
+	value: string
+	label: string
+	icon?: Component
+}
+
+defineProps<{
+	modelValue: string
+	options: SegmentedOption[]
+	compact?: boolean
+}>()
+
+const emit = defineEmits<{ 'update:modelValue': [string] }>()
+
+// Button.Group with `mandatory: true` + scalar v-model emits the single
+// selected value back as a string. With `mandatory: true` it cannot
+// emit null (no deselect possible), so the optional path is defensive.
+function onSelect(value: unknown): void {
+	if (typeof value === 'string') emit('update:modelValue', value)
+}
+</script>
+
+<style>
+/* Styles unscoped — V0 primitives set inheritAttrs:false so Vue does not
+   forward the parent's scoped data-v-* hash. .zw-segmented* class names
+   are unique to this atom. */
+.zw-segmented {
+	display: inline-flex;
+	background: var(--zw-bg);
+	border-radius: 5px;
+	padding: 2px;
+	border: 1px solid var(--zw-line-soft);
+}
+
+/* Type role is Caption (handoff TYPE_SCALE at design-system.jsx:51);
+   the selected state pops weight to 600 — matching the design's
+   own segmented mock in design-system.jsx:118-140. */
+.zw-segmented__btn {
+	appearance: none;
+	background: transparent;
+	border: none;
+	cursor: pointer;
+	color: var(--zw-fg-soft);
+	padding: 3px 8px;
+	border-radius: 4px;
+	display: inline-flex;
+	align-items: center;
+	gap: 4px;
+	font: var(--zw-text-caption);
+	line-height: 1.4;
+	letter-spacing: 0.1px;
+	transition:
+		background 0.12s,
+		color 0.12s;
+}
+
+.zw-segmented--compact .zw-segmented__btn {
+	padding: 3px 7px;
+}
+
+/* `data-selected="true"` is emitted by V0 ButtonRoot when inside a
+   ButtonGroup and selected — replaces the previous .--active class. */
+.zw-segmented__btn[data-selected='true'] {
+	background: var(--zw-card);
+	color: var(--zw-accent);
+	box-shadow: 0 1px 2px rgba(var(--v0-on-surface), 0.1);
+	font-weight: 600;
+}
+</style>

--- a/src/components/dashboard/atoms/ZwSegmented.vue
+++ b/src/components/dashboard/atoms/ZwSegmented.vue
@@ -61,9 +61,8 @@ function onSelect(value: unknown): void {
 	border: 1px solid var(--zw-line-soft);
 }
 
-/* Type role is Caption (handoff TYPE_SCALE at design-system.jsx:51);
-   the selected state pops weight to 600 — matching the design's
-   own segmented mock in design-system.jsx:118-140. */
+/* Type role is Caption; the selected state pops weight to 600 to
+   match the design's segmented control. */
 .zw-segmented__btn {
 	appearance: none;
 	background: transparent;

--- a/src/components/dashboard/atoms/ZwSegmented.vue
+++ b/src/components/dashboard/atoms/ZwSegmented.vue
@@ -12,11 +12,7 @@
 			:value="opt.value"
 			class="zw-segmented__btn zw-focus-ring"
 		>
-			<component
-				:is="opt.icon"
-				v-if="opt.icon"
-				:size="ICON_SIZE.chip"
-			/>
+			<component :is="opt.icon" v-if="opt.icon" :size="ICON_SIZE.chip" />
 			<span v-if="!compact">{{ opt.label }}</span>
 		</Button.Root>
 	</Button.Group>

--- a/src/components/dashboard/atoms/ZwSlider.vue
+++ b/src/components/dashboard/atoms/ZwSlider.vue
@@ -1,0 +1,121 @@
+<template>
+	<Slider.Root
+		class="zw-slider"
+		:model-value="modelValue"
+		:disabled="disabled"
+		:min="0"
+		:max="100"
+		:step="1"
+		@update:model-value="onUpdate"
+	>
+		<Slider.Track class="zw-slider__track">
+			<Slider.Range class="zw-slider__fill" />
+		</Slider.Track>
+		<Slider.Thumb class="zw-slider__thumb" />
+	</Slider.Root>
+</template>
+
+<script setup lang="ts">
+import { Slider } from '@vuetify/v0'
+
+defineProps<{
+	modelValue: number
+	disabled?: boolean
+}>()
+
+const emit = defineEmits<{ 'update:modelValue': [number] }>()
+
+// Slider.Root accepts scalar v-model and emits scalar back, but typescript
+// doesn't infer the scalar case so we narrow here.
+function onUpdate(value: number | number[]): void {
+	emit('update:modelValue', Array.isArray(value) ? (value[0] ?? 0) : value)
+}
+</script>
+
+<style>
+/* Styles unscoped — V0 primitives set inheritAttrs:false so Vue does not
+   forward the parent's scoped data-v-* hash onto the rendered elements.
+   .zw-slider namespace is unique to this atom. */
+.zw-slider {
+	position: relative;
+	height: 14px;
+	display: flex;
+	align-items: center;
+	cursor: pointer;
+	touch-action: none;
+}
+
+.zw-slider[data-disabled='true'] {
+	opacity: 0.5;
+	pointer-events: none;
+}
+
+/* Track captures pointerdown for click-to-jump, so its hit area spans
+   the full 14-px slider row even though the visual line is 6 px — clicks
+   in the padding above/below the line still register. */
+.zw-slider__track {
+	display: block;
+	position: relative;
+	height: 100%;
+	width: 100%;
+	background: transparent;
+}
+
+.zw-slider__track::before {
+	content: '';
+	position: absolute;
+	top: 50%;
+	left: 0;
+	right: 0;
+	height: 6px;
+	transform: translateY(-50%);
+	background: var(--zw-line);
+	border-radius: var(--zw-radius-pill);
+}
+
+.zw-slider__fill {
+	display: block;
+	position: absolute;
+	top: 50%;
+	height: 6px;
+	transform: translateY(-50%);
+	background: var(--zw-accent);
+	border-radius: var(--zw-radius-pill);
+	transition: width 0.05s;
+}
+
+/* 14-px solid accent disc. Drop-shadow at rest carries the "grabbable"
+   affordance; halo grows on hover and dragging. V0 sets inline
+   `left: <pct>%` so we translate(-50%) to center the disc on the value. */
+.zw-slider__thumb {
+	position: absolute;
+	top: 50%;
+	width: 14px;
+	height: 14px;
+	border-radius: 50%;
+	background: var(--zw-accent);
+	transform: translate(-50%, -50%);
+	box-shadow: 0 1px 2px rgba(var(--v0-on-surface), 0.2);
+	transition: box-shadow 0.15s;
+	outline: none;
+}
+
+.zw-slider:hover .zw-slider__thumb {
+	box-shadow:
+		0 0 0 5px rgba(var(--v0-primary), 0.1),
+		0 1px 2px rgba(var(--v0-on-surface), 0.2);
+}
+
+.zw-slider__thumb[data-state='dragging'],
+.zw-slider:hover .zw-slider__thumb[data-state='dragging'] {
+	box-shadow:
+		0 0 0 8px rgba(var(--v0-primary), 0.18),
+		0 1px 2px rgba(var(--v0-on-surface), 0.2);
+}
+
+.zw-slider__thumb:focus-visible {
+	box-shadow:
+		0 0 0 5px rgba(var(--v0-primary), 0.18),
+		0 1px 2px rgba(var(--v0-on-surface), 0.2);
+}
+</style>

--- a/src/components/dashboard/atoms/ZwStatusDot.vue
+++ b/src/components/dashboard/atoms/ZwStatusDot.vue
@@ -24,7 +24,9 @@ const props = withDefaults(
 // uses the default so the table's hundred-dot list allocates nothing
 // per row.
 const sizeStyle = computed(() =>
-	props.size === 8 ? undefined : { '--zw-status-dot-size': `${props.size}px` },
+	props.size === 8
+		? undefined
+		: { '--zw-status-dot-size': `${props.size}px` },
 )
 </script>
 

--- a/src/components/dashboard/atoms/ZwStatusDot.vue
+++ b/src/components/dashboard/atoms/ZwStatusDot.vue
@@ -1,0 +1,61 @@
+<template>
+	<span
+		class="zw-status-dot"
+		:class="`zw-status-dot--${status}`"
+		:style="sizeStyle"
+	/>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+
+type Status = 'alive' | 'awake' | 'asleep' | 'dead' | 'controller'
+
+const props = withDefaults(
+	defineProps<{
+		status: Status
+		size?: number
+	}>(),
+	{ size: 8 },
+)
+
+// Bind size through a single custom property so the style block owns
+// both width and height; skip the binding entirely when the caller
+// uses the default so the table's hundred-dot list allocates nothing
+// per row.
+const sizeStyle = computed(() =>
+	props.size === 8 ? undefined : { '--zw-status-dot-size': `${props.size}px` },
+)
+</script>
+
+<style scoped>
+.zw-status-dot {
+	display: inline-block;
+	width: var(--zw-status-dot-size, 8px);
+	height: var(--zw-status-dot-size, 8px);
+	border-radius: 50%;
+	vertical-align: middle;
+}
+
+.zw-status-dot--alive {
+	background: var(--zw-ok);
+}
+
+.zw-status-dot--awake {
+	background: var(--zw-ok);
+	/* Static halo — alpha 0x33 = 20% — matches direction-b.jsx. */
+	box-shadow: 0 0 0 3px rgba(var(--v0-success), 0.2);
+}
+
+.zw-status-dot--asleep {
+	background: var(--zw-muted);
+}
+
+.zw-status-dot--dead {
+	background: var(--zw-danger);
+}
+
+.zw-status-dot--controller {
+	background: var(--zw-accent);
+}
+</style>

--- a/src/components/dashboard/atoms/ZwStatusDot.vue
+++ b/src/components/dashboard/atoms/ZwStatusDot.vue
@@ -43,7 +43,7 @@ const sizeStyle = computed(() =>
 
 .zw-status-dot--awake {
 	background: var(--zw-ok);
-	/* Static halo — alpha 0x33 = 20% — matches direction-b.jsx. */
+	/* Static halo — alpha 0x33 = 20%. */
 	box-shadow: 0 0 0 3px rgba(var(--v0-success), 0.2);
 }
 

--- a/src/components/dashboard/atoms/ZwToggle.vue
+++ b/src/components/dashboard/atoms/ZwToggle.vue
@@ -1,0 +1,106 @@
+<template>
+	<Switch.Root
+		class="zw-toggle zw-focus-ring"
+		:class="`zw-toggle--${size}`"
+		:model-value="modelValue"
+		:disabled="disabled"
+		@update:model-value="emit('update:modelValue', $event)"
+	>
+		<Switch.Thumb class="zw-toggle__thumb" />
+	</Switch.Root>
+</template>
+
+<script setup lang="ts">
+import { Switch } from '@vuetify/v0'
+
+withDefaults(
+	defineProps<{
+		modelValue: boolean
+		size?: 'md' | 'sm'
+		disabled?: boolean
+	}>(),
+	{ size: 'md', disabled: false },
+)
+
+const emit = defineEmits<{ 'update:modelValue': [boolean] }>()
+</script>
+
+<style>
+/* Styles unscoped — V0 primitives set inheritAttrs:false so Vue does not
+   forward the parent's scoped data-v-* hash onto the rendered <button>.
+   .zw-toggle namespace is unique to this atom. */
+/* 2-px focus offset (vs the utility's 1-px default) so the ring sits
+   clear of the pill track. */
+.zw-toggle {
+	appearance: none;
+	border: none;
+	cursor: pointer;
+	padding: 0;
+	position: relative;
+	border-radius: var(--zw-radius-pill);
+	transition: background 0.18s;
+	--zw-focus-offset: 2px;
+}
+
+.zw-toggle[data-disabled='true'] {
+	pointer-events: none;
+	opacity: 0.5;
+}
+
+/* SwitchThumb sets `visibility: hidden` inline when unchecked — we
+   override it because the design slides the thumb between two positions
+   rather than fading it in/out. */
+.zw-toggle__thumb {
+	visibility: visible !important;
+	position: absolute;
+	background: rgb(var(--v0-on-primary));
+	border-radius: 50%;
+	transition: left 0.18s;
+}
+
+/* ── md (44 × 26) — card-view primary controls ─────────────── */
+.zw-toggle--md {
+	width: 44px;
+	height: 26px;
+	background: var(--zw-line);
+}
+
+.zw-toggle--md[data-state='checked'] {
+	background: var(--zw-accent);
+}
+
+.zw-toggle--md .zw-toggle__thumb {
+	width: 20px;
+	height: 20px;
+	top: 3px;
+	left: 3px;
+	box-shadow: 0 1px 3px rgba(0, 0, 0, 0.18);
+}
+
+.zw-toggle--md[data-state='checked'] .zw-toggle__thumb {
+	left: 21px;
+}
+
+/* ── sm (30 × 16) — table-row controls ─────────────────────── */
+.zw-toggle--sm {
+	width: 30px;
+	height: 16px;
+	background: var(--zw-line2);
+}
+
+.zw-toggle--sm[data-state='checked'] {
+	background: var(--zw-accent);
+}
+
+.zw-toggle--sm .zw-toggle__thumb {
+	width: 12px;
+	height: 12px;
+	top: 2px;
+	left: 2px;
+	box-shadow: 0 1px 2px rgba(0, 0, 0, 0.2);
+}
+
+.zw-toggle--sm[data-state='checked'] .zw-toggle__thumb {
+	left: 16px;
+}
+</style>

--- a/src/components/dashboard/atoms/ZwToggleMenu.vue
+++ b/src/components/dashboard/atoms/ZwToggleMenu.vue
@@ -1,0 +1,239 @@
+<template>
+	<Popover.Root v-model="open" :id="contentId">
+		<Popover.Activator as="button" class="zw-tm__trigger zw-focus-ring">
+			<component :is="triggerIcon ?? FilterIcon" :size="ICON_SIZE.chip" />
+			<span v-if="!triggerLabelHidden" class="zw-tm__label">
+				{{ triggerLabel }}
+			</span>
+			<span v-if="(badgeCount ?? 0) > 0" class="zw-tm__badge">
+				{{ badgeCount }}
+			</span>
+			<ChevronDownIcon class="zw-tm__chevron" :size="ICON_SIZE.pill" />
+		</Popover.Activator>
+		<Popover.Content
+			as="div"
+			class="zw-tm__panel"
+			role="menu"
+		>
+			<div v-if="header" class="zw-tm__header">{{ header }}</div>
+			<button
+				v-for="opt in options"
+				:key="opt.id"
+				type="button"
+				class="zw-tm__row"
+				role="menuitemcheckbox"
+				:aria-checked="selectedSet.has(opt.id)"
+				@click="onToggle(opt.id)"
+			>
+				<span
+					class="zw-tm__check"
+					:class="{ 'zw-tm__check--on': selectedSet.has(opt.id) }"
+				>
+					<CheckIcon
+						v-if="selectedSet.has(opt.id)"
+						:size="ICON_SIZE.pill"
+						:stroke-width="3"
+					/>
+				</span>
+				<component
+					:is="opt.icon"
+					v-if="opt.icon"
+					:size="ICON_SIZE.chip"
+					class="zw-tm__row-icon"
+				/>
+				<span class="zw-tm__row-label">{{ opt.label }}</span>
+			</button>
+		</Popover.Content>
+	</Popover.Root>
+</template>
+
+<script setup lang="ts">
+import { computed, ref, useId } from 'vue'
+import type { Component } from 'vue'
+import { Popover } from '@vuetify/v0'
+import {
+	CheckIcon,
+	ChevronDownIcon,
+	FilterIcon,
+	ICON_SIZE,
+} from '@/lib/icons'
+import { usePopoverFallback } from '@/lib/popover-fallback.ts'
+
+interface ToggleMenuOption {
+	id: string
+	label: string
+	icon?: Component
+}
+
+// Atom is locale-agnostic: callers pass an already-translated triggerLabel
+// (or set triggerLabelHidden to render an icon-only chevron trigger). No
+// EN fallback here would silently leak the literal "Filter" string.
+const props = defineProps<{
+	options: ToggleMenuOption[]
+	modelValue: readonly string[]
+	triggerIcon?: Component
+	triggerLabel?: string
+	triggerLabelHidden?: boolean
+	header?: string
+	badgeCount?: number | null
+}>()
+
+const emit = defineEmits<{ 'update:modelValue': [string[]] }>()
+
+const open = ref(false)
+const contentId = `zw-tm-${useId()}`
+
+usePopoverFallback({ open, contentId })
+
+// Built once per modelValue change so the three .has() calls per
+// option-row don't each pay an O(n) array walk.
+const selectedSet = computed(() => new Set(props.modelValue))
+
+function onToggle(id: string): void {
+	emit(
+		'update:modelValue',
+		selectedSet.value.has(id)
+			? props.modelValue.filter((x) => x !== id)
+			: [...props.modelValue, id],
+	)
+}
+</script>
+
+<style>
+/* Styles unscoped — V0 primitives set inheritAttrs:false so Vue's scoped
+   data-v-* hash does not reach the rendered elements. .zw-tm namespace is
+   unique to this atom. */
+/* Trigger is a Caption-role row (handoff TYPE_SCALE at
+   design-system.jsx:51 — "Subtitles, hints"). */
+.zw-tm__trigger {
+	appearance: none;
+	background: var(--zw-card);
+	border: 1px solid var(--zw-line);
+	border-radius: 5px;
+	padding: 4px 10px;
+	display: inline-flex;
+	align-items: center;
+	gap: 6px;
+	color: var(--zw-fg);
+	font: var(--zw-text-caption);
+	cursor: pointer;
+	transition:
+		background 0.12s,
+		border-color 0.12s;
+}
+
+/* V0 Popover.Activator stamps `data-open` on the trigger when the
+   popover is open — no Vue class binding needed. */
+.zw-tm__trigger[data-open] {
+	background: var(--zw-accent-soft);
+	border-color: rgba(var(--v0-primary), 0.4);
+}
+
+.zw-tm__label {
+	white-space: nowrap;
+}
+
+.zw-tm__badge {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	min-width: 16px;
+	height: 16px;
+	padding: 0 4px;
+	border-radius: var(--zw-radius-pill);
+	background: var(--zw-accent);
+	color: rgb(var(--v0-on-primary));
+	font-size: 10px;
+	font-weight: 600;
+}
+
+.zw-tm__chevron {
+	transition: transform 0.15s;
+	color: var(--zw-fg-soft);
+}
+
+.zw-tm__trigger[data-open] .zw-tm__chevron {
+	transform: rotate(180deg);
+}
+
+/* V0 hard-codes `position-area: bottom` + `position-anchor: --<id>` as an
+   inline style on the popover and Vue's `patchStyle` re-applies it on every
+   render, stripping any inline `!important` we add. An external stylesheet
+   rule with `!important` survives those re-patches and lets Floating UI's
+   manual top/left writes drive the actual position. */
+.zw-tm__panel {
+	position-area: none !important;
+	position-anchor: auto !important;
+	min-width: 220px;
+	background: var(--zw-card);
+	border: 1px solid var(--zw-line-soft);
+	border-radius: 6px;
+	box-shadow: var(--zw-e8);
+	padding: 4px;
+	animation: zw-fade-in 0.12s;
+}
+
+/* Reset native :popover style — V0 uses the HTML popover attribute, which
+   adds default border, padding, and an inset:auto box. We want our own
+   chrome to define those. */
+.zw-tm__panel::backdrop {
+	display: none;
+}
+
+.zw-tm__header {
+	padding: 6px 10px 4px;
+	font-family: var(--zw-mono);
+	font-size: 10px;
+	color: var(--zw-muted);
+	text-transform: uppercase;
+	letter-spacing: 0.6px;
+}
+
+/* Row text is Body S (handoff TYPE_SCALE at design-system.jsx:49 —
+   "Search input, dense rows"). */
+.zw-tm__row {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	width: 100%;
+	background: transparent;
+	border: none;
+	cursor: pointer;
+	padding: 6px 8px;
+	border-radius: 4px;
+	color: var(--zw-fg);
+	font: var(--zw-text-body-s);
+	line-height: 1.3;
+	text-align: left;
+}
+
+.zw-tm__row:hover {
+	background: var(--zw-row-hover);
+}
+
+.zw-tm__check {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	width: 14px;
+	height: 14px;
+	border: 1.5px solid var(--zw-line2);
+	border-radius: 3px;
+	color: rgb(var(--v0-on-primary));
+	flex: 0 0 14px;
+}
+
+.zw-tm__check--on {
+	background: var(--zw-accent);
+	border-color: var(--zw-accent);
+}
+
+.zw-tm__row-icon {
+	color: var(--zw-fg-soft);
+	flex: 0 0 auto;
+}
+
+.zw-tm__row-label {
+	flex: 1;
+}
+</style>

--- a/src/components/dashboard/atoms/ZwToggleMenu.vue
+++ b/src/components/dashboard/atoms/ZwToggleMenu.vue
@@ -103,8 +103,7 @@ function onToggle(id: string): void {
 /* Styles unscoped — V0 primitives set inheritAttrs:false so Vue's scoped
    data-v-* hash does not reach the rendered elements. .zw-tm namespace is
    unique to this atom. */
-/* Trigger is a Caption-role row (handoff TYPE_SCALE at
-   design-system.jsx:51 — "Subtitles, hints"). */
+/* Trigger uses the Caption type role. */
 .zw-tm__trigger {
 	appearance: none;
 	background: var(--zw-card);
@@ -189,8 +188,7 @@ function onToggle(id: string): void {
 	letter-spacing: 0.6px;
 }
 
-/* Row text is Body S (handoff TYPE_SCALE at design-system.jsx:49 —
-   "Search input, dense rows"). */
+/* Row text uses the Body S type role. */
 .zw-tm__row {
 	display: flex;
 	align-items: center;

--- a/src/components/dashboard/atoms/ZwToggleMenu.vue
+++ b/src/components/dashboard/atoms/ZwToggleMenu.vue
@@ -10,11 +10,7 @@
 			</span>
 			<ChevronDownIcon class="zw-tm__chevron" :size="ICON_SIZE.pill" />
 		</Popover.Activator>
-		<Popover.Content
-			as="div"
-			class="zw-tm__panel"
-			role="menu"
-		>
+		<Popover.Content as="div" class="zw-tm__panel" role="menu">
 			<div v-if="header" class="zw-tm__header">{{ header }}</div>
 			<button
 				v-for="opt in options"
@@ -51,12 +47,7 @@
 import { computed, ref, useId } from 'vue'
 import type { Component } from 'vue'
 import { Popover } from '@vuetify/v0'
-import {
-	CheckIcon,
-	ChevronDownIcon,
-	FilterIcon,
-	ICON_SIZE,
-} from '@/lib/icons'
+import { CheckIcon, ChevronDownIcon, FilterIcon, ICON_SIZE } from '@/lib/icons'
 import { usePopoverFallback } from '@/lib/popover-fallback.ts'
 
 interface ToggleMenuOption {

--- a/src/components/dashboard/atoms/ZwTransientReadout.vue
+++ b/src/components/dashboard/atoms/ZwTransientReadout.vue
@@ -1,0 +1,175 @@
+<template>
+	<span
+		class="zw-tx"
+		:class="[
+			`zw-tx--${variant}`,
+			{ 'zw-tx--indeterminate': pct === undefined },
+		]"
+		:title="title"
+	>
+		<component :is="iconComp" :size="ICON_SIZE.chip" class="zw-tx__icon" />
+		<Progress.Root
+			as="span"
+			class="zw-tx__bar"
+			:model-value="pct ?? 0"
+			:min="0"
+			:max="100"
+		>
+			<Progress.Fill as="span" class="zw-tx__fill">
+				<span v-if="variant === 'card'" class="zw-tx__shimmer" />
+			</Progress.Fill>
+		</Progress.Root>
+		<span v-if="pct !== undefined" class="zw-tx__pct">{{ pct }}%</span>
+	</span>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import { Progress } from '@vuetify/v0'
+import {
+	DownloadIcon,
+	RefreshIcon,
+	InterviewIcon,
+	ICON_SIZE,
+} from '@/lib/icons'
+
+type TransientType = 'ota' | 'rebuild' | 'interview'
+interface Transient {
+	type: TransientType
+	label: string
+	progress?: number
+}
+
+const props = withDefaults(
+	defineProps<{
+		transient: Transient
+		variant?: 'table' | 'card'
+	}>(),
+	{ variant: 'table' },
+)
+
+const TRANSIENT_ICON = {
+	ota: DownloadIcon,
+	rebuild: RefreshIcon,
+	interview: InterviewIcon,
+} as const
+
+const iconComp = computed(() => TRANSIENT_ICON[props.transient.type])
+
+// Progress is optional — when undefined the readout renders an
+// indeterminate sweep across the bar with no numeric label. A literal
+// placeholder (e.g. 30%) would be misleading, especially for OTA where
+// users watch the number.
+const pct = computed(() =>
+	props.transient.progress !== undefined
+		? Math.round(props.transient.progress * 100)
+		: undefined,
+)
+
+const title = computed(() =>
+	pct.value !== undefined
+		? `${props.transient.label} · ${pct.value}%`
+		: props.transient.label,
+)
+</script>
+
+<style>
+/* Unscoped — V0 primitives set inheritAttrs:false; .zw-tx namespace is
+   unique to this atom. */
+.zw-tx {
+	display: inline-flex;
+	align-items: center;
+	font-family: var(--zw-font);
+	color: var(--zw-accent-dark);
+}
+
+.zw-tx--table {
+	gap: 6px;
+}
+
+.zw-tx--card {
+	gap: 8px;
+	flex: 1;
+	min-width: 0;
+}
+
+.zw-tx__icon {
+	flex: 0 0 auto;
+	color: var(--zw-accent);
+}
+
+.zw-tx__bar {
+	position: relative;
+	height: 4px;
+	background: rgba(var(--v0-primary), 0.18);
+	border-radius: 2px;
+	overflow: hidden;
+}
+
+/* Indeterminate state hides the fill and animates a sweep across the
+   bar so the user still sees that work is in flight. */
+.zw-tx--indeterminate .zw-tx__fill {
+	display: none;
+}
+
+.zw-tx--indeterminate .zw-tx__bar::after {
+	content: '';
+	position: absolute;
+	inset: 0;
+	width: 40%;
+	background: var(--zw-accent);
+	border-radius: 2px;
+	animation: zw-tx-indeterminate 1.2s ease-in-out infinite;
+}
+
+@keyframes zw-tx-indeterminate {
+	0% {
+		transform: translateX(-100%);
+	}
+	100% {
+		transform: translateX(300%);
+	}
+}
+
+.zw-tx--table .zw-tx__bar {
+	width: 36px;
+	flex: 0 0 36px;
+}
+
+.zw-tx--card .zw-tx__bar {
+	flex: 1;
+	min-width: 24px;
+}
+
+.zw-tx__fill {
+	display: block;
+	height: 100%;
+	background: var(--zw-accent);
+	border-radius: 2px;
+	transition: width 0.3s;
+	position: relative;
+}
+
+.zw-tx__shimmer {
+	position: absolute;
+	inset: 0;
+	background: linear-gradient(
+		to right,
+		transparent 0%,
+		rgba(255, 255, 255, 0.25) 50%,
+		transparent 100%
+	);
+	transform: translateX(-100%);
+	animation: zw-shimmer 4s linear infinite;
+	pointer-events: none;
+}
+
+.zw-tx__pct {
+	font-family: var(--zw-mono);
+	font-size: 10px;
+	font-weight: 600;
+	min-width: 26px;
+	text-align: right;
+	font-variant-numeric: tabular-nums;
+}
+</style>

--- a/src/components/dashboard/atoms/ZwUpdateNotifier.vue
+++ b/src/components/dashboard/atoms/ZwUpdateNotifier.vue
@@ -60,15 +60,15 @@ const emit = defineEmits<{ click: [] }>()
 }
 
 /* Title is an intermediate of Caption (11/400) and Label (12/600):
-   the handoff renders 11/600 at design-system.jsx:460, which is not
-   a tabled TYPE_SCALE row. Keep the explicit declarations rather
-   than picking a role that would shift the size or drop emphasis. */
+   the design calls for 11/600, which is not a tabled type-scale
+   role. Keep the explicit declarations rather than picking a role
+   that would shift the size or drop emphasis. */
 .zw-update__title {
 	font-size: 11px;
 	font-weight: 600;
 }
 
-/* Versions line is Mono Micro (handoff line 55 — "pill text"). */
+/* Versions line is Mono Micro. */
 .zw-update__versions {
 	font: var(--zw-text-mono-micro);
 	color: var(--zw-fg-soft);

--- a/src/components/dashboard/atoms/ZwUpdateNotifier.vue
+++ b/src/components/dashboard/atoms/ZwUpdateNotifier.vue
@@ -9,7 +9,9 @@
 		<span v-if="compact" class="zw-update__dot" />
 		<span v-else class="zw-update__body">
 			<span class="zw-update__title">Update available</span>
-			<span class="zw-update__versions">{{ current }} → {{ available }}</span>
+			<span class="zw-update__versions"
+				>{{ current }} → {{ available }}</span
+			>
 		</span>
 	</Button.Root>
 </template>

--- a/src/components/dashboard/atoms/ZwUpdateNotifier.vue
+++ b/src/components/dashboard/atoms/ZwUpdateNotifier.vue
@@ -1,0 +1,97 @@
+<template>
+	<Button.Root
+		class="zw-update"
+		:class="{ 'zw-update--compact': compact }"
+		:aria-label="`Update available: ${current} → ${available}`"
+		@click="emit('click')"
+	>
+		<DownloadIcon :size="compact ? ICON_SIZE.button : ICON_SIZE.update" />
+		<span v-if="compact" class="zw-update__dot" />
+		<span v-else class="zw-update__body">
+			<span class="zw-update__title">Update available</span>
+			<span class="zw-update__versions">{{ current }} → {{ available }}</span>
+		</span>
+	</Button.Root>
+</template>
+
+<script setup lang="ts">
+import { Button } from '@vuetify/v0'
+import { DownloadIcon, ICON_SIZE } from '@/lib/icons'
+
+defineProps<{
+	current: string
+	available: string
+	compact?: boolean
+}>()
+
+const emit = defineEmits<{ click: [] }>()
+</script>
+
+<style>
+/* Unscoped — V0 primitives set inheritAttrs:false; .zw-update namespace
+   is unique to this atom. */
+.zw-update {
+	display: inline-flex;
+	align-items: center;
+	gap: 8px;
+	padding: 6px 8px;
+	border: 1px solid rgba(var(--v0-primary), 0.3);
+	background: var(--zw-accent-soft);
+	border-radius: 6px;
+	color: var(--zw-accent-dark);
+	text-align: left;
+	cursor: pointer;
+	font-family: inherit;
+}
+
+.zw-update:hover:not([data-disabled='true']) {
+	background: rgba(var(--v0-primary-soft), 0.85);
+}
+
+.zw-update:focus-visible {
+	outline: 2px solid var(--zw-accent);
+	outline-offset: 1px;
+}
+
+.zw-update__body {
+	display: inline-flex;
+	flex-direction: column;
+	line-height: 1.2;
+}
+
+/* Title is an intermediate of Caption (11/400) and Label (12/600):
+   the handoff renders 11/600 at design-system.jsx:460, which is not
+   a tabled TYPE_SCALE row. Keep the explicit declarations rather
+   than picking a role that would shift the size or drop emphasis. */
+.zw-update__title {
+	font-size: 11px;
+	font-weight: 600;
+}
+
+/* Versions line is Mono Micro (handoff line 55 — "pill text"). */
+.zw-update__versions {
+	font: var(--zw-text-mono-micro);
+	color: var(--zw-fg-soft);
+}
+
+.zw-update--compact {
+	position: relative;
+	width: 32px;
+	height: 32px;
+	padding: 0;
+	justify-content: center;
+}
+
+.zw-update__dot {
+	position: absolute;
+	top: 4px;
+	right: 4px;
+	width: 7px;
+	height: 7px;
+	background: var(--zw-accent);
+	border-radius: 50%;
+	/* Ring matches the card background so the dot reads as floating over
+	   the surface in either theme — not a literal white halo. */
+	box-shadow: 0 0 0 1.5px var(--zw-card);
+}
+</style>

--- a/src/lib/icons.ts
+++ b/src/lib/icons.ts
@@ -88,6 +88,7 @@ export const ICON_SIZE = {
 	pill: 10, // pill leading glyph
 	chip: 11, // chip glyph, table-row inline icon, segmented glyph, columns-menu filter
 	sortArrow: 12, // header chevrons, sort-direction arrows
+	update: 13, // expanded update-notifier
 	button: 14, // primary button leading icon, table-row archetype glyph, search-input prepend
 	nav: 16, // sidebar nav row, top-bar search glyph
 	topbar: 18, // top-bar icon buttons, menu icon, status icons, drawer close button

--- a/src/lib/popover-fallback.ts
+++ b/src/lib/popover-fallback.ts
@@ -1,0 +1,110 @@
+// Floating-UI-backed positioner for V0 Popover content.
+//
+// V0's docs explicitly recommend Floating UI for browsers without CSS
+// Anchor Positioning support — and even in supporting browsers, V0 hard-
+// codes `position-area: bottom` (with no way to override via Root props),
+// which centers the popover under its anchor instead of letting us
+// right-align it to a trigger button.
+//
+// `autoUpdate` keeps the popover in place while the user scrolls, resizes,
+// or interacts with surrounding layout, replacing V0's anchor-positioning
+// inline styles entirely. We disable V0's anchor styles by writing
+// `position-area: none !important` once, then drive `top`/`left` ourselves
+// via `computePosition`.
+//
+// Element lookup: neither `Popover.Activator` nor `Popover.Content` calls
+// `defineExpose`, so Vue template refs on them yield nothing useful. We
+// rely on the caller-supplied `contentId` (bound via `<Popover.Root :id>`
+// so V0 wires both activator's `popovertarget` and content's `id` to that
+// value), and find the elements at activation time via the DOM.
+//
+// Alignment rule:
+//   - placement: 'bottom-end' (menu's right edge aligned with activator's
+//     right edge, menu extends leftward) — matches typical dropdown UX.
+//   - Middleware `flip` switches to bottom-start (left-aligned) etc. when
+//     the preferred placement would clip.
+
+import { onBeforeUnmount, watch, toValue } from 'vue'
+import type { MaybeRefOrGetter, Ref } from 'vue'
+import {
+	computePosition,
+	autoUpdate,
+	flip,
+	shift,
+	offset,
+} from '@floating-ui/dom'
+
+interface FallbackPositionOptions {
+	open: Ref<boolean>
+	contentId: MaybeRefOrGetter<string>
+}
+
+export function usePopoverFallback({
+	open,
+	contentId,
+}: FallbackPositionOptions): void {
+	let cleanup: (() => void) | null = null
+
+	function startTracking(): void {
+		const id = toValue(contentId)
+		const c = document.getElementById(id)
+		const a = document.querySelector<HTMLElement>(`[popovertarget="${id}"]`)
+		if (!a || !c) return
+
+		// Override V0's `position-area: bottom` (which centers the popover
+		// on its anchor) and its `position-anchor` so Floating UI's manual
+		// top/left writes are not overridden by the CSS-anchor cascade.
+		// The position-strategy + right/bottom anchors are also static —
+		// set them once here, leaving only top/left to be rewritten on
+		// each autoUpdate tick.
+		c.style.setProperty('position-area', 'none', 'important')
+		c.style.setProperty('position-anchor', 'none', 'important')
+		c.style.setProperty('margin', '0', 'important')
+		c.style.setProperty('position', 'fixed', 'important')
+		c.style.setProperty('right', 'auto', 'important')
+		c.style.setProperty('bottom', 'auto', 'important')
+
+		cleanup = autoUpdate(a, c, () => {
+			computePosition(a, c, {
+				placement: 'bottom-end',
+				strategy: 'fixed',
+				middleware: [
+					offset(6),
+					flip({
+						fallbackPlacements: [
+							'bottom-start',
+							'top-end',
+							'top-start',
+						],
+					}),
+					shift({ padding: 8 }),
+				],
+			})
+				.then(({ x, y }) => {
+					c.style.setProperty('top', `${y}px`, 'important')
+					c.style.setProperty('left', `${x}px`, 'important')
+				})
+				.catch((err: unknown) => {
+					console.error(
+						'[popover-fallback] computePosition failed',
+						err,
+					)
+				})
+		})
+	}
+
+	function stopTracking(): void {
+		cleanup?.()
+		cleanup = null
+	}
+
+	watch(
+		() => open.value,
+		(isOpen) => {
+			stopTracking()
+			if (isOpen) startTracking()
+		},
+	)
+
+	onBeforeUnmount(stopTracking)
+}

--- a/src/lib/popover-fallback.ts
+++ b/src/lib/popover-fallback.ts
@@ -104,6 +104,10 @@ export function usePopoverFallback({
 			stopTracking()
 			if (isOpen) startTracking()
 		},
+		// Flush after the DOM patch: on open, V0 mounts Popover.Content in
+		// the same tick, so a default 'pre' watcher would query the DOM
+		// before the element exists and startTracking would bail on null.
+		{ flush: 'post' },
 	)
 
 	onBeforeUnmount(stopTracking)


### PR DESCRIPTION
This PR is based on https://github.com/zwave-js/zwave-js-ui/pull/4646

For review: all commits starting with [feat(ui): ZwPill atom (status pill, 7 tones × 2 sizes)](https://github.com/zwave-js/zwave-js-ui/commit/19ad516bd9cdddf8bb471a42d4e7386516f1743c) - the others are part of the preceding PRs.

Adds the twelve atomic dashboard components — status indicators (ZwPill, ZwChip, ZwStatusDot, ZwBatteryMini), form controls (ZwToggle, ZwSlider, ZwSegmented, ZwSearchInput, ZwButton, ZwToggleMenu), and progress/notifier readouts (ZwActivityReadout, ZwUpdateNotifier) — built against the foundation tokens and Lucide icon set. Each component is self-contained with its own tone/size variants exposed as props, so composites and layouts in later branches can compose them without restyling. Includes a small Floating UI wrapper used by the menu/dropdown atoms when native anchor positioning isn't available in the browser runtime.

<img width="418" height="754" alt="grafik" src="https://github.com/user-attachments/assets/8fcaa112-bdd6-4bf4-943c-093a3e692b03" />

<img width="694" height="530" alt="grafik" src="https://github.com/user-attachments/assets/71343887-4c40-45e4-9c41-9d761f968d5a" />
