### PR TITLE
fix(ui): reduce nodes-table re-render pressure and clear inclusion ghosts

### DIFF
--- a/api/lib/ZwaveClient.ts
+++ b/api/lib/ZwaveClient.ts
@@ -768,6 +768,10 @@ class ZwaveClient extends TypedEventEmitter<ZwaveClientEventCallbacks> {
 	private tmpNode: utils.DeepPartial<ZUINode>
 	// tells if a node replacement is in progress
 	private isReplacing = false
+	// node ids surfaced to the UI via `node found` that have not yet hit
+	// `node added` — if inclusion fails before the interview completes
+	// they're orphans stuck at ProtocolInfo and must be cleared (see #4639)
+	private _pendingInclusionNodeIds: Set<number> = new Set()
 
 	private hasUserCallbacks = false
 
@@ -2625,7 +2629,13 @@ class ZwaveClient extends TypedEventEmitter<ZwaveClientEventCallbacks> {
 			this.getNode(valueId.nodeId)?.getValueTimestamp(valueId) ??
 			Date.now()
 
-		this.sendToSocket(socketEvents.valueUpdated, valueId)
+		// Skip the socket broadcast when the value didn't actually change.
+		// Chatty meshes can produce ~50% no-op value updates (see #4639) and
+		// each one triggers an unnecessary re-render of the nodes table.
+		// MQTT/HASS still get every event via the local 'valueChanged' below.
+		if (changed) {
+			this.sendToSocket(socketEvents.valueUpdated, valueId)
+		}
 
 		this.emit('valueChanged', valueId, node, changed)
 	}
@@ -5823,6 +5833,23 @@ class ZwaveClient extends TypedEventEmitter<ZwaveClientEventCallbacks> {
 		const message = 'Inclusion failed'
 		this.isReplacing = false
 		this.tmpNode = undefined
+
+		// Clear any ghost nodes the driver surfaced via `node found` but never
+		// promoted to `node added`. zwave-js doesn't always emit `node removed`
+		// for these, so they would stay stuck on ProtocolInfo in the UI forever.
+		for (const nodeId of this._pendingInclusionNodeIds) {
+			const node = this._nodes.get(nodeId)
+			if (node && !node.ready) {
+				this.logNode(
+					nodeId,
+					'info',
+					'Removing ghost node after failed inclusion',
+				)
+				this._removeNode(nodeId)
+			}
+		}
+		this._pendingInclusionNodeIds.clear()
+
 		this._updateControllerStatus(message)
 		this.emit('event', EventSource.CONTROLLER, 'inclusion failed')
 	}
@@ -5844,6 +5871,8 @@ class ZwaveClient extends TypedEventEmitter<ZwaveClientEventCallbacks> {
 		if (this.driverReady) {
 			node = this._createNode(nodeId)
 			this.sendToSocket(socketEvents.nodeFound, { node })
+			// track until `node added` clears it; cleaned up on inclusion failure
+			this._pendingInclusionNodeIds.add(nodeId)
 		} else {
 			node = this._nodes.get(nodeId)
 		}
@@ -5860,6 +5889,8 @@ class ZwaveClient extends TypedEventEmitter<ZwaveClientEventCallbacks> {
 	 */
 	private async _onNodeAdded(zwaveNode: ZWaveNode, result: InclusionResult) {
 		let node: ZUINode
+		// node made it past `node found` — no longer a ghost candidate
+		this._pendingInclusionNodeIds.delete(zwaveNode.id)
 		// the driver is ready so this node has been added on fly
 		if (this.driverReady) {
 			node = this._addNode(zwaveNode)
@@ -7077,6 +7108,7 @@ class ZwaveClient extends TypedEventEmitter<ZwaveClientEventCallbacks> {
 	private _removeNode(nodeid: number) {
 		// don't use splice here, nodeid equals to the index in the array
 		const node = this._nodes.get(nodeid)
+		this._pendingInclusionNodeIds.delete(nodeid)
 		if (node) {
 			this._nodes.delete(nodeid)
 
@@ -7687,7 +7719,9 @@ class ZwaveClient extends TypedEventEmitter<ZwaveClientEventCallbacks> {
 
 				this.statelessTimeouts[valueId.id] = setTimeout(() => {
 					valueId.value = undefined
-					this.emitValueChanged(valueId, node, false)
+					// reset is itself a transition (X -> undefined), so the UI
+					// must be told even after the no-op suppression in emitValueChanged
+					this.emitValueChanged(valueId, node, true)
 				}, 1000)
 			}
 		}

--- a/src/components/nodes-table/RichValue.vue
+++ b/src/components/nodes-table/RichValue.vue
@@ -1,5 +1,19 @@
 <template>
-	<div v-tooltip:bottom="value.description">
+	<div>
+		<!--
+			Use the component form (not v-tooltip directive) so the overlay tracks
+			the parent's mount lifecycle. On chatty meshes the row re-renders many
+			times per second; the directive form leaks orphan tooltips (see #4639).
+			The open-delay also keeps transient mouse-overs from triggering at all.
+		-->
+		<v-tooltip
+			v-if="value && value.description"
+			activator="parent"
+			location="bottom"
+			:open-delay="300"
+		>
+			{{ value.description }}
+		</v-tooltip>
 		<span
 			v-if="value !== undefined && value.icon === ''"
 			:style="'padding-top: 4px; ' + value.displayStyle"

--- a/src/stores/base.js
+++ b/src/stores/base.js
@@ -323,7 +323,10 @@ const useBaseStore = defineStore('base', {
 			}
 
 			if (index >= 0) {
-				this.nodes.splice(index, 1, n)
+				// node already exists: Object.assign above mutated this.nodes[index]
+				// in place, so Vue reactivity already propagated the per-field changes.
+				// Splicing would invalidate v-data-table's row tracking and drop the
+				// expanded-row state mid-edit (see #4639).
 			} else {
 				this.nodes.push(n)
 				this.nodesMap.set(n.id, this.nodes.length - 1)

--- a/src/stores/base.js
+++ b/src/stores/base.js
@@ -322,12 +322,11 @@ const useBaseStore = defineStore('base', {
 				this.controllerId = n.id
 			}
 
-			if (index >= 0) {
-				// node already exists: Object.assign above mutated this.nodes[index]
-				// in place, so Vue reactivity already propagated the per-field changes.
-				// Splicing would invalidate v-data-table's row tracking and drop the
-				// expanded-row state mid-edit (see #4639).
-			} else {
+			// when the node already exists, Object.assign above mutated this.nodes[index]
+			// in place; Vue 3 reactivity propagates the per-field changes without us
+			// needing to splice the slot. Splicing would invalidate v-data-table's row
+			// tracking and drop the expanded-row state mid-edit (see #4639).
+			if (index === undefined) {
 				this.nodes.push(n)
 				this.nodesMap.set(n.id, this.nodes.length - 1)
 			}


### PR DESCRIPTION
## Summary

On meshes with many chatty nodes the control panel becomes laggy and visibly broken — see discussion #4639 (94-node setup, logs attached there). Three distinct UI symptoms, two of them sharing a root cause:

1. **The expanded config panel collapses mid-edit.** Every socket-driven node update was both `Object.assign`ing into the existing node object *and* `splice`ing it back into `this.nodes` — the splice was an array-level reactivity pulse that invalidated v-data-table's row identity and dropped the expanded slot.
2. **Hover tooltips on the table columns orphan and stack up** until something forces a global refresh. `RichValue.vue` used the `v-tooltip` directive form, which leaks overlays when the activator unmounts during a burst of re-renders. The component form (`<v-tooltip activator="parent">`) ties the overlay to its own mount lifecycle and is properly torn down.
3. **Failed inclusions leave permanent `ProtocolInfo` ghost entries.** `_onNodeFound` always pushes a partial node to the UI; `_onInclusionFailed` cleared `tmpNode`/`isReplacing` but never removed the ghost — and zwave-js does not consistently emit `node removed` when inclusion aborts before interview completes.

The reporter's logs also showed that **~50% of all `valueUpdated` socket emits were no-ops** (`X => X` — e.g. `0 => 0`, `true => true`, `100 => 100`). Suppressing those alone halves the re-render pressure on the frontend, which incidentally also widens the orphan-tooltip and collapse windows by a lot.

## Changes

### `api/lib/ZwaveClient.ts`

- `emitValueChanged` now skips the socket broadcast when `changed === false`. The local `'valueChanged'` event is still emitted unchanged so the MQTT gateway (`Gateway._onValueChanged`) sees every refresh — only the UI socket traffic is gated. `valueId.lastUpdate` is still updated server-side so the next real change carries a fresh timestamp.
- Stateless value reset (`statelessTimeouts`) now passes `changed=true` to `emitValueChanged` because the reset (X → undefined) is itself a transition the UI must see.
- `_onInclusionFailed` removes any node that came in via `node found` but never reached `node added`. Tracking lives in a new `_pendingInclusionNodeIds: Set<number>`, populated in `_onNodeFound`, cleared in `_onNodeAdded` and `_removeNode`.

### `src/stores/base.js`

- `updateNode` no longer `splice`s the merged node back into `this.nodes`. The `Object.assign` mutation propagates via Vue reactivity without invalidating the v-data-table's row identity.

### `src/components/nodes-table/RichValue.vue`

- Replaced the `v-tooltip:bottom` directive with `<v-tooltip activator="parent" :open-delay="300">`. The 300ms delay also keeps transient mouse-overs from opening a tooltip at all during update bursts.

## Notes / non-goals

- MQTT/HASS behavior is unchanged: the `'valueChanged'` local event still fires on every update (Gateway has its own filtering/publishing logic).
- Other `v-tooltip` directive uses elsewhere in the codebase are not touched in this PR — they aren't on hot paths in chatty mesh setups. Worth converting later if the same symptoms appear elsewhere.
- No batching/debouncing of socket events was added. With the no-op suppression alone the reported load drops by ~50%, and adding a coalescing window felt like over-reach for this fix. Easy follow-up if needed.

## Test plan

- [ ] Stand up the demo fleet (`npm run fake-stick:fleet`) and confirm the control panel still updates correctly on value change.
- [ ] Expand a node's Config panel, write a value via the `>` button; confirm the panel stays expanded after the round-trip.
- [ ] Hover repeatedly over Last Active / Status / Power on multiple rows; confirm tooltips don't stack and dismiss cleanly on mouse-out.
- [ ] Stateless button press: confirm UI shows the press and then clears after 1s.
- [ ] Force an inclusion failure (start inclusion, never present a device, wait for the 30s timeout) and confirm no ghost node remains in the table.
- [ ] MQTT gateway: confirm value updates including unchanged ones still publish.

Refs: #4639

🤖 Generated with [Claude Code](https://claude.com/claude-code)