### PR TITLE
fix(api): require authentication for the snippet listing endpoint

### DIFF
--- a/api/app.ts
+++ b/api/app.ts
@@ -2081,14 +2081,19 @@ app.post(
 	},
 )
 
-app.get('/api/snippet', apisLimiter, isAuthenticated, async function (req, res) {
-	try {
-		const snippets = await getSnippets()
-		res.json({ success: true, data: snippets })
-	} catch (err) {
-		res.json({ success: false, message: err.message })
-	}
-})
+app.get(
+	'/api/snippet',
+	apisLimiter,
+	isAuthenticated,
+	async function (req, res) {
+		try {
+			const snippets = await getSnippets()
+			res.json({ success: true, data: snippets })
+		} catch (err) {
+			res.json({ success: false, message: err.message })
+		}
+	},
+)
 
 // Debug capture endpoints
 app.get('/api/debug/status', apisLimiter, isAuthenticated, function (req, res) {

--- a/api/app.ts
+++ b/api/app.ts
@@ -2081,7 +2081,7 @@ app.post(
 	},
 )
 
-app.get('/api/snippet', apisLimiter, async function (req, res) {
+app.get('/api/snippet', apisLimiter, isAuthenticated, async function (req, res) {
 	try {
 		const snippets = await getSnippets()
 		res.json({ success: true, data: snippets })


### PR DESCRIPTION
Align the snippet listing route with its sibling store and debug routes by adding the `isAuthenticated` middleware so it consistently enforces access control when auth is enabled.