### PR TITLE
fix(gateway): apply numeric `postOperation` scaling directly

### DIFF
--- a/api/lib/Gateway.ts
+++ b/api/lib/Gateway.ts
@@ -466,7 +466,7 @@ export default class Gateway {
 					else if (op.includes('+')) op = op.replace(/\+/, '-')
 					else if (op.includes('-')) op = op.replace(/-/, '+')
 
-					payload = eval(`${payload}${op}`)
+					payload = this._applyOperation(payload, op)
 				}
 
 				if (valueConf.parseReceive) {
@@ -1974,7 +1974,10 @@ export default class Gateway {
 
 		if (valueConf) {
 			if (this._isValidOperation(valueConf.postOperation)) {
-				tmpVal = eval(valueId.value + valueConf.postOperation)
+				tmpVal = this._applyOperation(
+					valueId.value,
+					valueConf.postOperation,
+				)
 			}
 
 			if (valueConf.parseSend) {
@@ -2426,11 +2429,55 @@ export default class Gateway {
 	}
 
 	/**
-	 * Checks if an operation is valid, it must exist and must contains
-	 * only numbers and operators
+	 * A post operation is a single arithmetic operator (+ - * /) applied to a
+	 * literal number, e.g. "/10", "*100", "+20". Only this shape is supported
+	 * because the receive path inverts the operation by naively swapping the
+	 * operator (see parsePayload), which is only correct for a single operation.
+	 */
+	private static readonly POST_OPERATION =
+		/^\s*(?<operator>[-+*/])\s*(?<operand>-?\d+(?:\.\d+)?)\s*$/
+
+	/**
+	 * Checks if an operation is valid: a single operator (+ - * /) followed by
+	 * a literal number.
 	 */
 	private _isValidOperation(op: string): boolean {
-		return op && !/[^0-9.()\-+*/,]/g.test(op)
+		return typeof op === 'string' && Gateway.POST_OPERATION.test(op)
+	}
+
+	/**
+	 * Apply a numeric scaling operation (e.g. "/10", "*2", "+5") to a numeric value.
+	 */
+	private _applyOperation(value: any, op: string): any {
+		if (typeof value !== 'number' || !Number.isFinite(value)) {
+			return value
+		}
+
+		const match = Gateway.POST_OPERATION.exec(op)
+		if (!match) {
+			return value
+		}
+
+		const operand = Number(match.groups.operand)
+		let result: number
+		switch (match.groups.operator) {
+			case '+':
+				result = value + operand
+				break
+			case '-':
+				result = value - operand
+				break
+			case '*':
+				result = value * operand
+				break
+			case '/':
+				result = value / operand
+				break
+			default:
+				return value
+		}
+
+		return Number.isFinite(result) ? result : value
 	}
 
 	/**
@@ -2728,7 +2775,7 @@ export default class Gateway {
 			switchValue = `37-${endpoint}-currentValue`
 		}
 
-		/* 
+		/*
 			Find the control switch of the device Brightness or Binary
 			If multilevel is not there use binary
 			Some devices use also endpoint + 1 as on/off/brightness... try to guess that too!

--- a/api/lib/Gateway.ts
+++ b/api/lib/Gateway.ts
@@ -457,7 +457,7 @@ export default class Gateway {
 			}
 
 			if (valueConf) {
-				if (this._isValidOperation(valueConf.postOperation)) {
+				if (utils.isValidOperation(valueConf.postOperation)) {
 					let op = valueConf.postOperation
 
 					// revert operation to write
@@ -466,7 +466,7 @@ export default class Gateway {
 					else if (op.includes('+')) op = op.replace(/\+/, '-')
 					else if (op.includes('-')) op = op.replace(/-/, '+')
 
-					payload = this._applyOperation(payload, op)
+					payload = utils.applyOperation(payload, op)
 				}
 
 				if (valueConf.parseReceive) {
@@ -1973,8 +1973,8 @@ export default class Gateway {
 		let tmpVal = valueId.value
 
 		if (valueConf) {
-			if (this._isValidOperation(valueConf.postOperation)) {
-				tmpVal = this._applyOperation(
+			if (utils.isValidOperation(valueConf.postOperation)) {
+				tmpVal = utils.applyOperation(
 					valueId.value,
 					valueConf.postOperation,
 				)
@@ -2426,58 +2426,6 @@ export default class Gateway {
 			value,
 			payload.options,
 		)
-	}
-
-	/**
-	 * A post operation is a single arithmetic operator (+ - * /) applied to a
-	 * literal number, e.g. "/10", "*100", "+20". Only this shape is supported
-	 * because the receive path inverts the operation by naively swapping the
-	 * operator (see parsePayload), which is only correct for a single operation.
-	 */
-	private static readonly POST_OPERATION =
-		/^\s*(?<operator>[-+*/])\s*(?<operand>-?\d+(?:\.\d+)?)\s*$/
-
-	/**
-	 * Checks if an operation is valid: a single operator (+ - * /) followed by
-	 * a literal number.
-	 */
-	private _isValidOperation(op: string): boolean {
-		return typeof op === 'string' && Gateway.POST_OPERATION.test(op)
-	}
-
-	/**
-	 * Apply a numeric scaling operation (e.g. "/10", "*2", "+5") to a numeric value.
-	 */
-	private _applyOperation(value: any, op: string): any {
-		if (typeof value !== 'number' || !Number.isFinite(value)) {
-			return value
-		}
-
-		const match = Gateway.POST_OPERATION.exec(op)
-		if (!match) {
-			return value
-		}
-
-		const operand = Number(match.groups.operand)
-		let result: number
-		switch (match.groups.operator) {
-			case '+':
-				result = value + operand
-				break
-			case '-':
-				result = value - operand
-				break
-			case '*':
-				result = value * operand
-				break
-			case '/':
-				result = value / operand
-				break
-			default:
-				return value
-		}
-
-		return Number.isFinite(result) ? result : value
 	}
 
 	/**

--- a/api/lib/utils.ts
+++ b/api/lib/utils.ts
@@ -555,3 +555,55 @@ export function buildLogConfig(
 		forceConsole: isDocker() ? !config.logToFile : false,
 	}
 }
+
+/**
+ * A post operation is a single arithmetic operator (+ - * /) applied to a
+ * literal number, e.g. "/10", "*100", "+20". Only this shape is supported
+ * because the receive path inverts the operation by naively swapping the
+ * operator (see parsePayload), which is only correct for a single operation.
+ */
+const POST_OPERATION =
+	/^\s*(?<operator>[-+*/])\s*(?<operand>-?\d+(?:\.\d+)?)\s*$/
+
+/**
+ * Checks if an operation is valid: a single operator (+ - * /) followed by
+ * a literal number.
+ */
+export function isValidOperation(op: string): boolean {
+	return typeof op === 'string' && POST_OPERATION.test(op)
+}
+
+/**
+ * Apply a numeric scaling operation (e.g. "/10", "*2", "+5") to a numeric value.
+ */
+export function applyOperation(value: any, op: string): any {
+	if (typeof value !== 'number' || !Number.isFinite(value)) {
+		return value
+	}
+
+	const match = POST_OPERATION.exec(op)
+	if (!match) {
+		return value
+	}
+
+	const operand = Number(match.groups.operand)
+	let result: number
+	switch (match.groups.operator) {
+		case '+':
+			result = value + operand
+			break
+		case '-':
+			result = value - operand
+			break
+		case '*':
+			result = value * operand
+			break
+		case '/':
+			result = value / operand
+			break
+		default:
+			return value
+	}
+
+	return Number.isFinite(result) ? result : value
+}

--- a/test/lib/utils.test.ts
+++ b/test/lib/utils.test.ts
@@ -166,4 +166,72 @@ describe('#utils', () => {
 			expect(utils.isValidNodeIdString(5)).to.equal(false)
 		})
 	})
+
+	describe('#isValidOperation()', () => {
+		let utilsModule: any
+
+		before(async () => {
+			utilsModule = await esmock('../../api/lib/utils.ts')
+		})
+
+		it('accepts a single operator and number', () => {
+			expect(utilsModule.isValidOperation('/10')).to.equal(true)
+			expect(utilsModule.isValidOperation('*100')).to.equal(true)
+			expect(utilsModule.isValidOperation('+20')).to.equal(true)
+			expect(utilsModule.isValidOperation('-5')).to.equal(true)
+		})
+		it('accepts decimals, a signed operand and surrounding spaces', () => {
+			expect(utilsModule.isValidOperation('/2.5')).to.equal(true)
+			expect(utilsModule.isValidOperation('*-2')).to.equal(true)
+			expect(utilsModule.isValidOperation(' / 10 ')).to.equal(true)
+		})
+		it('rejects empty, non-string and malformed operations', () => {
+			expect(utilsModule.isValidOperation('')).to.equal(false)
+			expect(utilsModule.isValidOperation(undefined)).to.equal(false)
+			expect(utilsModule.isValidOperation('10')).to.equal(false)
+			expect(utilsModule.isValidOperation('/')).to.equal(false)
+		})
+		it('rejects multiple operations and parentheses', () => {
+			expect(utilsModule.isValidOperation('/10+5')).to.equal(false)
+			expect(utilsModule.isValidOperation('(1+2)*3')).to.equal(false)
+			expect(utilsModule.isValidOperation('/10,*2')).to.equal(false)
+		})
+		it('rejects anything that is not a number/operator', () => {
+			expect(utilsModule.isValidOperation('process.exit(1)')).to.equal(
+				false,
+			)
+		})
+	})
+
+	describe('#applyOperation()', () => {
+		let utilsModule: any
+
+		before(async () => {
+			utilsModule = await esmock('../../api/lib/utils.ts')
+		})
+
+		it('applies each operator to a number', () => {
+			expect(utilsModule.applyOperation(100, '/10')).to.equal(10)
+			expect(utilsModule.applyOperation(2, '*100')).to.equal(200)
+			expect(utilsModule.applyOperation(5, '+20')).to.equal(25)
+			expect(utilsModule.applyOperation(5, '-2')).to.equal(3)
+		})
+		it('handles decimals and signed operands', () => {
+			expect(utilsModule.applyOperation(5, '/2.5')).to.equal(2)
+			expect(utilsModule.applyOperation(3, '*-2')).to.equal(-6)
+		})
+		it('returns non-numeric values untouched', () => {
+			expect(utilsModule.applyOperation('foo', '/10')).to.equal('foo')
+			expect(utilsModule.applyOperation('100', '/10')).to.equal('100')
+			expect(utilsModule.applyOperation(true, '/10')).to.equal(true)
+			expect(utilsModule.applyOperation(null, '/10')).to.equal(null)
+		})
+		it('returns the value on a malformed operation', () => {
+			expect(utilsModule.applyOperation(100, '(1+2)*3')).to.equal(100)
+			expect(utilsModule.applyOperation(100, '/10+5')).to.equal(100)
+		})
+		it('returns the value on a non-finite result (divide by zero)', () => {
+			expect(utilsModule.applyOperation(100, '/0')).to.equal(100)
+		})
+	})
 })


### PR DESCRIPTION
A value's `postOperation` is a single +, -, *, / against a literal number, so compute it with a small arithmetic helper instead of using `eval`. `_isValidOperation` now enforces that shape, and only finite numeric values are scaled; any other payload or malformed operation is returned untouched.