### PR TITLE
fix(api): reduce default JSON request body size limit

### DIFF
--- a/api/app.ts
+++ b/api/app.ts
@@ -574,10 +574,10 @@ app.use(
 		level: 6, // Balanced compression level (0-9, higher = more compression but slower)
 	}),
 )
-app.use(express.json({ limit: '50mb' }) as RequestHandler)
+app.use(express.json({ limit: '5mb' }) as RequestHandler)
 app.use(
 	express.urlencoded({
-		limit: '50mb',
+		limit: '5mb',
 		extended: true,
 		parameterLimit: 50000,
 	}) as RequestHandler,


### PR DESCRIPTION
Lower the global express.json and urlencoded body size limit from 50mb to a more conservative 5mb that comfortably covers normal API payloads (settings, auth, store JSON). Large file uploads use multer and are unaffected. This avoids buffering and parsing oversized request bodies.

## Routes affected by the new 5 MB body limit

These accept a request body that flows through `express.json` / `express.urlencoded`, so they're now capped at 5 MB (was 50 MB). All carry small JSON payloads — well within 5 MB.

| Method | Route                                    | Body content                      |
| ------ | ---------------------------------------- | --------------------------------- |
| POST   | `/api/authenticate`                      | credentials                       |
| PUT    | `/api/password`                          | password change                   |
| POST   | `/api/settings`                          | gateway/zwave settings            |
| POST   | `/api/restart`                           | restart request                   |
| POST   | `/api/statistics`                        | statistics opt-in                 |
| POST   | `/api/versions`                          | version payload                   |
| POST   | `/api/importConfig`                      | node names/locations/hass devices |
| POST   | `/api/configuration-templates`           | single template                   |
| POST   | `/api/configuration-templates/import`    | template array                    |
| PUT    | `/api/configuration-templates/:id`       | template update                   |
| DELETE | `/api/configuration-templates/:id`       | —                                 |
| POST   | `/api/configuration-templates/:id/apply` | apply params                      |
| PUT    | `/api/store`                             | single store file                 |
| DELETE | `/api/store`                             | file path(s)                      |
| PUT    | `/api/store-multi`                       | multiple store files              |
| POST   | `/api/store-multi`                       | multiple store files              |
| POST   | `/api/debug/start`                       | debug options                     |
| POST   | `/api/debug/stop`                        | —                                 |
| POST   | `/api/debug/cancel`                      | —                                 |

## Routes NOT affected (no size restriction) — backup/restore safe

| Method | Route                         | Why it's exempt                                                                                                                                                      |
| ------ | ----------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
| POST   | `/api/store/upload`           | **Backup/store restore.** `multipart/form-data` handled by **multer** disk storage (`api/app.ts:107`) — never touches `express.json`; no file-size limit configured. |
| —      | `restoreNVM` / `backupNVMRaw` | **NVM backup/restore.** Sent over **Socket.IO** as a `callApi` (arrayBuffer), not an HTTP body — bypasses Express body parsers entirely.                             |

## GET routes (no request body — limit irrelevant)

`/api/auth-enabled`, `/api/logout`, `/health`, `/health/:client`, `/version`, `/api/settings`, `/api/serial-ports`, `/api/exportConfig`, `/api/configuration-templates`, `/api/configuration-templates/export`, `/api/configuration-templates/device-params/:deviceId`, `/api/store`, `/api/store/backup`, `/api/snippet`, `/api/debug/status`
