### PR TITLE
fix(ui): keep node index map consistent after node removal

### DIFF
--- a/src/stores/base.js
+++ b/src/stores/base.js
@@ -346,8 +346,15 @@ const useBaseStore = defineStore('base', {
 			const index = this.nodesMap.get(n.id)
 
 			if (index >= 0) {
-				this.nodesMap.delete(n.id)
 				this.nodes.splice(index, 1)
+				// splice shifts every node after `index` down by one, so the cached
+				// id -> index map is now stale for all of them. Rebuild it so getNode
+				// and updateNode keep resolving to the right slot — otherwise partial
+				// updates (e.g. status changes after Replace Failed Node) land on the
+				// wrong node and the UI goes stale until a refresh (see #4666).
+				this.nodesMap = new Map(
+					this.nodes.map((node, i) => [node.id, i]),
+				)
 			}
 		},
 		setNeighbors(neighbors) {


### PR DESCRIPTION
## Problem

Closes #4666

After using **Advanced → Failed Node → Replace** to replace a node, the node's **Status icon stays "Dead"** in the UI even though everything else works — pinging the node reports success, but the icon won't update until the browser is refreshed.

## Root cause

The frontend store (`src/stores/base.js`) maintains `nodesMap`, a `nodeId → index in this.nodes` lookup used by both `getNode` and `updateNode`. `removeNode` spliced a node out of the array but only deleted *that* node's `nodesMap` entry:

```js
this.nodesMap.delete(n.id)
this.nodes.splice(index, 1)   // every later node shifts down one slot
```

Splicing shifts every node *after* the removed index down by one, but their `nodesMap` entries keep pointing at the old (now off-by-one) index. "Replace Failed Node" removes the old node mid-array and then re-includes a new one, so afterwards the map is wrong for every later node. Incoming **partial** `nodeUpdated` status events (alive/dead/ping) are then `Object.assign`-ed into the *wrong* array slot, so the visible node's status never changes.

A browser refresh fixes it because `init` → `initNodes` rebuilds the map from scratch — which also confirms the backend status was correct the whole time.

## Fix

Rebuild `nodesMap` from the array after the splice, matching the reassign-a-fresh-`Map` pattern already used by `resetNodes`. This is the removal-side counterpart to the existing `updateNode` decision (#4639) to avoid splicing-on-update for the same index-integrity reason.

Frontend-only, one method changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
