### PR TITLE
fix(hass): add LZW45 to Inovelli RGBW Home Assistant discovery template

### DIFF
--- a/api/hass/devices.ts
+++ b/api/hass/devices.ts
@@ -208,7 +208,7 @@ const AEROPAC: HassDevice = {
 
 // Inovelli RGBW devices using Multilevel Switch + Color Switch
 const INOVELLI_RGBW_DEVICE: HassDevice = {
-	type: 'light',
+    type: 'light',
     object_id: 'rgbw_bulb',
     values: [
         '38-0-currentValue',

--- a/api/hass/devices.ts
+++ b/api/hass/devices.ts
@@ -206,6 +206,40 @@ const AEROPAC: HassDevice = {
 	},
 }
 
+// Inovelli RGBW devices using Multilevel Switch + Color Switch
+const INOVELLI_RGBW_DEVICE: HassDevice = {
+	type: 'light',
+    object_id: 'rgbw_bulb',
+    values: [
+        '38-0-currentValue',
+        '38-0-targetValue',
+        '51-0-currentColor',
+        '51-0-targetColor',
+    ],
+    discovery_payload: {
+        state_topic: '38-0-currentValue',
+        command_topic: '38-0-targetValue',
+        on_command_type: 'brightness',
+        brightness_state_topic: '38-0-currentValue',
+        brightness_command_topic: '38-0-targetValue',
+        state_value_template: '{{ "on" if value_json.value|int > 0 else "0" }}',
+        brightness_value_template: '{{ (value_json.value|int) | round(0) }}',
+        brightness_scale: '99',
+        color_temp_state_topic: '51-0-currentColor',
+        color_temp_command_template: "{{ {'warmWhite': ((0.7349 * (value - 153))|round(0)), 'coldWhite': (255 - (0.7349 * (value - 153))|round(0)), 'red': 255, 'green': 255, 'blue': 255}|to_json }}",
+        color_temp_command_topic: '51-0-targetColor',
+        color_temp_value_template: "{{ '%03d%03d' | format((value_json.value.warmWhite), (value_json.value.coldWhite)) }}",
+        rgb_command_template: "{{ {'warmWhite': 0, 'coldWhite': 0, 'red': red, 'green': green, 'blue': blue}|to_json }}",
+        rgb_command_topic: '51-0-targetColor',
+        rgb_state_topic: '51-0-currentColor',
+        rgb_value_template: '{{ value_json.value.red }},{{ value_json.value.green }},{{ value_json.value.blue }}',
+        min_mireds: 153,
+        max_mireds: 500,
+        payload_on: 'on',
+        payload_off: '0',
+	},
+}
+
 const devices: { [deviceId: string]: HassDevice[] } = {
 	'89-3-1': [
 		{
@@ -256,47 +290,6 @@ const devices: { [deviceId: string]: HassDevice[] } = {
 				current_temperature_template: '{{ value_json.value }}',
 				temperature_state_template: '{{ value_json.value }}',
 				temperature_command_topic: true,
-			},
-		},
-	],
-	'798-1-5': [
-		// Inovelli LZW42 Multi-Color Bulb
-		{
-			type: 'light',
-			object_id: 'rgbw_bulb',
-			values: [
-				'38-0-currentValue',
-				'38-0-targetValue',
-				'51-0-currentColor',
-				'51-0-targetColor',
-			],
-			discovery_payload: {
-				state_topic: '38-0-currentValue',
-				command_topic: '38-0-targetValue',
-				on_command_type: 'brightness',
-				brightness_state_topic: '38-0-currentValue',
-				brightness_command_topic: '38-0-targetValue',
-				state_value_template:
-					'{{ "on" if value_json.value|int > 0 else "0" }}',
-				brightness_value_template:
-					'{{ (value_json.value|int) | round(0) }}',
-				brightness_scale: '99',
-				color_temp_state_topic: '51-0-currentColor',
-				color_temp_command_template:
-					"{{ {'warmWhite': ((0.7349 * (value - 153))|round(0)), 'coldWhite': (255 - (0.7349 * (value - 153))|round(0)), 'red': 255, 'green': 255, 'blue': 255}|to_json }}",
-				color_temp_command_topic: '51-0-targetColor',
-				color_temp_value_template:
-					"{{ '%03d%03d' | format((value_json.value.warmWhite), (value_json.value.coldWhite)) }}",
-				rgb_command_template:
-					"{{ {'warmWhite': 0, 'coldWhite': 0, 'red': red, 'green': green, 'blue': blue}|to_json }}",
-				rgb_command_topic: '51-0-targetColor',
-				rgb_state_topic: '51-0-currentColor',
-				rgb_value_template:
-					'{{ value_json.value.red }},{{ value_json.value.green }},{{ value_json.value.blue }}',
-				min_mireds: 153,
-				max_mireds: 500,
-				payload_on: 'on',
-				payload_off: '0',
 			},
 		},
 	],
@@ -413,6 +406,8 @@ const devices: { [deviceId: string]: HassDevice[] } = {
 	'881-21-2': [SPIRIT_ZWAVE_PLUS], // Eurotronic Spirit / Aeotec ZWA021
 	'129-1-20': [AEROPAC], //Siegenia Aeropac
 	'2-32784-3': [THERMOSTAT_DANFOSS], // Danfoss Room Thermostat (MT2649 / DRS21) https://products.z-wavealliance.org/products/1062
+	'798-1-5': [INOVELLI_RGBW_DEVICE], // Inovelli LZW42 Multi-Color Bulb
+    '798-1-10': [INOVELLI_RGBW_DEVICE], // Inovelli LZW45 Light Strip
 }
 
 export default devices

--- a/api/hass/devices.ts
+++ b/api/hass/devices.ts
@@ -208,35 +208,35 @@ const AEROPAC: HassDevice = {
 
 // Inovelli RGBW devices using Multilevel Switch + Color Switch
 const INOVELLI_RGBW_DEVICE: HassDevice = {
-    type: 'light',
-    object_id: 'rgbw_bulb',
-    values: [
-        '38-0-currentValue',
-        '38-0-targetValue',
-        '51-0-currentColor',
-        '51-0-targetColor',
-    ],
-    discovery_payload: {
-        state_topic: '38-0-currentValue',
-        command_topic: '38-0-targetValue',
-        on_command_type: 'brightness',
-        brightness_state_topic: '38-0-currentValue',
-        brightness_command_topic: '38-0-targetValue',
-        state_value_template: '{{ "on" if value_json.value|int > 0 else "0" }}',
-        brightness_value_template: '{{ (value_json.value|int) | round(0) }}',
-        brightness_scale: '99',
-        color_temp_state_topic: '51-0-currentColor',
-        color_temp_command_template: "{{ {'warmWhite': ((0.7349 * (value - 153))|round(0)), 'coldWhite': (255 - (0.7349 * (value - 153))|round(0)), 'red': 255, 'green': 255, 'blue': 255}|to_json }}",
-        color_temp_command_topic: '51-0-targetColor',
-        color_temp_value_template: "{{ '%03d%03d' | format((value_json.value.warmWhite), (value_json.value.coldWhite)) }}",
-        rgb_command_template: "{{ {'warmWhite': 0, 'coldWhite': 0, 'red': red, 'green': green, 'blue': blue}|to_json }}",
-        rgb_command_topic: '51-0-targetColor',
-        rgb_state_topic: '51-0-currentColor',
-        rgb_value_template: '{{ value_json.value.red }},{{ value_json.value.green }},{{ value_json.value.blue }}',
-        min_mireds: 153,
-        max_mireds: 500,
-        payload_on: 'on',
-        payload_off: '0',
+	type: 'light',
+	object_id: 'rgbw_bulb',
+	values: [
+		'38-0-currentValue',
+		'38-0-targetValue',
+		'51-0-currentColor',
+		'51-0-targetColor',
+	],
+	discovery_payload: {
+		state_topic: '38-0-currentValue',
+		command_topic: '38-0-targetValue',
+		on_command_type: 'brightness',
+		brightness_state_topic: '38-0-currentValue',
+		brightness_command_topic: '38-0-targetValue',
+		state_value_template: '{{ "on" if value_json.value|int > 0 else "0" }}',
+		brightness_value_template: '{{ (value_json.value|int) | round(0) }}',
+		brightness_scale: '99',
+		color_temp_state_topic: '51-0-currentColor',
+		color_temp_command_template: "{{ {'warmWhite': ((0.7349 * (value - 153))|round(0)), 'coldWhite': (255 - (0.7349 * (value - 153))|round(0)), 'red': 255, 'green': 255, 'blue': 255}|to_json }}",
+		color_temp_command_topic: '51-0-targetColor',
+		color_temp_value_template: "{{ '%03d%03d' | format((value_json.value.warmWhite), (value_json.value.coldWhite)) }}",
+		rgb_command_template: "{{ {'warmWhite': 0, 'coldWhite': 0, 'red': red, 'green': green, 'blue': blue}|to_json }}",
+		rgb_command_topic: '51-0-targetColor',
+		rgb_state_topic: '51-0-currentColor',
+		rgb_value_template: '{{ value_json.value.red }},{{ value_json.value.green }},{{ value_json.value.blue }}',
+		min_mireds: 153,
+		max_mireds: 500,
+		payload_on: 'on',
+		payload_off: '0',
 	},
 }
 
@@ -406,8 +406,8 @@ const devices: { [deviceId: string]: HassDevice[] } = {
 	'881-21-2': [SPIRIT_ZWAVE_PLUS], // Eurotronic Spirit / Aeotec ZWA021
 	'129-1-20': [AEROPAC], //Siegenia Aeropac
 	'2-32784-3': [THERMOSTAT_DANFOSS], // Danfoss Room Thermostat (MT2649 / DRS21) https://products.z-wavealliance.org/products/1062
-    '798-1-5': [INOVELLI_RGBW_DEVICE], // Inovelli LZW42 Multi-Color Bulb
-    '798-1-10': [INOVELLI_RGBW_DEVICE], // Inovelli LZW45 Light Strip
+	'798-1-5': [INOVELLI_RGBW_DEVICE], // Inovelli LZW42 Multi-Color Bulb
+	'798-1-10': [INOVELLI_RGBW_DEVICE], // Inovelli LZW45 Light Strip
 }
 
 export default devices

--- a/api/hass/devices.ts
+++ b/api/hass/devices.ts
@@ -226,13 +226,17 @@ const INOVELLI_RGBW_DEVICE: HassDevice = {
 		brightness_value_template: '{{ (value_json.value|int) | round(0) }}',
 		brightness_scale: '99',
 		color_temp_state_topic: '51-0-currentColor',
-		color_temp_command_template: "{{ {'warmWhite': ((0.7349 * (value - 153))|round(0)), 'coldWhite': (255 - (0.7349 * (value - 153))|round(0)), 'red': 255, 'green': 255, 'blue': 255}|to_json }}",
+		color_temp_command_template:
+			"{{ {'warmWhite': ((0.7349 * (value - 153))|round(0)), 'coldWhite': (255 - (0.7349 * (value - 153))|round(0)), 'red': 255, 'green': 255, 'blue': 255}|to_json }}",
 		color_temp_command_topic: '51-0-targetColor',
-		color_temp_value_template: "{{ '%03d%03d' | format((value_json.value.warmWhite), (value_json.value.coldWhite)) }}",
-		rgb_command_template: "{{ {'warmWhite': 0, 'coldWhite': 0, 'red': red, 'green': green, 'blue': blue}|to_json }}",
+		color_temp_value_template:
+			"{{ '%03d%03d' | format((value_json.value.warmWhite), (value_json.value.coldWhite)) }}",
+		rgb_command_template:
+			"{{ {'warmWhite': 0, 'coldWhite': 0, 'red': red, 'green': green, 'blue': blue}|to_json }}",
 		rgb_command_topic: '51-0-targetColor',
 		rgb_state_topic: '51-0-currentColor',
-		rgb_value_template: '{{ value_json.value.red }},{{ value_json.value.green }},{{ value_json.value.blue }}',
+		rgb_value_template:
+			'{{ value_json.value.red }},{{ value_json.value.green }},{{ value_json.value.blue }}',
 		min_mireds: 153,
 		max_mireds: 500,
 		payload_on: 'on',

--- a/api/hass/devices.ts
+++ b/api/hass/devices.ts
@@ -406,7 +406,7 @@ const devices: { [deviceId: string]: HassDevice[] } = {
 	'881-21-2': [SPIRIT_ZWAVE_PLUS], // Eurotronic Spirit / Aeotec ZWA021
 	'129-1-20': [AEROPAC], //Siegenia Aeropac
 	'2-32784-3': [THERMOSTAT_DANFOSS], // Danfoss Room Thermostat (MT2649 / DRS21) https://products.z-wavealliance.org/products/1062
-	'798-1-5': [INOVELLI_RGBW_DEVICE], // Inovelli LZW42 Multi-Color Bulb
+    '798-1-5': [INOVELLI_RGBW_DEVICE], // Inovelli LZW42 Multi-Color Bulb
     '798-1-10': [INOVELLI_RGBW_DEVICE], // Inovelli LZW45 Light Strip
 }
 


### PR DESCRIPTION
## Summary

Add the Inovelli LZW45 Light Strip (`798-1-10`) to the existing `rgbw_bulb` Home Assistant MQTT discovery definition used by the Inovelli LZW42 Multi-Color Bulb (`798-1-5`).

## Problem

The LZW45 currently falls back to the generic `light_rgb_dimmer` discovery template. The generated MQTT discovery payload contains RGB, brightness, and color temperature support, but Home Assistant does not correctly expose or handle all color controls when discovered through this template.

Example of the generated discovery payload:

```json
"supported_color_modes": ["rgb", "brightness", "white"]
```

and

```jinja
{{ '%03d%03d' | format((value_json.value.warmWhite || 0), (value_json.value.coldWhite || 0)) }}
```

In testing, Home Assistant would create an entity that supported basic on/off and brightness control but did not reliably expose or operate RGB and color temperature controls.

## Investigation

The LZW42 already has a device-specific Home Assistant discovery override defined in `devices.ts` and is mapped to the `rgbw_bulb` template.

The LZW45 exposes the same relevant Command Class values used by the LZW42:

* `38-0-currentValue`
* `38-0-targetValue`
* `51-0-currentColor`
* `51-0-targetColor`

The Color Switch payload also contains the same RGB + Warm White + Cold White structure expected by the existing `rgbw_bulb` discovery template.

Manual testing was performed by replacing the generated `light_rgb_dimmer` discovery configuration with the LZW42 `light_rgbw_bulb` configuration. After rediscovery, Home Assistant correctly exposed:

* On/Off
* Brightness
* RGB Color Control
* Color Temperature Control

This behavior was reproduced on multiple LZW45 devices.

## Solution

Create a shared `INOVELLI_RGBW_DEVICE` definition and map both the LZW42 and LZW45 to it:

```ts
'798-1-5': [INOVELLI_RGBW_DEVICE],  // Inovelli LZW42 Multi-Color Bulb
'798-1-10': [INOVELLI_RGBW_DEVICE], // Inovelli LZW45 Light Strip
```

This reuses the existing, working `rgbw_bulb` discovery template rather than duplicating discovery definitions.

## Benefits

* Fixes MQTT Home Assistant discovery for LZW45 devices
* Provides working RGB and color temperature support
* Reuses the existing LZW42 implementation
* Reduces duplicated discovery definitions
* Keeps future maintenance centralized in a single shared template

## Testing

Verified using multiple Inovelli LZW45 Light Strips running firmware 1.20.x.

After deleting existing MQTT discovery topics and rediscovering devices:

* `light_rgbw_bulb` was generated automatically
* Home Assistant exposed brightness, RGB, and color temperature controls
* State and color updates were correctly synchronized through MQTT
* No changes were required to device firmware or Z-Wave configuration
