### PR TITLE
fix: prevent symlinks from escaping the store directory

### DIFF
--- a/api/app.ts
+++ b/api/app.ts
@@ -2014,7 +2014,6 @@ app.put(
 		try {
 			const files = req.body.files || []
 			for (const f of files) {
-				// lgtm [js/path-injection]
 				await rm(await getSafePath(f), { recursive: true, force: true })
 			}
 			res.json({ success: true })

--- a/api/app.ts
+++ b/api/app.ts
@@ -395,32 +395,28 @@ async function assertRealPathInStore(target: string) {
 }
 
 /**
- * Get the `path` param from a request. Throws if the path is not safe.
- * Performs a string confinement check and, when `resolveReal` is set,
- * additionally resolves the real path of the nearest existing ancestor to
- * guard against symlinked components escaping `storeDir`.
+ * Get the `path` param from a request. Throws if the path is not safe - that is if it escapes the storeDir.
  */
 async function getSafePath(req: Request | string, resolveReal = true) {
-	let reqPath = typeof req === 'string' ? req : req.query.path
+	const reqPath = typeof req === 'string' ? req : req.query.path
 
 	if (typeof reqPath !== 'string') {
 		throw Error('Invalid path')
 	}
 
-	reqPath = path.normalize(reqPath)
+	// path.resolve collapses any `..` segments and yields an absolute path, so
+	// the prefix check below cannot be bypassed with traversal sequences.
+	const safePath = path.resolve(storeDir, reqPath)
 
-	if (
-		(!reqPath.startsWith(storeDir + path.sep) && reqPath !== storeDir) ||
-		reqPath === storeDir
-	) {
+	if (safePath === storeDir || !safePath.startsWith(storeDir + path.sep)) {
 		throw Error('Path not allowed')
 	}
 
 	if (resolveReal) {
-		await assertRealPathInStore(reqPath)
+		await assertRealPathInStore(safePath)
 	}
 
-	return reqPath
+	return safePath
 }
 
 async function loadCertKey(): Promise<{

--- a/api/app.ts
+++ b/api/app.ts
@@ -2010,7 +2010,13 @@ app.post(
 			const s = await lstat(f)
 			const name = f.replace(storeDir, '')
 			if (s.isFile()) {
-				archive.file(f, { name })
+				try {
+					// check path is secure, if so add it as file
+					getSafePath(f)
+					archive.file(f, { name })
+				} catch (e) {
+					// ignore
+				}
 			} else if (s.isSymbolicLink()) {
 				const targetPath = await realpath(f)
 				try {

--- a/api/app.ts
+++ b/api/app.ts
@@ -1968,7 +1968,8 @@ app.put(
 		try {
 			const files = req.body.files || []
 			for (const f of files) {
-				await rm(f, { recursive: true, force: true })
+				// lgtm [js/path-injection]
+				await rm(getSafePath(f), { recursive: true, force: true })
 			}
 			res.json({ success: true })
 		} catch (error) {

--- a/api/app.ts
+++ b/api/app.ts
@@ -375,12 +375,17 @@ async function assertRealPathInStore(target: string) {
 
 	while (true) {
 		try {
+			// If the path exists, check if it is a symlink that escapes the store
 			const real = await realpath(current)
 			if (real !== storeDir && !real.startsWith(storeDir + path.sep)) {
 				throw Error('Path not allowed')
 			}
+			// We found an existing non-symlink target within the store,
+			// so the given path is safe to use (whether it exists or not)
 			return
 		} catch (err) {
+			// If the path does not exist, e.g. when creating a directory,
+			// walk up to the nearest existing ancestor and check that.
 			if (err?.code !== 'ENOENT') {
 				throw err
 			}

--- a/api/app.ts
+++ b/api/app.ts
@@ -2077,7 +2077,7 @@ app.put(
 			const files = req.body.files || []
 			for (const f of files) {
 				// lgtm [js/path-injection]
-				await rm(getSafePath(f), { recursive: true, force: true })
+				await rm(await getSafePath(f), { recursive: true, force: true })
 			}
 			res.json({ success: true })
 		} catch (error) {
@@ -2120,7 +2120,7 @@ app.post(
 			if (s.isFile()) {
 				try {
 					// check path is secure, if so add it as file
-					getSafePath(f)
+					await getSafePath(f)
 					archive.file(f, { name })
 				} catch (e) {
 					// ignore

--- a/api/app.ts
+++ b/api/app.ts
@@ -17,7 +17,6 @@ import type { CallAPIResult, ZwaveConfig } from './lib/ZwaveClient.ts'
 import ZWaveClient from './lib/ZwaveClient.ts'
 import multer, { diskStorage } from 'multer'
 import extract from 'extract-zip'
-import * as yauzl from 'yauzl'
 import { serverVersion } from '@zwave-js/server'
 import archiver from 'archiver'
 import rateLimit from 'express-rate-limit'
@@ -34,6 +33,7 @@ import { Driver, libVersion } from 'zwave-js'
 import {
 	defaultPsw,
 	defaultUser,
+	logsDir,
 	sessionSecret,
 	snippetsDir,
 	storeDir,
@@ -64,6 +64,8 @@ import {
 	writeFile,
 	lstat,
 	mkdir,
+	mkdtemp,
+	cp,
 } from 'node:fs/promises'
 import { generate } from 'selfsigned'
 import type { ZnifferConfig } from './lib/ZnifferManager.ts'
@@ -357,71 +359,6 @@ async function getSnippets() {
 }
 
 /**
- * Scan a zip archive's central directory and reject it if any entry is not a
- * regular file or directory (e.g. symlinks or device/special files). This is
- * done before extraction because extract-zip materializes such entries
- * verbatim, which could be abused to plant a link escaping `storeDir`.
- */
-function assertArchiveHasNoLinks(zipPath: string): Promise<void> {
-	const IFMT = 0o170000
-	const IFDIR = 0o040000
-	const IFREG = 0o100000
-
-	return new Promise((resolve, reject) => {
-		yauzl.open(
-			zipPath,
-			{ lazyEntries: true },
-			(err, zipfile) => {
-				if (err || !zipfile) {
-					return reject(err ?? Error('Invalid archive'))
-				}
-
-				let settled = false
-				const fail = (e: Error) => {
-					if (settled) return
-					settled = true
-					zipfile.close()
-					reject(e)
-				}
-
-				zipfile.on('entry', (entry: yauzl.Entry) => {
-					// Convert the external file attributes into a unix stat mode
-					const mode = (entry.externalFileAttributes >>> 16) & 0xffff
-					const fmt = mode & IFMT
-
-					const isDir =
-						fmt === IFDIR || entry.fileName.endsWith('/')
-					// mode is 0 for archives created without unix attributes
-					// (e.g. plain Windows zips) - treat those as regular files
-					const isRegular = fmt === IFREG || mode === 0
-
-					if (!isDir && !isRegular) {
-						return fail(
-							Error(
-								`Restore archive contains an unsupported entry: ${entry.fileName}`,
-							),
-						)
-					}
-
-					zipfile.readEntry()
-				})
-
-				zipfile.on('end', () => {
-					if (settled) return
-					settled = true
-					zipfile.close()
-					resolve()
-				})
-
-				zipfile.on('error', fail)
-
-				zipfile.readEntry()
-			},
-		)
-	})
-}
-
-/**
  * Resolve the real path of the nearest existing ancestor of `target` and
  * ensure it is still confined within `storeDir`. This defeats symlinked
  * path components (which a plain string prefix check is blind to) for both
@@ -431,7 +368,7 @@ async function assertRealPathInStore(target: string) {
 	let current = target
 
 	// Walk up until we hit an existing ancestor (the target itself may be new)
-	// eslint-disable-next-line no-constant-condition
+
 	while (true) {
 		try {
 			const real = await realpath(current)
@@ -1504,6 +1441,7 @@ app.post(
 							// Build logConfig object from our settings
 							editableOptions.logConfig = utils.buildLogConfig(
 								settings.zwave || {},
+								logsDir,
 							)
 						}
 
@@ -2177,11 +2115,19 @@ app.post(
 			}
 
 			if (isRestore) {
-				// Reject archives containing symlink/hardlink/device entries:
-				// extract-zip materializes them verbatim, which could plant a
-				// link escaping storeDir for a later write to follow.
-				await assertArchiveHasNoLinks(file.path)
-				await extract(file.path, { dir: storeDir })
+				// Stage, reject symlinks escaping the store, then merge in.
+				const stageDir = await mkdtemp(path.join(storeDir, '.restore-'))
+				try {
+					await extract(file.path, { dir: stageDir })
+					await utils.assertNoEscapingSymlinks(stageDir, stageDir)
+					await cp(stageDir, storeDir, {
+						recursive: true,
+						// keep in-store links (e.g. *_current.log) as links, don't copy their targets
+						verbatimSymlinks: true,
+					})
+				} finally {
+					await rm(stageDir, { recursive: true, force: true })
+				}
 			} else {
 				const destinationPath = await getSafePath(
 					path.join(storeDir, folder, file.originalname),

--- a/api/app.ts
+++ b/api/app.ts
@@ -17,6 +17,7 @@ import type { CallAPIResult, ZwaveConfig } from './lib/ZwaveClient.ts'
 import ZWaveClient from './lib/ZwaveClient.ts'
 import multer, { diskStorage } from 'multer'
 import extract from 'extract-zip'
+import * as yauzl from 'yauzl'
 import { serverVersion } from '@zwave-js/server'
 import archiver from 'archiver'
 import rateLimit from 'express-rate-limit'
@@ -356,9 +357,109 @@ async function getSnippets() {
 }
 
 /**
- * Get the `path` param from a request. Throws if the path is not safe
+ * Scan a zip archive's central directory and reject it if any entry is not a
+ * regular file or directory (e.g. symlinks or device/special files). This is
+ * done before extraction because extract-zip materializes such entries
+ * verbatim, which could be abused to plant a link escaping `storeDir`.
  */
-function getSafePath(req: Request | string) {
+function assertArchiveHasNoLinks(zipPath: string): Promise<void> {
+	const IFMT = 0o170000
+	const IFDIR = 0o040000
+	const IFREG = 0o100000
+
+	return new Promise((resolve, reject) => {
+		yauzl.open(
+			zipPath,
+			{ lazyEntries: true },
+			(err, zipfile) => {
+				if (err || !zipfile) {
+					return reject(err ?? Error('Invalid archive'))
+				}
+
+				let settled = false
+				const fail = (e: Error) => {
+					if (settled) return
+					settled = true
+					zipfile.close()
+					reject(e)
+				}
+
+				zipfile.on('entry', (entry: yauzl.Entry) => {
+					// Convert the external file attributes into a unix stat mode
+					const mode = (entry.externalFileAttributes >>> 16) & 0xffff
+					const fmt = mode & IFMT
+
+					const isDir =
+						fmt === IFDIR || entry.fileName.endsWith('/')
+					// mode is 0 for archives created without unix attributes
+					// (e.g. plain Windows zips) - treat those as regular files
+					const isRegular = fmt === IFREG || mode === 0
+
+					if (!isDir && !isRegular) {
+						return fail(
+							Error(
+								`Restore archive contains an unsupported entry: ${entry.fileName}`,
+							),
+						)
+					}
+
+					zipfile.readEntry()
+				})
+
+				zipfile.on('end', () => {
+					if (settled) return
+					settled = true
+					zipfile.close()
+					resolve()
+				})
+
+				zipfile.on('error', fail)
+
+				zipfile.readEntry()
+			},
+		)
+	})
+}
+
+/**
+ * Resolve the real path of the nearest existing ancestor of `target` and
+ * ensure it is still confined within `storeDir`. This defeats symlinked
+ * path components (which a plain string prefix check is blind to) for both
+ * existing and not-yet-created paths.
+ */
+async function assertRealPathInStore(target: string) {
+	let current = target
+
+	// Walk up until we hit an existing ancestor (the target itself may be new)
+	// eslint-disable-next-line no-constant-condition
+	while (true) {
+		try {
+			const real = await realpath(current)
+			if (real !== storeDir && !real.startsWith(storeDir + path.sep)) {
+				throw Error('Path not allowed')
+			}
+			return
+		} catch (err) {
+			if (err?.code !== 'ENOENT') {
+				throw err
+			}
+			const parent = path.dirname(current)
+			if (parent === current) {
+				// reached filesystem root without finding an existing ancestor
+				throw Error('Path not allowed')
+			}
+			current = parent
+		}
+	}
+}
+
+/**
+ * Get the `path` param from a request. Throws if the path is not safe.
+ * Performs a string confinement check and, when `resolveReal` is set,
+ * additionally resolves the real path of the nearest existing ancestor to
+ * guard against symlinked components escaping `storeDir`.
+ */
+async function getSafePath(req: Request | string, resolveReal = true) {
 	let reqPath = typeof req === 'string' ? req : req.query.path
 
 	if (typeof reqPath !== 'string') {
@@ -367,8 +468,15 @@ function getSafePath(req: Request | string) {
 
 	reqPath = path.normalize(reqPath)
 
-	if (!reqPath.startsWith(storeDir) || reqPath === storeDir) {
+	if (
+		(!reqPath.startsWith(storeDir + path.sep) && reqPath !== storeDir) ||
+		reqPath === storeDir
+	) {
 		throw Error('Path not allowed')
+	}
+
+	if (resolveReal) {
+		await assertRealPathInStore(reqPath)
 	}
 
 	return reqPath
@@ -1873,14 +1981,14 @@ app.get('/api/store', storeLimiter, isAuthenticated, async function (req, res) {
 	try {
 		let data: StoreFileEntry[] | string
 		if (req.query.path) {
-			const reqPath = getSafePath(req)
+			const reqPath = await getSafePath(req)
 			// lgtm [js/path-injection]
 			let stat = await lstat(reqPath)
 
 			// check symlink is secure
 			if (stat.isSymbolicLink()) {
 				const realPath = await realpath(reqPath)
-				getSafePath(realPath)
+				await getSafePath(realPath)
 				stat = await lstat(realPath)
 			}
 
@@ -1912,7 +2020,7 @@ app.get('/api/store', storeLimiter, isAuthenticated, async function (req, res) {
 
 app.put('/api/store', storeLimiter, isAuthenticated, async function (req, res) {
 	try {
-		const reqPath = getSafePath(req)
+		const reqPath = await getSafePath(req)
 
 		const isNew = req.query.isNew === 'true'
 		const isDirectory = req.query.isDirectory === 'true'
@@ -1947,7 +2055,7 @@ app.delete(
 	isAuthenticated,
 	async function (req, res) {
 		try {
-			const reqPath = getSafePath(req)
+			const reqPath = await getSafePath(req)
 
 			// lgtm [js/path-injection]
 			await rm(reqPath, { recursive: true, force: true })
@@ -2021,7 +2129,7 @@ app.post(
 				const targetPath = await realpath(f)
 				try {
 					// check path is secure, if so add it as file
-					getSafePath(targetPath)
+					await getSafePath(targetPath)
 					archive.file(targetPath, { name })
 				} catch (e) {
 					// ignore
@@ -2069,9 +2177,13 @@ app.post(
 			}
 
 			if (isRestore) {
+				// Reject archives containing symlink/hardlink/device entries:
+				// extract-zip materializes them verbatim, which could plant a
+				// link escaping storeDir for a later write to follow.
+				await assertArchiveHasNoLinks(file.path)
 				await extract(file.path, { dir: storeDir })
 			} else {
-				const destinationPath = getSafePath(
+				const destinationPath = await getSafePath(
 					path.join(storeDir, folder, file.originalname),
 				)
 				await rename(file.path, destinationPath)

--- a/api/lib/ZwaveClient.ts
+++ b/api/lib/ZwaveClient.ts
@@ -119,7 +119,7 @@ import {
 	BatteryReplacementStatus,
 } from 'zwave-js'
 import { getEnumMemberName, parseQRCodeString } from 'zwave-js/Utils'
-import { configDbDir, nvmBackupsDir, storeDir } from '../config/app.ts'
+import { configDbDir, logsDir, nvmBackupsDir, storeDir } from '../config/app.ts'
 import store from '../config/store.ts'
 import jsonStore from './jsonStore.ts'
 import * as LogManager from './logger.ts'
@@ -2289,7 +2289,7 @@ class ZwaveClient extends TypedEventEmitter<ZwaveClientEventCallbacks> {
 					this.cfg.deviceConfigPriorityDir || deviceConfigPriorityDir,
 			},
 			// https://zwave-js.github.io/node-zwave-js/#/api/driver?id=logconfig
-			logConfig: utils.buildLogConfig(this.cfg),
+			logConfig: utils.buildLogConfig(this.cfg, logsDir),
 			emitValueUpdateAfterSetValue: true,
 			apiKeys: {
 				firmwareUpdateService:

--- a/api/lib/utils.ts
+++ b/api/lib/utils.ts
@@ -5,9 +5,8 @@ import { readFileSync, statSync } from 'node:fs'
 import type { ZwaveConfig } from './ZwaveClient.ts'
 import { isUint8Array } from 'node:util/types'
 import { createRequire } from 'node:module'
-import { mkdir, access } from 'node:fs/promises'
+import { mkdir, access, readdir, readlink } from 'node:fs/promises'
 import { fileURLToPath } from 'node:url'
-import { logsDir } from '../config/app.ts'
 import tripleBeam from 'triple-beam'
 
 const loglevels = tripleBeam.configs.npm.levels
@@ -502,10 +501,40 @@ export function buildPreferences(
 }
 
 /**
+ * Throw if any symlink under `dir` resolves outside `root`. Targets are
+ * resolved literally (not followed), so dangling links work and the walk
+ * never leaves `root`. Permits in-store links (e.g. `*_current.log`).
+ */
+export async function assertNoEscapingSymlinks(
+	dir: string,
+	root: string,
+): Promise<void> {
+	const entries = await readdir(dir, { withFileTypes: true })
+
+	for (const entry of entries) {
+		const full = path.join(dir, entry.name)
+
+		if (entry.isSymbolicLink()) {
+			const target = await readlink(full)
+			const resolved = path.resolve(path.dirname(full), target)
+
+			if (resolved !== root && !resolved.startsWith(root + path.sep)) {
+				throw Error(
+					`Archive contains a symlink escaping the store: ${entry.name}`,
+				)
+			}
+		} else if (entry.isDirectory()) {
+			await assertNoEscapingSymlinks(full, root)
+		}
+	}
+}
+
+/**
  * Build logConfig object for Z-Wave driver options from Z-Wave configuration
  */
 export function buildLogConfig(
 	config: ZwaveConfig,
+	logsDir: string,
 ): PartialZWaveOptions['logConfig'] {
 	return {
 		enabled: config.logEnabled,

--- a/test/lib/utils.test.ts
+++ b/test/lib/utils.test.ts
@@ -4,8 +4,14 @@ import type { SinonStub } from 'sinon'
 import sinon from 'sinon'
 
 import sinonChai from 'sinon-chai'
+import chaiAsPromised from 'chai-as-promised'
+import { mkdtemp, mkdir, writeFile, symlink, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import nodePath from 'node:path'
+import { assertNoEscapingSymlinks } from '../../api/lib/utils.ts'
 
 chai.use(sinonChai)
+chai.use(chaiAsPromised)
 
 declare let process: NodeJS.Process & {
 	pkg?: boolean
@@ -71,6 +77,62 @@ describe('#utils', () => {
 				snapshotPath,
 				'bar',
 			)
+		})
+	})
+
+	describe('#assertNoEscapingSymlinks()', () => {
+		let root: string
+
+		beforeEach(async () => {
+			root = await mkdtemp(nodePath.join(tmpdir(), 'zui-symlink-test-'))
+		})
+
+		afterEach(async () => {
+			await rm(root, { recursive: true, force: true })
+		})
+
+		it('resolves for a tree of only files and directories', async () => {
+			await mkdir(nodePath.join(root, 'sub'))
+			await writeFile(nodePath.join(root, 'sub', 'a.json'), '{}')
+			await expect(assertNoEscapingSymlinks(root, root)).to.be.fulfilled
+		})
+
+		it('allows a relative symlink pointing inside the root', async () => {
+			await writeFile(nodePath.join(root, 'zwavejs_2024.log'), 'log')
+			await symlink(
+				'zwavejs_2024.log',
+				nodePath.join(root, 'zwavejs_current.log'),
+			)
+			await expect(assertNoEscapingSymlinks(root, root)).to.be.fulfilled
+		})
+
+		it('allows a relative in-root symlink nested in a subdirectory', async () => {
+			await mkdir(nodePath.join(root, 'logs'))
+			await writeFile(nodePath.join(root, 'logs', 'a.log'), 'log')
+			await symlink('a.log', nodePath.join(root, 'logs', 'current.log'))
+			await expect(assertNoEscapingSymlinks(root, root)).to.be.fulfilled
+		})
+
+		it('rejects an absolute symlink escaping the root', async () => {
+			await symlink('/etc/passwd', nodePath.join(root, 'settings.json'))
+			await expect(
+				assertNoEscapingSymlinks(root, root),
+			).to.be.rejectedWith(/escaping the store/)
+		})
+
+		it('rejects a relative symlink escaping the root via ..', async () => {
+			await symlink('../../../../etc/passwd', nodePath.join(root, 'evil'))
+			await expect(
+				assertNoEscapingSymlinks(root, root),
+			).to.be.rejectedWith(/escaping the store/)
+		})
+
+		it('rejects an escaping symlink nested in a subdirectory', async () => {
+			await mkdir(nodePath.join(root, 'nested'))
+			await symlink('../../../etc', nodePath.join(root, 'nested', 'out'))
+			await expect(
+				assertNoEscapingSymlinks(root, root),
+			).to.be.rejectedWith(/escaping the store/)
 		})
 	})
 })


### PR DESCRIPTION
The `PUT/POST` `/api/store-multi` endpoints and the backup-restore flow took user-supplied paths and applied only a string-prefix check, so an authenticated user could delete or ZIP-export files outside storeDir, and a restore archive could plant a symlink that escaped `storeDir` to write arbitrary files. The shared `getSafePath()` helper never resolved real paths, so symlinked components defeated the confinement.

With this PR, `getSafePath()` now normalizes paths relative to the `storeDir` and resolves the targets of symlinks, optionally throwing if a path ends up pointing outside the store.
Also, the restore flow now stages the ZIP file contents, and checks them for symlinks that would point outside the store, before restoring the archive.