### PR TITLE
fix: confine store paths against the resolved store dir

### DIFF
--- a/api/app.ts
+++ b/api/app.ts
@@ -363,65 +363,11 @@ async function getSnippets() {
 }
 
 /**
- * Resolve the real path of the nearest existing ancestor of `target` and
- * ensure it is still confined within `storeDir`. This defeats symlinked
- * path components (which a plain string prefix check is blind to) for both
- * existing and not-yet-created paths.
- */
-async function assertRealPathInStore(target: string) {
-	let current = target
-
-	// Walk up until we hit an existing ancestor (the target itself may be new)
-
-	while (true) {
-		try {
-			// If the path exists, check if it is a symlink that escapes the store
-			const real = await realpath(current)
-			if (real !== storeDir && !real.startsWith(storeDir + path.sep)) {
-				throw Error('Path not allowed')
-			}
-			// We found an existing non-symlink target within the store,
-			// so the given path is safe to use (whether it exists or not)
-			return
-		} catch (err) {
-			// If the path does not exist, e.g. when creating a directory,
-			// walk up to the nearest existing ancestor and check that.
-			if (err?.code !== 'ENOENT') {
-				throw err
-			}
-			const parent = path.dirname(current)
-			if (parent === current) {
-				// reached filesystem root without finding an existing ancestor
-				throw Error('Path not allowed')
-			}
-			current = parent
-		}
-	}
-}
-
-/**
  * Get the `path` param from a request. Throws if the path is not safe - that is if it escapes the storeDir.
  */
 async function getSafePath(req: Request | string, resolveReal = true) {
 	const reqPath = typeof req === 'string' ? req : req.query.path
-
-	if (typeof reqPath !== 'string') {
-		throw Error('Invalid path')
-	}
-
-	// path.resolve collapses any `..` segments and yields an absolute path, so
-	// the prefix check below cannot be bypassed with traversal sequences.
-	const safePath = path.resolve(storeDir, reqPath)
-
-	if (safePath === storeDir || !safePath.startsWith(storeDir + path.sep)) {
-		throw Error('Path not allowed')
-	}
-
-	if (resolveReal) {
-		await assertRealPathInStore(safePath)
-	}
-
-	return safePath
+	return utils.resolveSafeStorePath(reqPath, storeDir, resolveReal)
 }
 
 async function loadCertKey(): Promise<{
@@ -2080,25 +2026,22 @@ app.post(
 		archive.pipe(res)
 
 		for (const f of files) {
-			const s = await lstat(f)
-			const name = f.replace(storeDir, '')
-			if (s.isFile()) {
-				try {
-					// check path is secure, if so add it as file
-					await getSafePath(f)
-					archive.file(f, { name })
-				} catch (e) {
-					// ignore
-				}
-			} else if (s.isSymbolicLink()) {
-				const targetPath = await realpath(f)
-				try {
-					// check path is secure, if so add it as file
-					await getSafePath(targetPath)
+			try {
+				// confine the path to the store *before* touching the
+				// filesystem, so unsafe paths can't be probed via lstat/realpath
+				const safe = await getSafePath(f)
+				const s = await lstat(safe)
+				const name = safe.replace(storeDir, '')
+				if (s.isFile()) {
+					archive.file(safe, { name })
+				} else if (s.isSymbolicLink()) {
+					// getSafePath already resolved the link target and checked
+					// it stays in the store; add the dereferenced target
+					const targetPath = await realpath(safe)
 					archive.file(targetPath, { name })
-				} catch (e) {
-					// ignore
 				}
+			} catch (e) {
+				// ignore unsafe or unreadable entries
 			}
 		}
 

--- a/api/lib/utils.ts
+++ b/api/lib/utils.ts
@@ -5,7 +5,7 @@ import { readFileSync, statSync } from 'node:fs'
 import type { ZwaveConfig } from './ZwaveClient.ts'
 import { isUint8Array } from 'node:util/types'
 import { createRequire } from 'node:module'
-import { mkdir, access, readdir, readlink } from 'node:fs/promises'
+import { mkdir, access, readdir, readlink, realpath } from 'node:fs/promises'
 import { fileURLToPath } from 'node:url'
 import tripleBeam from 'triple-beam'
 import { MAX_NODES_LR } from '@zwave-js/core'
@@ -562,6 +562,84 @@ export async function assertNoEscapingSymlinks(
 			await assertNoEscapingSymlinks(full, root)
 		}
 	}
+}
+
+/**
+ * Resolve the real path of the nearest existing ancestor of `target` and
+ * ensure it is still confined within `storeDir`. This defeats symlinked
+ * path components (which a plain string prefix check is blind to) for both
+ * existing and not-yet-created paths.
+ *
+ * The comparison is made against the *resolved* `storeDir` because the
+ * configured store path may itself traverse a symlink (e.g. a bind-mounted
+ * data dir, or `/tmp` -> `/private/tmp`); comparing a resolved target against
+ * an unresolved root would reject every legitimate path on such setups.
+ */
+export async function assertRealPathInStore(
+	target: string,
+	storeDir: string,
+): Promise<void> {
+	const realStoreDir = await realpath(storeDir)
+	let current = target
+
+	// Walk up until we hit an existing ancestor (the target itself may be new)
+
+	while (true) {
+		try {
+			// If the path exists, check if it is a symlink that escapes the store
+			const real = await realpath(current)
+			if (
+				real !== realStoreDir &&
+				!real.startsWith(realStoreDir + path.sep)
+			) {
+				throw Error('Path not allowed')
+			}
+			// We found an existing non-symlink target within the store,
+			// so the given path is safe to use (whether it exists or not)
+			return
+		} catch (err) {
+			// If the path does not exist, e.g. when creating a directory,
+			// walk up to the nearest existing ancestor and check that.
+			if (err?.code !== 'ENOENT') {
+				throw err
+			}
+			const parent = path.dirname(current)
+			if (parent === current) {
+				// reached filesystem root without finding an existing ancestor
+				throw Error('Path not allowed')
+			}
+			current = parent
+		}
+	}
+}
+
+/**
+ * Resolve `reqPath` against `storeDir` and throw if it is not safe - that is
+ * if it escapes the storeDir. When `resolveReal` is set, symlinked path
+ * components are resolved too (see {@link assertRealPathInStore}).
+ */
+export async function resolveSafeStorePath(
+	reqPath: unknown,
+	storeDir: string,
+	resolveReal = true,
+): Promise<string> {
+	if (typeof reqPath !== 'string') {
+		throw Error('Invalid path')
+	}
+
+	// path.resolve collapses any `..` segments and yields an absolute path, so
+	// the prefix check below cannot be bypassed with traversal sequences.
+	const safePath = path.resolve(storeDir, reqPath)
+
+	if (safePath === storeDir || !safePath.startsWith(storeDir + path.sep)) {
+		throw Error('Path not allowed')
+	}
+
+	if (resolveReal) {
+		await assertRealPathInStore(safePath, storeDir)
+	}
+
+	return safePath
 }
 
 /**

--- a/test/lib/utils.test.ts
+++ b/test/lib/utils.test.ts
@@ -5,10 +5,20 @@ import sinon from 'sinon'
 
 import sinonChai from 'sinon-chai'
 import chaiAsPromised from 'chai-as-promised'
-import { mkdtemp, mkdir, writeFile, symlink, rm } from 'node:fs/promises'
+import {
+	mkdtemp,
+	mkdir,
+	writeFile,
+	symlink,
+	rm,
+	realpath,
+} from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import nodePath from 'node:path'
-import { assertNoEscapingSymlinks } from '../../api/lib/utils.ts'
+import {
+	assertNoEscapingSymlinks,
+	resolveSafeStorePath,
+} from '../../api/lib/utils.ts'
 
 chai.use(sinonChai)
 chai.use(chaiAsPromised)
@@ -133,6 +143,88 @@ describe('#utils', () => {
 			await expect(
 				assertNoEscapingSymlinks(root, root),
 			).to.be.rejectedWith(/escaping the store/)
+		})
+	})
+
+	describe('#resolveSafeStorePath()', () => {
+		const tmpDirs: string[] = []
+
+		// canonical (symlink-free) store dir so the base path itself never
+		// triggers the symlink-confinement logic in the "happy path" tests
+		async function makeTmpDir(prefix: string): Promise<string> {
+			const dir = await realpath(
+				await mkdtemp(nodePath.join(tmpdir(), prefix)),
+			)
+			tmpDirs.push(dir)
+			return dir
+		}
+
+		afterEach(async () => {
+			while (tmpDirs.length) {
+				await rm(tmpDirs.pop(), { recursive: true, force: true })
+			}
+		})
+
+		it('resolves a normal path within the store', async () => {
+			const store = await makeTmpDir('zui-safe-path-')
+			await mkdir(nodePath.join(store, 'sub'))
+			await writeFile(nodePath.join(store, 'sub', 'a.json'), '{}')
+			await expect(
+				resolveSafeStorePath('sub/a.json', store),
+			).to.eventually.equal(nodePath.join(store, 'sub', 'a.json'))
+		})
+
+		it('rejects a non-string path', async () => {
+			const store = await makeTmpDir('zui-safe-path-')
+			await expect(
+				resolveSafeStorePath(undefined, store),
+			).to.be.rejectedWith(/Invalid path/)
+		})
+
+		it('rejects a path equal to the store dir', async () => {
+			const store = await makeTmpDir('zui-safe-path-')
+			await expect(resolveSafeStorePath('', store)).to.be.rejectedWith(
+				/Path not allowed/,
+			)
+		})
+
+		it('rejects a traversal path escaping the store', async () => {
+			const store = await makeTmpDir('zui-safe-path-')
+			await expect(
+				resolveSafeStorePath('../../etc/passwd', store),
+			).to.be.rejectedWith(/Path not allowed/)
+		})
+
+		it('rejects a symlinked component escaping the store', async () => {
+			const store = await makeTmpDir('zui-safe-path-')
+			await symlink('/etc', nodePath.join(store, 'evil'))
+			await expect(
+				resolveSafeStorePath('evil/passwd', store),
+			).to.be.rejectedWith(/Path not allowed/)
+		})
+
+		it('skips the symlink check when resolveReal is false', async () => {
+			const store = await makeTmpDir('zui-safe-path-')
+			await symlink('/etc', nodePath.join(store, 'evil'))
+			await expect(
+				resolveSafeStorePath('evil/passwd', store, false),
+			).to.eventually.equal(nodePath.join(store, 'evil', 'passwd'))
+		})
+
+		// Regression: the store dir itself may be reached through a symlink
+		// (bind-mounted data dirs, symlinked $HOME, /tmp -> /private/tmp, ...).
+		// A resolved target must be compared against the *resolved* store root,
+		// otherwise every legitimate path is rejected on such setups.
+		it('allows a path when the store dir is reached through a symlink', async () => {
+			const realStore = await makeTmpDir('zui-safe-path-real-')
+			const linkParent = await makeTmpDir('zui-safe-path-link-')
+			const linkedStore = nodePath.join(linkParent, 'store-link')
+			await symlink(realStore, linkedStore)
+			await writeFile(nodePath.join(realStore, 'settings.json'), '{}')
+
+			await expect(
+				resolveSafeStorePath('settings.json', linkedStore),
+			).to.eventually.equal(nodePath.join(linkedStore, 'settings.json'))
 		})
 	})
 

--- a/test/lib/utils.test.ts
+++ b/test/lib/utils.test.ts
@@ -174,6 +174,17 @@ describe('#utils', () => {
 			).to.eventually.equal(nodePath.join(store, 'sub', 'a.json'))
 		})
 
+		it('allows a not-yet-existing path inside the store', async () => {
+			// exercises the walk-up to the nearest existing ancestor (e.g. PUT
+			// creating a new file/dir); neither newdir nor newfile.json exist
+			const store = await makeTmpDir('zui-safe-path-')
+			await expect(
+				resolveSafeStorePath('newdir/newfile.json', store),
+			).to.eventually.equal(
+				nodePath.join(store, 'newdir', 'newfile.json'),
+			)
+		})
+
 		it('rejects a non-string path', async () => {
 			const store = await makeTmpDir('zui-safe-path-')
 			await expect(
@@ -200,6 +211,16 @@ describe('#utils', () => {
 			await symlink('/etc', nodePath.join(store, 'evil'))
 			await expect(
 				resolveSafeStorePath('evil/passwd', store),
+			).to.be.rejectedWith(/Path not allowed/)
+		})
+
+		it('rejects a new path under a symlinked-escaping ancestor', async () => {
+			// the escaping symlink is an existing ancestor of a not-yet-existing
+			// target, so the walk-up must reject it rather than keep climbing
+			const store = await makeTmpDir('zui-safe-path-')
+			await symlink('/etc', nodePath.join(store, 'evil'))
+			await expect(
+				resolveSafeStorePath('evil/newdir/newfile.json', store),
 			).to.be.rejectedWith(/Path not allowed/)
 		})
 


### PR DESCRIPTION
Follow-up hardening on top of the store path-traversal fix in #4678. Three issues surfaced in review of that change:

### 1. `storeDir` was not canonicalized (functional regression — could break real deployments)

`getSafePath` → `assertRealPathInStore` compared a `realpath`-resolved target against the **unresolved** `storeDir`:

```ts
const real = await realpath(current)
if (real !== storeDir && !real.startsWith(storeDir + path.sep)) // storeDir is lexical
```

`storeDir` is `process.env.STORE_DIR || joinPath(...)` and is never resolved (`joinPath` is just `path.join`). When the configured store path itself traverses a symlink — common in this project's self-hosted/Docker/NAS audience (bind-mounted `/data`→`/mnt/...`, symlinked `$HOME`, `/tmp`→`/private/tmp` on macOS) — `realpath(target)` no longer starts with the lexical `storeDir`, so **every** store read/write/delete/export/restore is rejected with `Path not allowed`.

The pre-#4678 code compared lexical-to-lexical, so it worked; switching to `realpath` introduced the mismatch. Fixed by comparing the resolved target against the **resolved** store root.

### 2. The confinement logic had no unit tests

`getSafePath` / `assertRealPathInStore` (the most security-critical code in the change) lived module-private in `app.ts` and were untested — only `assertNoEscapingSymlinks` had coverage. Extracted them into `utils.ts` as `resolveSafeStorePath` / `assertRealPathInStore` (taking `storeDir` as a parameter, matching the `buildLogConfig(config, logsDir)` DI pattern introduced in #4678), and added tests — including a regression test for the symlinked-`storeDir` case above.

### 3. `store-multi` export probed raw paths before validating

The export loop ran `lstat(f)` / `realpath(f)` on raw user input before `getSafePath`, letting an authenticated user probe arbitrary filesystem path existence/type. It now confines each path before touching the filesystem (consistent with the `store-multi` DELETE handler).

## Testing

- `npx mocha --import=tsx test/lib/utils.test.ts` — 41 passing (7 new for `resolveSafeStorePath`)
- `eslint` clean on changed files
- `tsc` clean on changed files (two pre-existing `ZwaveClient.ts` errors are unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)