### PR TITLE
fix: refresh broadcast virtual nodes to avoid querying removed nodes

### DIFF
--- a/api/lib/ZwaveClient.ts
+++ b/api/lib/ZwaveClient.ts
@@ -3940,24 +3940,31 @@ class ZwaveClient extends TypedEventEmitter<ZwaveClientEventCallbacks> {
 		if (!this.driverReady) return
 
 		const controller = this._driver.controller
-		const broadcastNodeIds = [NODE_ID_BROADCAST, NODE_ID_BROADCAST_LR]
 
-		for (const nodeId of broadcastNodeIds) {
+		// Pair each broadcast node id with a freshly fetched driver instance.
+		// The driver snapshots the physical node set at construction time, so a
+		// cached instance keeps referencing nodes that have since been removed —
+		// querying those throws "Node X was not found" (#4677). Re-fetching here
+		// also keeps the instance used for write-back (via `getVirtualNode`) in
+		// sync with the network. The LR broadcast node only exists while the
+		// network has LR nodes (see `_refreshBroadcastLRNode`).
+		const broadcastNodes: [number, VirtualNode][] = [
+			[NODE_ID_BROADCAST, controller.getBroadcastNode()],
+		]
+
+		if (this._virtualNodes.has(NODE_ID_BROADCAST_LR)) {
+			broadcastNodes.push([
+				NODE_ID_BROADCAST_LR,
+				controller.getBroadcastNodeLR(),
+			])
+		}
+
+		for (const [nodeId, broadcastInstance] of broadcastNodes) {
 			try {
 				const virtualNode = this._nodes.get(nodeId)
 
-				if (!this._virtualNodes.has(nodeId) || !virtualNode) continue
+				if (!virtualNode) continue
 
-				// Re-fetch a fresh broadcast instance from the controller. The
-				// driver snapshots the physical node set at construction time,
-				// so a cached instance keeps referencing nodes that have since
-				// been removed — querying those throws "Node X was not found"
-				// (#4677). Refreshing here also keeps the instance used for
-				// write-back (via `getVirtualNode`) in sync with the network.
-				const broadcastInstance =
-					nodeId === NODE_ID_BROADCAST
-						? controller.getBroadcastNode()
-						: controller.getBroadcastNodeLR()
 				this._virtualNodes.set(nodeId, broadcastInstance)
 
 				const definedValueIds = broadcastInstance.getDefinedValueIDs()

--- a/api/lib/ZwaveClient.ts
+++ b/api/lib/ZwaveClient.ts
@@ -3929,6 +3929,11 @@ class ZwaveClient extends TypedEventEmitter<ZwaveClientEventCallbacks> {
 	private _updateBroadcastNodeValues(): void {
 		if (!this.driverReady) return
 
+		// Keep the cached instances in sync with the driver *synchronously*, so
+		// the write-back path (`getVirtualNode` → `setValue`) never targets a
+		// removed node even before the throttled value rebuild below runs.
+		this._refreshBroadcastInstances()
+
 		this.throttle(
 			'broadcast_values_rebuild',
 			() => this._doUpdateBroadcastNodeValues(),
@@ -3936,36 +3941,52 @@ class ZwaveClient extends TypedEventEmitter<ZwaveClientEventCallbacks> {
 		)
 	}
 
-	private _doUpdateBroadcastNodeValues(): void {
+	/**
+	 * Re-fetch the cached broadcast VirtualNode instances from the controller.
+	 *
+	 * The driver snapshots the physical node set when a broadcast node is
+	 * constructed, so a long-lived instance keeps referencing nodes that have
+	 * since been removed — using one then throws "Node X was not found" (#4677),
+	 * both when enumerating values and when sending a write. Re-fetching is
+	 * cheap (it just wraps the controller's current node set), so we do it
+	 * eagerly on every node-set change. Only instances that currently exist are
+	 * refreshed; the LR broadcast node exists solely while the network has LR
+	 * nodes (see `_refreshBroadcastLRNode`).
+	 */
+	private _refreshBroadcastInstances(): void {
 		if (!this.driverReady) return
 
 		const controller = this._driver.controller
 
-		// Pair each broadcast node id with a freshly fetched driver instance.
-		// The driver snapshots the physical node set at construction time, so a
-		// cached instance keeps referencing nodes that have since been removed —
-		// querying those throws "Node X was not found" (#4677). Re-fetching here
-		// also keeps the instance used for write-back (via `getVirtualNode`) in
-		// sync with the network. The LR broadcast node only exists while the
-		// network has LR nodes (see `_refreshBroadcastLRNode`).
-		const broadcastNodes: [number, VirtualNode][] = [
-			[NODE_ID_BROADCAST, controller.getBroadcastNode()],
-		]
-
-		if (this._virtualNodes.has(NODE_ID_BROADCAST_LR)) {
-			broadcastNodes.push([
-				NODE_ID_BROADCAST_LR,
-				controller.getBroadcastNodeLR(),
-			])
+		if (this._virtualNodes.has(NODE_ID_BROADCAST)) {
+			this._virtualNodes.set(
+				NODE_ID_BROADCAST,
+				controller.getBroadcastNode(),
+			)
 		}
 
-		for (const [nodeId, broadcastInstance] of broadcastNodes) {
+		if (this._virtualNodes.has(NODE_ID_BROADCAST_LR)) {
+			this._virtualNodes.set(
+				NODE_ID_BROADCAST_LR,
+				controller.getBroadcastNodeLR(),
+			)
+		}
+	}
+
+	private _doUpdateBroadcastNodeValues(): void {
+		if (!this.driverReady) return
+
+		const broadcastNodeIds = [NODE_ID_BROADCAST, NODE_ID_BROADCAST_LR]
+
+		for (const nodeId of broadcastNodeIds) {
 			try {
+				// The cached instances are kept current by
+				// `_refreshBroadcastInstances`, so they already reflect the
+				// live node set (no removed nodes) by the time we get here.
+				const broadcastInstance = this._virtualNodes.get(nodeId)
 				const virtualNode = this._nodes.get(nodeId)
 
-				if (!virtualNode) continue
-
-				this._virtualNodes.set(nodeId, broadcastInstance)
+				if (!broadcastInstance || !virtualNode) continue
 
 				const definedValueIds = broadcastInstance.getDefinedValueIDs()
 

--- a/api/lib/ZwaveClient.ts
+++ b/api/lib/ZwaveClient.ts
@@ -3937,14 +3937,28 @@ class ZwaveClient extends TypedEventEmitter<ZwaveClientEventCallbacks> {
 	}
 
 	private _doUpdateBroadcastNodeValues(): void {
+		if (!this.driverReady) return
+
+		const controller = this._driver.controller
 		const broadcastNodeIds = [NODE_ID_BROADCAST, NODE_ID_BROADCAST_LR]
 
 		for (const nodeId of broadcastNodeIds) {
 			try {
-				const broadcastInstance = this._virtualNodes.get(nodeId)
 				const virtualNode = this._nodes.get(nodeId)
 
-				if (!broadcastInstance || !virtualNode) continue
+				if (!this._virtualNodes.has(nodeId) || !virtualNode) continue
+
+				// Re-fetch a fresh broadcast instance from the controller. The
+				// driver snapshots the physical node set at construction time,
+				// so a cached instance keeps referencing nodes that have since
+				// been removed — querying those throws "Node X was not found"
+				// (#4677). Refreshing here also keeps the instance used for
+				// write-back (via `getVirtualNode`) in sync with the network.
+				const broadcastInstance =
+					nodeId === NODE_ID_BROADCAST
+						? controller.getBroadcastNode()
+						: controller.getBroadcastNodeLR()
+				this._virtualNodes.set(nodeId, broadcastInstance)
 
 				const definedValueIds = broadcastInstance.getDefinedValueIDs()
 


### PR DESCRIPTION
## Problem

After removing a node and adding another during testing, errors like the following appeared in the log (#4677):

```
ERROR Z-WAVE: Error updating broadcast node 255 values: Node 262 was not found! (ZW0211)
ERROR Z-WAVE: Error updating broadcast node 4095 values: Node 262 was not found! (ZW0211)
```

## Root cause

The broadcast `VirtualNode` instances are fetched once via `controller.getBroadcastNode()` / `getBroadcastNodeLR()` and cached in `_virtualNodes`. The driver **snapshots** the physical node set at construction time (`VirtualNode.physicalNodes`). When a node is later removed, the cached instance keeps referencing it, so `getDefinedValueIDs()` iterates over the now-removed node and the driver throws `Node X was not found`.

## Fix

Re-fetch a fresh broadcast instance from the controller inside `_doUpdateBroadcastNodeValues()` — which already runs after every node add/remove/ready event — and store it back in the cache. This:

- gives `getDefinedValueIDs()` a node set that reflects the current network, so removed nodes are no longer queried, and
- keeps the instance later used for write-back (`getVirtualNode` → `setValue`) in sync with the network.

A `driverReady` guard is added since the method now touches the controller (it runs on a trailing throttle, so the driver may have gone away in the meantime).

Note: issue point 1 (standard broadcast 255 enumerating LR nodes) is a driver-side concern — `getBroadcastNode()` includes all nodes regardless of protocol — and is out of scope here; this change resolves the reported "node not found" errors.

Closes #4677

🤖 Generated with [Claude Code](https://claude.com/claude-code)