### PR TITLE
feat(ui): implement more complex UI components

### DIFF
--- a/src/components/dashboard/components/ZwAddDeviceSplitButton.vue
+++ b/src/components/dashboard/components/ZwAddDeviceSplitButton.vue
@@ -58,7 +58,7 @@ import {
 } from '@/lib/icons'
 import { usePopoverFallback } from '@/lib/popover-fallback.ts'
 
-type Action = 'include' | 'replace' | 'exclude'
+type Action = 'include' | 'replace-failed' | 'exclude'
 
 defineProps<{
 	compact?: boolean
@@ -81,7 +81,7 @@ const MENU = [
 		destructive: false,
 	},
 	{
-		id: 'replace' as const,
+		id: 'replace-failed' as const,
 		icon: RefreshIcon,
 		title: 'Replace failed device',
 		desc: 'Swap an unresponsive node in place',

--- a/src/components/dashboard/components/ZwAddDeviceSplitButton.vue
+++ b/src/components/dashboard/components/ZwAddDeviceSplitButton.vue
@@ -19,11 +19,7 @@
 				<ChevronDownIcon :size="ICON_SIZE.button" />
 			</Popover.Activator>
 		</Button.Group>
-		<Popover.Content
-			as="div"
-			class="zw-asb__menu"
-			role="menu"
-		>
+		<Popover.Content as="div" class="zw-asb__menu" role="menu">
 			<button
 				v-for="item in MENU"
 				:key="item.id"

--- a/src/components/dashboard/components/ZwAddDeviceSplitButton.vue
+++ b/src/components/dashboard/components/ZwAddDeviceSplitButton.vue
@@ -1,0 +1,259 @@
+<template>
+	<Popover.Root v-model="open" :id="contentId">
+		<Button.Group class="zw-asb__group">
+			<Button.Root
+				class="zw-asb__face"
+				:class="{ 'zw-asb__face--compact': compact }"
+				@click="onFaceClick"
+			>
+				<AddIcon :size="ICON_SIZE.button" />
+				<span v-if="!compact">{{ wide ? 'Add device' : 'Add' }}</span>
+			</Button.Root>
+			<span class="zw-asb__divider" />
+			<Popover.Activator
+				as="button"
+				class="zw-asb__chev"
+				:class="{ 'zw-asb__chev--open': open }"
+				aria-haspopup="menu"
+			>
+				<ChevronDownIcon :size="ICON_SIZE.button" />
+			</Popover.Activator>
+		</Button.Group>
+		<Popover.Content
+			as="div"
+			class="zw-asb__menu"
+			role="menu"
+		>
+			<button
+				v-for="item in MENU"
+				:key="item.id"
+				type="button"
+				role="menuitem"
+				class="zw-asb__item"
+				:class="{ 'zw-asb__item--destructive': item.destructive }"
+				@click="onItemClick(item.id)"
+			>
+				<span
+					class="zw-asb__item-icon"
+					:class="{
+						'zw-asb__item-icon--destructive': item.destructive,
+					}"
+				>
+					<component :is="item.icon" :size="ICON_SIZE.button" />
+				</span>
+				<span class="zw-asb__item-text">
+					<span class="zw-asb__item-title">{{ item.title }}</span>
+					<span class="zw-asb__item-desc">{{ item.desc }}</span>
+				</span>
+			</button>
+		</Popover.Content>
+	</Popover.Root>
+</template>
+
+<script setup lang="ts">
+import { ref, useId } from 'vue'
+import { Button, Popover } from '@vuetify/v0'
+import {
+	AddIcon,
+	ChevronDownIcon,
+	ICON_SIZE,
+	RefreshIcon,
+	TrashIcon,
+} from '@/lib/icons'
+import { usePopoverFallback } from '@/lib/popover-fallback.ts'
+
+type Action = 'include' | 'replace' | 'exclude'
+
+defineProps<{
+	compact?: boolean
+	wide?: boolean
+}>()
+
+const emit = defineEmits<{ action: [Action] }>()
+
+const open = ref(false)
+const contentId = `zw-asb-${useId()}`
+
+usePopoverFallback({ open, contentId })
+
+const MENU = [
+	{
+		id: 'include' as const,
+		icon: AddIcon,
+		title: 'Include device',
+		desc: 'Add a new device to the network',
+		destructive: false,
+	},
+	{
+		id: 'replace' as const,
+		icon: RefreshIcon,
+		title: 'Replace failed device',
+		desc: 'Swap an unresponsive node in place',
+		destructive: false,
+	},
+	{
+		id: 'exclude' as const,
+		icon: TrashIcon,
+		title: 'Exclude device',
+		desc: 'Remove a device from the network',
+		destructive: true,
+	},
+]
+
+function onFaceClick(): void {
+	emit('action', 'include')
+}
+
+function onItemClick(id: Action): void {
+	emit('action', id)
+	open.value = false
+}
+</script>
+
+<style>
+/* Unscoped — V0 primitives set inheritAttrs:false; .zw-asb namespace is
+   unique to this component. */
+.zw-asb__group {
+	display: inline-flex;
+	border-radius: 6px;
+	overflow: hidden;
+	box-shadow: 0 1px 2px rgba(25, 118, 210, 0.3);
+}
+
+.zw-asb__face,
+.zw-asb__chev {
+	appearance: none;
+	border: none;
+	cursor: pointer;
+	background: var(--zw-accent);
+	color: #fff;
+	font-family: var(--zw-font);
+	font-weight: 600;
+	letter-spacing: 0.4px;
+	text-transform: uppercase;
+	display: inline-flex;
+	align-items: center;
+	gap: 6px;
+	transition: background 0.12s;
+}
+
+.zw-asb__face {
+	font-size: 12px;
+	padding: 7px 14px;
+}
+
+.zw-asb__face--compact {
+	padding: 7px 9px;
+}
+
+.zw-asb__face:hover,
+.zw-asb__chev:hover {
+	background: var(--zw-accent-dark);
+}
+
+.zw-asb__divider {
+	width: 1px;
+	background: rgba(255, 255, 255, 0.28);
+}
+
+.zw-asb__chev {
+	padding: 7px 10px;
+}
+
+.zw-asb__chev--open,
+.zw-asb__chev[data-open] {
+	background: var(--zw-accent-dark);
+}
+
+.zw-asb__chev--open svg,
+.zw-asb__chev[data-open] svg {
+	transform: rotate(180deg);
+	transition: transform 0.15s;
+}
+
+/* V0 hard-codes `position-area: bottom` inline on the popover and Vue
+   re-applies it on every render, so neutralise via stylesheet so Floating
+   UI's manual top/left writes drive the actual position. See ZwToggleMenu. */
+.zw-asb__menu {
+	position-area: none !important;
+	position-anchor: auto !important;
+	min-width: 260px;
+	background: var(--zw-card);
+	border: 1px solid var(--zw-line);
+	border-radius: 6px;
+	box-shadow: var(--zw-e8);
+	padding: 4px;
+	animation: zw-fade-in 0.12s;
+}
+
+.zw-asb__menu::backdrop {
+	display: none;
+}
+
+.zw-asb__item {
+	display: flex;
+	align-items: center;
+	gap: 10px;
+	width: 100%;
+	background: transparent;
+	border: none;
+	cursor: pointer;
+	padding: 8px 10px;
+	border-radius: 4px;
+	text-align: left;
+	color: var(--zw-fg);
+	font-family: var(--zw-font);
+	font-size: 13px;
+}
+
+.zw-asb__item:hover {
+	background: var(--zw-row-hover);
+}
+
+.zw-asb__item--destructive {
+	color: var(--zw-danger);
+}
+
+.zw-asb__item--destructive:hover {
+	background: var(--zw-danger-soft);
+}
+
+.zw-asb__item-icon {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	width: 28px;
+	height: 28px;
+	border-radius: 6px;
+	background: var(--zw-accent-soft);
+	color: var(--zw-accent);
+	flex: 0 0 28px;
+}
+
+.zw-asb__item-icon--destructive {
+	background: var(--zw-danger-soft);
+	color: var(--zw-danger);
+}
+
+.zw-asb__item-text {
+	display: flex;
+	flex-direction: column;
+	min-width: 0;
+}
+
+.zw-asb__item-title {
+	font-weight: 600;
+	font-size: 13px;
+	line-height: 1.2;
+}
+
+.zw-asb__item-desc {
+	font-size: 11px;
+	color: var(--zw-muted);
+	line-height: 1.2;
+}
+
+.zw-asb__item--destructive .zw-asb__item-desc {
+	color: rgba(229, 57, 53, 0.7);
+}
+</style>

--- a/src/components/dashboard/components/ZwColumnsMenu.vue
+++ b/src/components/dashboard/components/ZwColumnsMenu.vue
@@ -1,0 +1,36 @@
+<template>
+	<ZwToggleMenu
+		:options="TOGGLEABLE_COLS"
+		:model-value="modelValue"
+		trigger-label="Columns"
+		:trigger-label-hidden="triggerLabelHidden"
+		header="Toggle columns"
+		:badge-count="TOGGLEABLE_COLS.length - modelValue.length"
+		@update:model-value="
+			(next) => emit('update:modelValue', next as ToggleableCol[])
+		"
+	/>
+</template>
+
+<script setup lang="ts">
+import ZwToggleMenu from '@/components/dashboard/atoms/ZwToggleMenu.vue'
+
+type ToggleableCol = 'activity' | 'location' | 'value' | 'power' | 'lastSeen'
+
+defineProps<{
+	modelValue: readonly ToggleableCol[]
+	triggerLabelHidden?: boolean
+}>()
+
+const emit = defineEmits<{
+	'update:modelValue': [ToggleableCol[]]
+}>()
+
+const TOGGLEABLE_COLS = [
+	{ id: 'activity', label: 'Activity' },
+	{ id: 'location', label: 'Location' },
+	{ id: 'value', label: 'State / Value' },
+	{ id: 'power', label: 'Power' },
+	{ id: 'lastSeen', label: 'Last seen' },
+]
+</script>

--- a/src/components/dashboard/components/ZwColumnsMenu.vue
+++ b/src/components/dashboard/components/ZwColumnsMenu.vue
@@ -14,7 +14,7 @@
 
 <script setup lang="ts">
 import ZwToggleMenu from '@/components/dashboard/atoms/ZwToggleMenu.vue'
-import type { ToggleableCol } from './deviceRowGrid'
+import { TOGGLEABLE_COLS, type ToggleableCol } from './deviceRowGrid'
 
 defineProps<{
 	modelValue: readonly ToggleableCol[]
@@ -24,13 +24,4 @@ defineProps<{
 const emit = defineEmits<{
 	'update:modelValue': [ToggleableCol[]]
 }>()
-
-const TOGGLEABLE_COLS: { id: ToggleableCol; label: string }[] = [
-	{ id: 'activity', label: 'Activity' },
-	{ id: 'location', label: 'Location' },
-	{ id: 'value', label: 'State / Value' },
-	{ id: 'power', label: 'Power' },
-	{ id: 'signal', label: 'Link' },
-	{ id: 'lastSeen', label: 'Last seen' },
-]
 </script>

--- a/src/components/dashboard/components/ZwColumnsMenu.vue
+++ b/src/components/dashboard/components/ZwColumnsMenu.vue
@@ -14,8 +14,7 @@
 
 <script setup lang="ts">
 import ZwToggleMenu from '@/components/dashboard/atoms/ZwToggleMenu.vue'
-
-type ToggleableCol = 'activity' | 'location' | 'value' | 'power' | 'lastSeen'
+import type { ToggleableCol } from './deviceRowGrid'
 
 defineProps<{
 	modelValue: readonly ToggleableCol[]
@@ -26,11 +25,12 @@ const emit = defineEmits<{
 	'update:modelValue': [ToggleableCol[]]
 }>()
 
-const TOGGLEABLE_COLS = [
+const TOGGLEABLE_COLS: { id: ToggleableCol; label: string }[] = [
 	{ id: 'activity', label: 'Activity' },
 	{ id: 'location', label: 'Location' },
 	{ id: 'value', label: 'State / Value' },
 	{ id: 'power', label: 'Power' },
+	{ id: 'signal', label: 'Link' },
 	{ id: 'lastSeen', label: 'Last seen' },
 ]
 </script>

--- a/src/components/dashboard/components/ZwCompactPrimary.vue
+++ b/src/components/dashboard/components/ZwCompactPrimary.vue
@@ -3,14 +3,14 @@
 		<!-- toggle -->
 		<template v-if="pv?.type === 'toggle'">
 			<ZwToggle
-				:model-value="(pv as PrimaryValueToggle).on"
+				:model-value="pv.on"
 				size="sm"
 				@update:model-value="
 					(on) => emit('action', device, { type: 'toggle', on })
 				"
 			/>
 			<ZwChip tone="neutral">
-				{{ (pv as PrimaryValueToggle).on ? 'ON' : 'OFF' }}
+				{{ pv.on ? 'ON' : 'OFF' }}
 			</ZwChip>
 		</template>
 
@@ -20,51 +20,42 @@
 			<span class="zw-cp__bar">
 				<span
 					class="zw-cp__bar-fill"
-					:style="{ width: `${(pv as PrimaryValueDim).level}%` }"
+					:style="{ width: `${pv.level}%` }"
 				/>
 			</span>
-			<span class="zw-cp__num">{{ (pv as PrimaryValueDim).level }}%</span>
+			<span class="zw-cp__num">{{ pv.level }}%</span>
 		</template>
 
 		<!-- lock -->
 		<template v-else-if="pv?.type === 'lock'">
 			<ZwToggle
-				:model-value="(pv as PrimaryValueLock).locked"
+				:model-value="pv.locked"
 				size="sm"
 				@update:model-value="
 					(locked) => emit('action', device, { type: 'lock', locked })
 				"
 			/>
-			<ZwChip :tone="(pv as PrimaryValueLock).locked ? 'ok' : 'warn'">
-				{{ (pv as PrimaryValueLock).locked ? 'LOCKED' : 'UNLOCKED' }}
+			<ZwChip :tone="pv.locked ? 'ok' : 'warn'">
+				{{ pv.locked ? 'LOCKED' : 'UNLOCKED' }}
 			</ZwChip>
 		</template>
 
 		<!-- reading -->
 		<template v-else-if="pv?.type === 'reading'">
-			<span class="zw-cp__num">
-				{{ (pv as PrimaryValueReading).value
-				}}{{ (pv as PrimaryValueReading).unit }}
-			</span>
+			<span class="zw-cp__num"> {{ pv.value }}{{ pv.unit }} </span>
 		</template>
 
 		<!-- state -->
 		<template v-else-if="pv?.type === 'state'">
 			<ZwChip :tone="stateChipTone">
-				{{ (pv as PrimaryValueState).value.toUpperCase() }}
+				{{ pv.value.toUpperCase() }}
 			</ZwChip>
 		</template>
 
 		<!-- thermostat -->
 		<template v-else-if="pv?.type === 'thermostat'">
-			<span class="zw-cp__num">
-				{{ (pv as PrimaryValueThermostat).value
-				}}{{ (pv as PrimaryValueThermostat).unit }}
-			</span>
-			<span class="zw-cp__sub">
-				→ {{ (pv as PrimaryValueThermostat).setpoint
-				}}{{ (pv as PrimaryValueThermostat).unit }}
-			</span>
+			<span class="zw-cp__num"> {{ pv.value }}{{ pv.unit }} </span>
+			<span class="zw-cp__sub"> → {{ pv.setpoint }}{{ pv.unit }} </span>
 		</template>
 	</span>
 </template>
@@ -73,17 +64,7 @@
 import { computed } from 'vue'
 import ZwToggle from '@/components/dashboard/atoms/ZwToggle.vue'
 import ZwChip from '@/components/dashboard/atoms/ZwChip.vue'
-import type {
-	Device,
-	DeviceAction,
-	PrimaryValue,
-	PrimaryValueToggle,
-	PrimaryValueDim,
-	PrimaryValueLock,
-	PrimaryValueReading,
-	PrimaryValueState,
-	PrimaryValueThermostat,
-} from '@/lib/dashboard-types'
+import type { Device, DeviceAction, PrimaryValue } from '@/lib/dashboard-types'
 
 const props = defineProps<{ device: Device }>()
 const emit = defineEmits<{ action: [Device, DeviceAction] }>()
@@ -91,8 +72,8 @@ const emit = defineEmits<{ action: [Device, DeviceAction] }>()
 const pv = computed<PrimaryValue | null>(() => props.device.primaryValue)
 
 const stateChipTone = computed(() => {
-	const s = pv.value as PrimaryValueState | null
-	if (!s) return 'neutral'
+	const s = pv.value
+	if (!s || s.type !== 'state') return 'neutral'
 	if (s.stateIdx !== 1) return 'neutral'
 	const c = s.colors[1]
 	if (c === 'red') return 'danger'

--- a/src/components/dashboard/components/ZwCompactPrimary.vue
+++ b/src/components/dashboard/components/ZwCompactPrimary.vue
@@ -9,9 +9,7 @@
 					(on) => emit('action', device, { type: 'toggle', on })
 				"
 			/>
-			<ZwChip
-				:tone="(pv as PrimaryValueToggle).on ? 'neutral' : 'neutral'"
-			>
+			<ZwChip tone="neutral">
 				{{ (pv as PrimaryValueToggle).on ? 'ON' : 'OFF' }}
 			</ZwChip>
 		</template>

--- a/src/components/dashboard/components/ZwCompactPrimary.vue
+++ b/src/components/dashboard/components/ZwCompactPrimary.vue
@@ -1,0 +1,136 @@
+<template>
+	<span class="zw-cp" @click.stop>
+		<!-- toggle -->
+		<template v-if="pv?.type === 'toggle'">
+			<ZwToggle
+				:model-value="(pv as PrimaryValueToggle).on"
+				size="sm"
+				@update:model-value="(on) => emit('action', device, { type: 'toggle', on })"
+			/>
+			<ZwChip :tone="(pv as PrimaryValueToggle).on ? 'neutral' : 'neutral'">
+				{{ (pv as PrimaryValueToggle).on ? 'ON' : 'OFF' }}
+			</ZwChip>
+		</template>
+
+		<!-- dim — read-only thin fill in the row; editing happens in
+			 the expanded body / drawer. -->
+		<template v-else-if="pv?.type === 'dim'">
+			<span class="zw-cp__bar">
+				<span
+					class="zw-cp__bar-fill"
+					:style="{ width: `${(pv as PrimaryValueDim).level}%` }"
+				/>
+			</span>
+			<span class="zw-cp__num">{{ (pv as PrimaryValueDim).level }}%</span>
+		</template>
+
+		<!-- lock -->
+		<template v-else-if="pv?.type === 'lock'">
+			<ZwToggle
+				:model-value="(pv as PrimaryValueLock).locked"
+				size="sm"
+				@update:model-value="(locked) => emit('action', device, { type: 'lock', locked })"
+			/>
+			<ZwChip :tone="(pv as PrimaryValueLock).locked ? 'ok' : 'warn'">
+				{{ (pv as PrimaryValueLock).locked ? 'LOCKED' : 'UNLOCKED' }}
+			</ZwChip>
+		</template>
+
+		<!-- reading -->
+		<template v-else-if="pv?.type === 'reading'">
+			<span class="zw-cp__num">
+				{{ (pv as PrimaryValueReading).value }}{{ (pv as PrimaryValueReading).unit }}
+			</span>
+		</template>
+
+		<!-- state -->
+		<template v-else-if="pv?.type === 'state'">
+			<ZwChip :tone="stateChipTone">
+				{{ (pv as PrimaryValueState).value.toUpperCase() }}
+			</ZwChip>
+		</template>
+
+		<!-- thermostat -->
+		<template v-else-if="pv?.type === 'thermostat'">
+			<span class="zw-cp__num">
+				{{ (pv as PrimaryValueThermostat).value
+				}}{{ (pv as PrimaryValueThermostat).unit }}
+			</span>
+			<span class="zw-cp__sub">
+				→ {{ (pv as PrimaryValueThermostat).setpoint
+				}}{{ (pv as PrimaryValueThermostat).unit }}
+			</span>
+		</template>
+	</span>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import ZwToggle from '@/components/dashboard/atoms/ZwToggle.vue'
+import ZwChip from '@/components/dashboard/atoms/ZwChip.vue'
+import type {
+	Device,
+	DeviceAction,
+	PrimaryValue,
+	PrimaryValueToggle,
+	PrimaryValueDim,
+	PrimaryValueLock,
+	PrimaryValueReading,
+	PrimaryValueState,
+	PrimaryValueThermostat,
+} from '@/lib/dashboard-types'
+
+const props = defineProps<{ device: Device }>()
+const emit = defineEmits<{ action: [Device, DeviceAction] }>()
+
+const pv = computed<PrimaryValue | null>(() => props.device.primaryValue)
+
+const stateChipTone = computed(() => {
+	const s = pv.value as PrimaryValueState | null
+	if (!s) return 'neutral'
+	if (s.stateIdx !== 1) return 'neutral'
+	const c = s.colors[1]
+	if (c === 'red') return 'danger'
+	if (c === 'amber') return 'warn'
+	return 'neutral'
+})
+</script>
+
+<style scoped>
+.zw-cp {
+	display: inline-flex;
+	align-items: center;
+	gap: 6px;
+	white-space: nowrap;
+}
+
+.zw-cp__bar {
+	position: relative;
+	width: 100px;
+	max-width: 100%;
+	height: 4px;
+	background: var(--zw-line);
+	border-radius: 2px;
+	overflow: hidden;
+}
+
+.zw-cp__bar-fill {
+	position: absolute;
+	inset: 0;
+	background: var(--zw-accent);
+	border-radius: 2px;
+}
+
+.zw-cp__num {
+	font-family: var(--zw-mono);
+	font-size: 11px;
+	font-variant-numeric: tabular-nums;
+	color: var(--zw-fg);
+}
+
+.zw-cp__sub {
+	font-family: var(--zw-mono);
+	font-size: 10px;
+	color: var(--zw-muted);
+}
+</style>

--- a/src/components/dashboard/components/ZwCompactPrimary.vue
+++ b/src/components/dashboard/components/ZwCompactPrimary.vue
@@ -5,9 +5,13 @@
 			<ZwToggle
 				:model-value="(pv as PrimaryValueToggle).on"
 				size="sm"
-				@update:model-value="(on) => emit('action', device, { type: 'toggle', on })"
+				@update:model-value="
+					(on) => emit('action', device, { type: 'toggle', on })
+				"
 			/>
-			<ZwChip :tone="(pv as PrimaryValueToggle).on ? 'neutral' : 'neutral'">
+			<ZwChip
+				:tone="(pv as PrimaryValueToggle).on ? 'neutral' : 'neutral'"
+			>
 				{{ (pv as PrimaryValueToggle).on ? 'ON' : 'OFF' }}
 			</ZwChip>
 		</template>
@@ -29,7 +33,9 @@
 			<ZwToggle
 				:model-value="(pv as PrimaryValueLock).locked"
 				size="sm"
-				@update:model-value="(locked) => emit('action', device, { type: 'lock', locked })"
+				@update:model-value="
+					(locked) => emit('action', device, { type: 'lock', locked })
+				"
 			/>
 			<ZwChip :tone="(pv as PrimaryValueLock).locked ? 'ok' : 'warn'">
 				{{ (pv as PrimaryValueLock).locked ? 'LOCKED' : 'UNLOCKED' }}
@@ -39,7 +45,8 @@
 		<!-- reading -->
 		<template v-else-if="pv?.type === 'reading'">
 			<span class="zw-cp__num">
-				{{ (pv as PrimaryValueReading).value }}{{ (pv as PrimaryValueReading).unit }}
+				{{ (pv as PrimaryValueReading).value
+				}}{{ (pv as PrimaryValueReading).unit }}
 			</span>
 		</template>
 

--- a/src/components/dashboard/components/ZwCompactPrimary.vue
+++ b/src/components/dashboard/components/ZwCompactPrimary.vue
@@ -64,6 +64,7 @@
 import { computed } from 'vue'
 import ZwToggle from '@/components/dashboard/atoms/ZwToggle.vue'
 import ZwChip from '@/components/dashboard/atoms/ZwChip.vue'
+import { isStateAlert } from '@/lib/primaryValue'
 import type { Device, DeviceAction, PrimaryValue } from '@/lib/dashboard-types'
 
 const props = defineProps<{ device: Device }>()
@@ -73,12 +74,9 @@ const pv = computed<PrimaryValue | null>(() => props.device.primaryValue)
 
 const stateChipTone = computed(() => {
 	const s = pv.value
-	if (!s || s.type !== 'state') return 'neutral'
-	if (s.stateIdx !== 1) return 'neutral'
-	const c = s.colors[1]
-	if (c === 'red') return 'danger'
-	if (c === 'amber') return 'warn'
-	return 'neutral'
+	if (!s || s.type !== 'state' || !isStateAlert(s)) return 'neutral'
+	// isStateAlert guarantees the colour is red or amber.
+	return s.colors[1] === 'red' ? 'danger' : 'warn'
 })
 </script>
 

--- a/src/components/dashboard/components/ZwDeviceCard.vue
+++ b/src/components/dashboard/components/ZwDeviceCard.vue
@@ -1,0 +1,195 @@
+<template>
+	<div
+		class="zw-card"
+		:class="{ 'zw-card--dead': device.status === 'dead' }"
+		role="button"
+		tabindex="0"
+		@click="emit('open', device)"
+		@keydown="onKeyDown"
+	>
+		<header class="zw-card__header">
+			<div
+				class="zw-card__icon"
+				:class="{ 'zw-card__icon--alert': isAlertState }"
+			>
+				<component :is="device.archetype.icon" :size="18" />
+			</div>
+			<div class="zw-card__name-col">
+				<div class="zw-card__name">{{ device.name }}</div>
+				<div class="zw-card__sub">
+					{{ nodeIdLabel }} ·
+					{{ device.location || 'No location' }}
+				</div>
+			</div>
+		</header>
+
+		<div class="zw-card__body">
+			<ZwPrimaryDisplay
+				:device="device"
+				@action="(d, a) => emit('action', d, a)"
+			/>
+		</div>
+
+		<footer class="zw-card__foot">
+			<ZwActivityReadout
+				v-if="device.activity[0]"
+				variant="card"
+				:activity="device.activity[0]"
+			/>
+			<template v-else>
+				<ZwBatteryMini
+					v-if="device.power.type === 'battery'"
+					:pct="device.power.battery"
+				/>
+				<ZwPill v-if="device.status === 'asleep'" tone="asleep" size="sm">
+					<MoonIcon :size="ICON_SIZE.pill" /> Asleep
+				</ZwPill>
+				<ZwPill v-else-if="device.status === 'dead'" tone="danger" size="sm">
+					Dead
+				</ZwPill>
+				<ZwPill
+					v-else-if="
+						device.interviewState !== 'complete' && !device.isController
+					"
+					tone="info"
+					size="sm"
+				>
+					Interviewing
+				</ZwPill>
+				<ZwPill v-else-if="device.hasUpdate" tone="accent" size="sm">
+					<DownloadIcon :size="ICON_SIZE.pill" /> Update
+				</ZwPill>
+			</template>
+		</footer>
+	</div>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import ZwPrimaryDisplay from './ZwPrimaryDisplay.vue'
+import ZwPill from '@/components/dashboard/atoms/ZwPill.vue'
+import ZwBatteryMini from '@/components/dashboard/atoms/ZwBatteryMini.vue'
+import ZwActivityReadout from '@/components/dashboard/atoms/ZwActivityReadout.vue'
+import { DownloadIcon, ICON_SIZE, MoonIcon } from '@/lib/icons'
+import type {
+	Device,
+	DeviceAction,
+	PrimaryValueState,
+} from '@/lib/dashboard-types'
+
+const props = defineProps<{ device: Device }>()
+const emit = defineEmits<{
+	open: [Device]
+	action: [Device, DeviceAction]
+}>()
+
+const nodeIdLabel = computed(() =>
+	String(props.device.nodeId).padStart(3, '0'),
+)
+
+const isAlertState = computed(() => {
+	const pv = props.device.primaryValue
+	if (!pv || pv.type !== 'state') return false
+	const s = pv as PrimaryValueState
+	return s.stateIdx === 1 && (s.colors[1] === 'red' || s.colors[1] === 'amber')
+})
+
+function onKeyDown(e: KeyboardEvent) {
+	if (e.key === 'Enter' || e.key === ' ') {
+		e.preventDefault()
+		emit('open', props.device)
+	}
+}
+</script>
+
+<style scoped>
+.zw-card {
+	display: flex;
+	flex-direction: column;
+	gap: 12px;
+	background: var(--zw-card);
+	border: 1px solid var(--zw-line);
+	border-radius: 4px;
+	box-shadow: var(--zw-e2);
+	padding: 12px;
+	min-height: 132px;
+	cursor: pointer;
+	transition:
+		box-shadow 0.2s,
+		transform 0.15s,
+		border-color 0.15s;
+	position: relative;
+}
+
+.zw-card:hover {
+	transform: translateY(-1px);
+	box-shadow: var(--zw-e4);
+}
+
+.zw-card:focus-visible {
+	outline: 2px solid var(--zw-accent);
+	outline-offset: 1px;
+}
+
+.zw-card--dead {
+	opacity: 0.66;
+}
+
+.zw-card__header {
+	display: flex;
+	align-items: center;
+	gap: 10px;
+}
+
+.zw-card__icon {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	width: 36px;
+	height: 36px;
+	border-radius: 10px;
+	background: var(--zw-chip-bg);
+	color: var(--zw-fg);
+	flex: 0 0 36px;
+}
+
+.zw-card__icon--alert {
+	background: var(--zw-warn-soft);
+	color: var(--zw-warning);
+}
+
+.zw-card__name-col {
+	display: flex;
+	flex-direction: column;
+	min-width: 0;
+}
+
+.zw-card__name {
+	font-size: 14px;
+	font-weight: 600;
+	color: var(--zw-fg);
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+.zw-card__sub {
+	font-family: var(--zw-mono);
+	font-size: 11px;
+	color: var(--zw-muted);
+}
+
+.zw-card__body {
+	flex: 1;
+	display: flex;
+	flex-direction: column;
+	justify-content: center;
+}
+
+.zw-card__foot {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	min-height: 18px;
+}
+</style>

--- a/src/components/dashboard/components/ZwDeviceCard.vue
+++ b/src/components/dashboard/components/ZwDeviceCard.vue
@@ -80,6 +80,7 @@ import ZwPill from '@/components/dashboard/atoms/ZwPill.vue'
 import ZwBatteryMini from '@/components/dashboard/atoms/ZwBatteryMini.vue'
 import ZwActivityReadout from '@/components/dashboard/atoms/ZwActivityReadout.vue'
 import { DownloadIcon, ICON_SIZE, MoonIcon } from '@/lib/icons'
+import { isStateAlert } from '@/lib/primaryValue'
 import type { Device, DeviceAction } from '@/lib/dashboard-types'
 
 const props = defineProps<{ device: Device }>()
@@ -92,11 +93,7 @@ const nodeIdLabel = computed(() => String(props.device.nodeId).padStart(3, '0'))
 
 const isAlertState = computed(() => {
 	const pv = props.device.primaryValue
-	if (!pv || pv.type !== 'state') return false
-	return (
-		pv.stateIdx === 1 &&
-		(pv.colors[1] === 'red' || pv.colors[1] === 'amber')
-	)
+	return pv?.type === 'state' ? isStateAlert(pv) : false
 })
 
 function onKeyDown(e: KeyboardEvent) {

--- a/src/components/dashboard/components/ZwDeviceCard.vue
+++ b/src/components/dashboard/components/ZwDeviceCard.vue
@@ -80,11 +80,7 @@ import ZwPill from '@/components/dashboard/atoms/ZwPill.vue'
 import ZwBatteryMini from '@/components/dashboard/atoms/ZwBatteryMini.vue'
 import ZwActivityReadout from '@/components/dashboard/atoms/ZwActivityReadout.vue'
 import { DownloadIcon, ICON_SIZE, MoonIcon } from '@/lib/icons'
-import type {
-	Device,
-	DeviceAction,
-	PrimaryValueState,
-} from '@/lib/dashboard-types'
+import type { Device, DeviceAction } from '@/lib/dashboard-types'
 
 const props = defineProps<{ device: Device }>()
 const emit = defineEmits<{
@@ -97,9 +93,9 @@ const nodeIdLabel = computed(() => String(props.device.nodeId).padStart(3, '0'))
 const isAlertState = computed(() => {
 	const pv = props.device.primaryValue
 	if (!pv || pv.type !== 'state') return false
-	const s = pv as PrimaryValueState
 	return (
-		s.stateIdx === 1 && (s.colors[1] === 'red' || s.colors[1] === 'amber')
+		pv.stateIdx === 1 &&
+		(pv.colors[1] === 'red' || pv.colors[1] === 'amber')
 	)
 })
 

--- a/src/components/dashboard/components/ZwDeviceCard.vue
+++ b/src/components/dashboard/components/ZwDeviceCard.vue
@@ -41,15 +41,24 @@
 					v-if="device.power.type === 'battery'"
 					:pct="device.power.battery"
 				/>
-				<ZwPill v-if="device.status === 'asleep'" tone="asleep" size="sm">
+				<ZwPill
+					v-if="device.status === 'asleep'"
+					tone="asleep"
+					size="sm"
+				>
 					<MoonIcon :size="ICON_SIZE.pill" /> Asleep
 				</ZwPill>
-				<ZwPill v-else-if="device.status === 'dead'" tone="danger" size="sm">
+				<ZwPill
+					v-else-if="device.status === 'dead'"
+					tone="danger"
+					size="sm"
+				>
 					Dead
 				</ZwPill>
 				<ZwPill
 					v-else-if="
-						device.interviewState !== 'complete' && !device.isController
+						device.interviewState !== 'complete' &&
+						!device.isController
 					"
 					tone="info"
 					size="sm"
@@ -83,15 +92,15 @@ const emit = defineEmits<{
 	action: [Device, DeviceAction]
 }>()
 
-const nodeIdLabel = computed(() =>
-	String(props.device.nodeId).padStart(3, '0'),
-)
+const nodeIdLabel = computed(() => String(props.device.nodeId).padStart(3, '0'))
 
 const isAlertState = computed(() => {
 	const pv = props.device.primaryValue
 	if (!pv || pv.type !== 'state') return false
 	const s = pv as PrimaryValueState
-	return s.stateIdx === 1 && (s.colors[1] === 'red' || s.colors[1] === 'amber')
+	return (
+		s.stateIdx === 1 && (s.colors[1] === 'red' || s.colors[1] === 'amber')
+	)
 })
 
 function onKeyDown(e: KeyboardEvent) {

--- a/src/components/dashboard/components/ZwDeviceRow.vue
+++ b/src/components/dashboard/components/ZwDeviceRow.vue
@@ -3,7 +3,7 @@
 		class="zw-row"
 		:class="{
 			'zw-row--expanded': expanded,
-			'zw-row--mobile': viewport < 600,
+			'zw-row--mobile': viewport < MOBILE_BREAKPOINT,
 		}"
 		:style="rowStyle"
 		@click="emit('expand', device.id)"
@@ -27,7 +27,10 @@
 		</span>
 
 		<!-- activity/activity -->
-		<span v-if="hasCol('activity') && viewport >= 600" class="zw-row__cell">
+		<span
+			v-if="hasCol('activity') && viewport >= MOBILE_BREAKPOINT"
+			class="zw-row__cell"
+		>
 			<ZwActivityReadout
 				v-if="device.activity[0]"
 				variant="table"
@@ -40,14 +43,17 @@
 
 		<!-- location -->
 		<span
-			v-if="hasCol('location') && viewport >= 600"
+			v-if="hasCol('location') && viewport >= MOBILE_BREAKPOINT"
 			class="zw-row__cell zw-row__cell--muted"
 		>
 			{{ device.location || '—' }}
 		</span>
 
 		<!-- value -->
-		<span v-if="hasCol('value') || viewport < 600" class="zw-row__cell">
+		<span
+			v-if="hasCol('value') || viewport < MOBILE_BREAKPOINT"
+			class="zw-row__cell"
+		>
 			<ZwCompactPrimary
 				:device="device"
 				@action="(d, a) => emit('action', d, a)"
@@ -55,7 +61,10 @@
 		</span>
 
 		<!-- power -->
-		<span v-if="hasCol('power') && viewport >= 600" class="zw-row__cell">
+		<span
+			v-if="hasCol('power') && viewport >= MOBILE_BREAKPOINT"
+			class="zw-row__cell"
+		>
 			<span v-if="device.power.type === 'mains'" class="zw-row__mains">
 				MAINS
 			</span>
@@ -63,7 +72,10 @@
 		</span>
 
 		<!-- signal -->
-		<span v-if="hasCol('signal') && viewport >= 600" class="zw-row__cell">
+		<span
+			v-if="hasCol('signal') && viewport >= MOBILE_BREAKPOINT"
+			class="zw-row__cell"
+		>
 			<component
 				:is="signalIcon"
 				:size="14"
@@ -73,7 +85,7 @@
 
 		<!-- last seen -->
 		<span
-			v-if="hasCol('lastSeen') && viewport >= 600"
+			v-if="hasCol('lastSeen') && viewport >= MOBILE_BREAKPOINT"
 			class="zw-row__cell zw-row__cell--last"
 		>
 			{{ device.lastSeen }}
@@ -106,6 +118,7 @@ import ZwChip from '@/components/dashboard/atoms/ZwChip.vue'
 import ZwActivityReadout from '@/components/dashboard/atoms/ZwActivityReadout.vue'
 import ZwCompactPrimary from './ZwCompactPrimary.vue'
 import { deviceRowGrid, type ToggleableCol } from './deviceRowGrid'
+import { MOBILE_BREAKPOINT } from '@/lib/dashboard-breakpoints'
 import {
 	ChevronDownIcon,
 	DownloadIcon,

--- a/src/components/dashboard/components/ZwDeviceRow.vue
+++ b/src/components/dashboard/components/ZwDeviceRow.vue
@@ -1,0 +1,250 @@
+<template>
+	<div
+		class="zw-row"
+		:class="{
+			'zw-row--expanded': expanded,
+			'zw-row--mobile': viewport < 600,
+		}"
+		:style="rowStyle"
+		@click="emit('expand', device.id)"
+	>
+		<ZwStatusDot
+			:status="device.isController ? 'controller' : device.status"
+		/>
+		<span class="zw-row__id">{{ nodeIdLabel }}</span>
+		<span class="zw-row__name">
+			<component
+				:is="device.archetype.icon"
+				:size="14"
+				class="zw-row__archicon"
+			/>
+			<span class="zw-row__name-stack">
+				<span class="zw-row__name-text">
+					{{ device.name || device.product }}
+				</span>
+				<span v-if="subtitle" class="zw-row__sub">{{ subtitle }}</span>
+			</span>
+		</span>
+
+		<!-- activity/activity -->
+		<span v-if="hasCol('activity') && viewport >= 600" class="zw-row__cell">
+			<ZwActivityReadout
+				v-if="device.activity[0]"
+				variant="table"
+				:activity="device.activity[0]"
+			/>
+			<ZwChip v-else-if="device.hasUpdate" tone="warn">
+				<DownloadIcon :size="ICON_SIZE.chip" /> UPDATE
+			</ZwChip>
+		</span>
+
+		<!-- location -->
+		<span
+			v-if="hasCol('location') && viewport >= 600"
+			class="zw-row__cell zw-row__cell--muted"
+		>
+			{{ device.location || '—' }}
+		</span>
+
+		<!-- value -->
+		<span v-if="hasCol('value') || viewport < 600" class="zw-row__cell">
+			<ZwCompactPrimary
+				:device="device"
+				@action="(d, a) => emit('action', d, a)"
+			/>
+		</span>
+
+		<!-- power -->
+		<span v-if="hasCol('power') && viewport >= 600" class="zw-row__cell">
+			<span v-if="device.power.type === 'mains'" class="zw-row__mains">
+				MAINS
+			</span>
+			<ZwBatteryMini v-else :pct="device.power.battery" />
+		</span>
+
+		<!-- signal -->
+		<span v-if="hasCol('signal') && viewport >= 600" class="zw-row__cell">
+			<component
+				:is="signalIcon"
+				:size="14"
+				:style="{ color: signalIconColor }"
+			/>
+		</span>
+
+		<!-- last seen -->
+		<span
+			v-if="hasCol('lastSeen') && viewport >= 600"
+			class="zw-row__cell zw-row__cell--last"
+		>
+			{{ device.lastSeen }}
+		</span>
+
+		<!-- chevron -->
+		<span class="zw-row__cell">
+			<ChevronDownIcon
+				:size="ICON_SIZE.sortArrow"
+				class="zw-row__chev"
+				:class="{ 'zw-row__chev--open': expanded }"
+			/>
+		</span>
+	</div>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import ZwStatusDot from '@/components/dashboard/atoms/ZwStatusDot.vue'
+import ZwBatteryMini from '@/components/dashboard/atoms/ZwBatteryMini.vue'
+import ZwChip from '@/components/dashboard/atoms/ZwChip.vue'
+import ZwActivityReadout from '@/components/dashboard/atoms/ZwActivityReadout.vue'
+import ZwCompactPrimary from './ZwCompactPrimary.vue'
+import { deviceRowGrid, type ToggleableCol } from './deviceRowGrid'
+import {
+	ChevronDownIcon,
+	DownloadIcon,
+	ICON_SIZE,
+	SignalHighIcon,
+	SignalLowIcon,
+} from '@/lib/icons'
+import type { Device, DeviceAction } from '@/lib/dashboard-types'
+
+const props = defineProps<{
+	device: Device
+	expanded: boolean
+	columns: ToggleableCol[]
+	viewport: number
+}>()
+
+const emit = defineEmits<{
+	expand: [Device['id']]
+	action: [Device, DeviceAction]
+}>()
+
+const nodeIdLabel = computed(() => String(props.device.nodeId).padStart(3, '0'))
+
+const subtitle = computed(() => {
+	const parts = [props.device.manufacturer, props.device.productCode].filter(
+		Boolean,
+	)
+	return parts.length ? parts.join(' · ') : ''
+})
+
+const rowStyle = computed(() => ({
+	gridTemplateColumns: deviceRowGrid(props.viewport, props.columns),
+}))
+
+function hasCol(c: ToggleableCol): boolean {
+	return props.columns.includes(c)
+}
+
+const signalIcon = computed(() =>
+	props.device.health === 'weak' ? SignalLowIcon : SignalHighIcon,
+)
+
+const signalIconColor = computed(() =>
+	props.device.health === 'weak' ? 'var(--zw-warning)' : 'var(--zw-fg-soft)',
+)
+</script>
+
+<style scoped>
+.zw-row {
+	display: grid;
+	column-gap: 8px;
+	align-items: center;
+	padding: 0 16px;
+	height: 42px;
+	border-bottom: 1px solid var(--zw-line);
+	cursor: pointer;
+	transition: background 0.12s;
+}
+
+.zw-row--mobile {
+	padding: 8px 12px;
+	height: auto;
+}
+
+.zw-row:hover {
+	background: var(--zw-row-hover);
+}
+
+.zw-row--expanded {
+	background: var(--zw-chip-bg);
+}
+
+.zw-row__id {
+	font-family: var(--zw-mono);
+	font-size: 11px;
+	color: var(--zw-muted);
+}
+
+.zw-row__name {
+	display: inline-flex;
+	align-items: center;
+	gap: 8px;
+	min-width: 0;
+}
+
+.zw-row__archicon {
+	color: var(--zw-muted);
+	flex: 0 0 auto;
+}
+
+.zw-row__name-stack {
+	display: flex;
+	flex-direction: column;
+	min-width: 0;
+}
+
+.zw-row__name-text {
+	font-size: 13px;
+	font-weight: 600;
+	color: var(--zw-fg);
+	line-height: 1.25;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+.zw-row__sub {
+	font-family: var(--zw-mono);
+	font-size: 10px;
+	color: var(--zw-muted);
+	line-height: 1.25;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+.zw-row__cell {
+	display: inline-flex;
+	align-items: center;
+	min-width: 0;
+}
+
+.zw-row__cell--muted {
+	color: var(--zw-muted);
+	font-size: 12px;
+}
+
+.zw-row__cell--last {
+	font-family: var(--zw-mono);
+	font-size: 10px;
+	color: var(--zw-muted);
+	justify-content: flex-end;
+}
+
+.zw-row__mains {
+	font-family: var(--zw-mono);
+	font-size: 10px;
+	color: var(--zw-muted);
+	letter-spacing: 0.4px;
+}
+
+.zw-row__chev {
+	color: var(--zw-fg-soft);
+	transition: transform 0.18s;
+}
+
+.zw-row__chev--open {
+	transform: rotate(180deg);
+}
+</style>

--- a/src/components/dashboard/components/ZwDeviceRow.vue
+++ b/src/components/dashboard/components/ZwDeviceRow.vue
@@ -81,11 +81,19 @@
 
 		<!-- chevron -->
 		<span class="zw-row__cell">
-			<ChevronDownIcon
-				:size="ICON_SIZE.sortArrow"
-				class="zw-row__chev"
-				:class="{ 'zw-row__chev--open': expanded }"
-			/>
+			<button
+				type="button"
+				class="zw-row__expand"
+				:aria-expanded="expanded"
+				:aria-label="expanded ? 'Collapse details' : 'Expand details'"
+				@click.stop="emit('expand', device.id)"
+			>
+				<ChevronDownIcon
+					:size="ICON_SIZE.sortArrow"
+					class="zw-row__chev"
+					:class="{ 'zw-row__chev--open': expanded }"
+				/>
+			</button>
 		</span>
 	</div>
 </template>
@@ -237,6 +245,23 @@ const signalIconColor = computed(() =>
 	font-size: 10px;
 	color: var(--zw-muted);
 	letter-spacing: 0.4px;
+}
+
+.zw-row__expand {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	padding: 0;
+	border: 0;
+	background: none;
+	color: inherit;
+	cursor: pointer;
+}
+
+.zw-row__expand:focus-visible {
+	outline: 2px solid var(--zw-fg);
+	outline-offset: 2px;
+	border-radius: 4px;
 }
 
 .zw-row__chev {

--- a/src/components/dashboard/components/ZwDeviceRow.vue
+++ b/src/components/dashboard/components/ZwDeviceRow.vue
@@ -6,7 +6,7 @@
 			'zw-row--mobile': viewport < MOBILE_BREAKPOINT,
 		}"
 		:style="rowStyle"
-		@click="emit('expand', device.id)"
+		@click="emit('open', device)"
 	>
 		<ZwStatusDot
 			:status="device.isController ? 'controller' : device.status"
@@ -98,7 +98,7 @@
 				class="zw-row__expand"
 				:aria-expanded="expanded"
 				:aria-label="expanded ? 'Collapse details' : 'Expand details'"
-				@click.stop="emit('expand', device.id)"
+				@click.stop="emit('open', device)"
 			>
 				<ChevronDownIcon
 					:size="ICON_SIZE.sortArrow"
@@ -136,7 +136,11 @@ const props = defineProps<{
 }>()
 
 const emit = defineEmits<{
-	expand: [Device['id']]
+	// "Show this device's details" — the same intent (name + payload) that
+	// ZwDeviceCard emits, so a parent wires one handler for both the row and
+	// the card. The parent owns the surface: expand this row inline (table
+	// view) or open the drawer (card view).
+	open: [Device]
 	action: [Device, DeviceAction]
 }>()
 

--- a/src/components/dashboard/components/ZwExpandedRow.vue
+++ b/src/components/dashboard/components/ZwExpandedRow.vue
@@ -1,0 +1,24 @@
+<template>
+	<div class="zw-expanded-row">
+		<ZwNodeDetailsBody
+			:device="device"
+			:viewport="viewport"
+			@action="(d, a) => emit('action', d, a)"
+		/>
+	</div>
+</template>
+
+<script setup lang="ts">
+import ZwNodeDetailsBody from './ZwNodeDetailsBody.vue'
+import type { Device, DeviceAction } from '@/lib/dashboard-types'
+
+defineProps<{ device: Device; viewport: number }>()
+const emit = defineEmits<{ action: [Device, DeviceAction] }>()
+</script>
+
+<style scoped>
+.zw-expanded-row {
+	background: var(--zw-bg);
+	border-bottom: 1px solid var(--zw-line);
+}
+</style>

--- a/src/components/dashboard/components/ZwExpandedRow.vue
+++ b/src/components/dashboard/components/ZwExpandedRow.vue
@@ -2,7 +2,6 @@
 	<div class="zw-expanded-row">
 		<ZwNodeDetailsBody
 			:device="device"
-			:viewport="viewport"
 			@action="(d, a) => emit('action', d, a)"
 		/>
 	</div>
@@ -12,7 +11,7 @@
 import ZwNodeDetailsBody from './ZwNodeDetailsBody.vue'
 import type { Device, DeviceAction } from '@/lib/dashboard-types'
 
-defineProps<{ device: Device; viewport: number }>()
+defineProps<{ device: Device }>()
 const emit = defineEmits<{ action: [Device, DeviceAction] }>()
 </script>
 

--- a/src/components/dashboard/components/ZwNodeDetailsBody.vue
+++ b/src/components/dashboard/components/ZwNodeDetailsBody.vue
@@ -221,7 +221,7 @@ const advancedCommands = computed<{ label: string; action: DeviceAction }[]>(
 					{ label: 'Interview', action: { type: 'interview' } },
 					{ label: 'Refresh', action: { type: 'refresh' } },
 					{ label: 'Rebuild', action: { type: 'rebuild' } },
-					{ label: 'Replace', action: { type: 'replace' } },
+					{ label: 'Replace', action: { type: 'replace-failed' } },
 					{ label: 'Remove', action: { type: 'remove' } },
 					{ label: 'Ping', action: { type: 'ping' } },
 					{ label: 'Export', action: { type: 'export' } },

--- a/src/components/dashboard/components/ZwNodeDetailsBody.vue
+++ b/src/components/dashboard/components/ZwNodeDetailsBody.vue
@@ -37,8 +37,8 @@
 					Controller exposes no command-class values.
 				</div>
 				<div v-else class="zw-nd__values-stub">
-					<!-- TODO: full ValuesView lands as a follow-up plan
-						 (handoff: values-view.jsx). Render a placeholder. -->
+					<!-- TODO: full ValuesView lands as a follow-up plan.
+						 Render a placeholder for now. -->
 					Values pane — full ValuesView ships with a follow-up plan.
 				</div>
 			</Tabs.Panel>

--- a/src/components/dashboard/components/ZwNodeDetailsBody.vue
+++ b/src/components/dashboard/components/ZwNodeDetailsBody.vue
@@ -1,0 +1,410 @@
+<template>
+	<div class="zw-nd">
+		<header class="zw-nd__header">
+			<div class="zw-nd__header-top">
+				<span class="zw-nd__overline">PRIMARY</span>
+				<span class="zw-nd__status">
+					<ZwStatusDot
+						:status="device.isController ? 'controller' : device.status"
+					/>
+					<span class="zw-nd__status-label">{{ statusLabel }}</span>
+					<span class="zw-nd__bullet">·</span>
+					<span class="zw-nd__lastseen">last seen {{ device.lastSeen }}</span>
+				</span>
+			</div>
+			<div class="zw-nd__primary">
+				<ZwPrimaryDisplay
+					:device="device"
+					@action="(d, a) => emit('action', d, a)"
+				/>
+			</div>
+		</header>
+
+		<Tabs.Root v-model="tab">
+			<Tabs.List as="nav" class="zw-nd__tabs">
+				<Tabs.Item
+					v-for="t in tabs"
+					:key="t.id"
+					:value="t.id"
+					class="zw-nd__tab"
+				>
+					{{ t.label }}
+				</Tabs.Item>
+			</Tabs.List>
+
+			<Tabs.Panel value="values" class="zw-nd__content">
+				<div v-if="device.isController" class="zw-nd__empty">
+					Controller exposes no command-class values.
+				</div>
+				<div v-else class="zw-nd__values-stub">
+					<!-- TODO: full ValuesView lands as a follow-up plan
+						 (handoff: values-view.jsx). Render a placeholder. -->
+					Values pane — full ValuesView ships with a follow-up plan.
+				</div>
+			</Tabs.Panel>
+
+			<Tabs.Panel value="summary" class="zw-nd__content zw-nd__summary">
+				<ZwPropTable :rows="manufacturerRows" />
+				<ZwPropTable :rows="firmwareRows" />
+				<ZwSecurityPanel :device="device" />
+			</Tabs.Panel>
+
+			<Tabs.Panel value="groups" class="zw-nd__content">
+				<ZwPropTable :rows="groupsStub" />
+			</Tabs.Panel>
+
+			<Tabs.Panel value="updates" class="zw-nd__content zw-nd__updates">
+				<div v-if="device.hasUpdate" class="zw-nd__update-card">
+					<div class="zw-nd__update-current">
+						Current {{ device.firmware?.node ?? '—' }}
+					</div>
+					<div class="zw-nd__update-line">
+						Update available — see the device drawer's footer to apply.
+					</div>
+				</div>
+				<div v-else class="zw-nd__empty">No firmware update available.</div>
+			</Tabs.Panel>
+
+			<Tabs.Panel value="events" class="zw-nd__content zw-nd__empty">
+				Recent events — wired up by plan 74 (activity feed).
+			</Tabs.Panel>
+
+			<Tabs.Panel value="debug" class="zw-nd__content">
+				<div v-if="device.isController" class="zw-nd__stats">
+					<ZwStatsCard title="Communication" :items="commStats" />
+					<ZwStatsCard title="Messages" :items="messageStats" />
+				</div>
+				<ZwPropTable v-else :rows="debugRows" />
+			</Tabs.Panel>
+
+			<Tabs.Panel value="advanced" class="zw-nd__content zw-nd__advanced">
+				<ZwButton
+					v-for="cmd in advancedCommands"
+					:key="cmd.label"
+					variant="mono-outline"
+					size="sm"
+					@click="emit('action', device, cmd.action)"
+				>
+					{{ cmd.label }}
+				</ZwButton>
+			</Tabs.Panel>
+		</Tabs.Root>
+	</div>
+</template>
+
+<script setup lang="ts">
+import { ref, computed, watch } from 'vue'
+import { Tabs } from '@vuetify/v0'
+import ZwStatusDot from '@/components/dashboard/atoms/ZwStatusDot.vue'
+import ZwButton from '@/components/dashboard/atoms/ZwButton.vue'
+import ZwPrimaryDisplay from './ZwPrimaryDisplay.vue'
+import ZwPropTable from './ZwPropTable.vue'
+import ZwSecurityPanel from './ZwSecurityPanel.vue'
+import ZwStatsCard, { type StatsItem } from './ZwStatsCard.vue'
+import type { Device, DeviceAction } from '@/lib/dashboard-types'
+
+const props = defineProps<{ device: Device }>()
+const emit = defineEmits<{ action: [Device, DeviceAction] }>()
+
+type TabId =
+	| 'values'
+	| 'summary'
+	| 'groups'
+	| 'updates'
+	| 'events'
+	| 'debug'
+	| 'advanced'
+
+const tabs: { id: TabId; label: string }[] = [
+	{ id: 'values', label: 'Values' },
+	{ id: 'summary', label: 'Summary' },
+	{ id: 'groups', label: 'Groups' },
+	{ id: 'updates', label: 'Updates' },
+	{ id: 'events', label: 'Events' },
+	{ id: 'debug', label: 'Debug' },
+	{ id: 'advanced', label: 'Advanced' },
+]
+
+const tab = ref<TabId>(props.device.isController ? 'summary' : 'values')
+
+// Switching to a different device resets to that device's default tab.
+watch(
+	() => props.device.id,
+	() => {
+		tab.value = props.device.isController ? 'summary' : 'values'
+	},
+)
+
+const statusLabel = computed(() => {
+	const s = props.device.isController ? 'controller' : props.device.status
+	return s.charAt(0).toUpperCase() + s.slice(1)
+})
+
+const manufacturerRows = computed<[string, string | number][]>(() => [
+	['Manufacturer', props.device.manufacturer ?? '—'],
+	['Product', props.device.product ?? '—'],
+	['Code', props.device.productCode ?? '—'],
+	['Protocol', props.device.protocol ?? '—'],
+])
+
+const firmwareRows = computed<[string, string | number][]>(() => [
+	['Firmware', props.device.firmware?.node ?? '—'],
+	['SDK', props.device.firmware?.sdk ?? '—'],
+	['Last seen', props.device.lastSeen],
+	['Interview', props.device.interviewState],
+])
+
+// Stubs — plan 70 (association groups) and plan 74 (events) will
+// flesh these out.
+const groupsStub: [string, string][] = [
+	['Lifeline', '1 → Controller'],
+	['NodeID_1', '—'],
+	['Endpoint', '—'],
+]
+
+const commStats = computed<StatsItem[]>(() => {
+	const s = props.device.commStats
+	return [
+		{ label: 'CAN', value: s?.can ?? 0 },
+		{ label: 'NAK', value: s?.nak ?? 0 },
+		{ label: 'Timeout ACK', value: s?.timeoutACK ?? 0 },
+		{ label: 'Timeout Response', value: s?.timeoutResponse ?? 0 },
+		{ label: 'Timeout Callback', value: s?.timeoutCallback ?? 0 },
+	]
+})
+
+const messageStats = computed<StatsItem[]>(() => {
+	const s = props.device.commStats
+	return [
+		{ label: 'TX', value: s?.messagesTX ?? 0 },
+		{ label: 'RX', value: s?.messagesRX ?? 0 },
+		{ label: 'Dropped TX', value: s?.messagesDroppedTX ?? 0 },
+		{ label: 'Dropped RX', value: s?.messagesDroppedRX ?? 0 },
+	]
+})
+
+const debugRows = computed<[string, string | number][]>(() => [
+	['Endpoint count', '1'],
+	['Routing scheme', '—'],
+	['Tx power', String(props.device.txPower ?? 0) + ' dBm'],
+	[
+		'Wakeup interval',
+		props.device.power.type === 'battery' ? '3600s' : '—',
+	],
+	['Generic device class', props.device.archetype.label],
+])
+
+const advancedCommands = computed<{ label: string; action: DeviceAction }[]>(
+	() =>
+		props.device.isController
+			? [
+					{ label: 'Heal', action: { type: 'heal' } },
+					{ label: 'Backup NVM', action: { type: 'backup-nvm' } },
+					{ label: 'Restore NVM', action: { type: 'restore-nvm' } },
+					{ label: 'Reset stats', action: { type: 'reset-stats' } },
+					{ label: 'Export JSON', action: { type: 'export-json' } },
+					{ label: 'Update topics', action: { type: 'update-topics' } },
+					{ label: 'Hard reset', action: { type: 'hard-reset' } },
+					{ label: 'Restart driver', action: { type: 'restart-driver' } },
+				]
+			: [
+					{ label: 'Interview', action: { type: 'interview' } },
+					{ label: 'Refresh', action: { type: 'refresh' } },
+					{ label: 'Rebuild', action: { type: 'rebuild' } },
+					{ label: 'Replace', action: { type: 'replace' } },
+					{ label: 'Remove', action: { type: 'remove' } },
+					{ label: 'Ping', action: { type: 'ping' } },
+					{ label: 'Export', action: { type: 'export' } },
+					{ label: 'Clear', action: { type: 'clear' } },
+				],
+)
+</script>
+
+<style>
+/* Unscoped — V0 Tabs primitives set inheritAttrs:false, so Vue does not
+   forward the parent's scoped data-v-* hash onto the rendered tab list,
+   items, or panels. The .zw-nd namespace is unique to this component. */
+.zw-nd {
+	display: flex;
+	flex-direction: column;
+	container-type: inline-size;
+	container-name: zw-nd;
+}
+
+/* ── Header ──────────────────────────────────────────────────── */
+.zw-nd__header {
+	padding: 16px;
+	background: var(--zw-bg-soft);
+	border-bottom: 1px solid var(--zw-line);
+}
+
+.zw-nd__header-top {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	margin-bottom: 12px;
+}
+
+.zw-nd__overline {
+	font-family: var(--zw-mono);
+	font-size: 10px;
+	font-weight: 600;
+	color: var(--zw-muted);
+	text-transform: uppercase;
+	letter-spacing: 0.6px;
+}
+
+.zw-nd__status {
+	display: inline-flex;
+	align-items: center;
+	gap: 6px;
+}
+
+.zw-nd__status-label {
+	font-size: 12px;
+	font-weight: 500;
+	color: var(--zw-fg);
+}
+
+.zw-nd__bullet {
+	color: var(--zw-muted);
+}
+
+.zw-nd__lastseen {
+	font-family: var(--zw-mono);
+	font-size: 11px;
+	color: var(--zw-muted);
+}
+
+.zw-nd__primary {
+	font-size: 24px;
+}
+
+/* ── Tabs ────────────────────────────────────────────────────── */
+.zw-nd__tabs {
+	display: flex;
+	gap: 4px;
+	padding: 8px 12px;
+	border-bottom: 1px solid var(--zw-line);
+	background: var(--zw-card);
+	overflow-x: auto;
+}
+
+.zw-nd__tab {
+	appearance: none;
+	background: transparent;
+	border: none;
+	cursor: pointer;
+	padding: 5px 10px;
+	border-radius: 4px;
+	font-family: var(--zw-font);
+	font-size: 12px;
+	font-weight: 500;
+	color: var(--zw-muted);
+	text-transform: capitalize;
+	white-space: nowrap;
+	transition:
+		background 0.12s,
+		color 0.12s;
+}
+
+/* V0 Tabs.Item emits `data-selected="true"` on the active tab. */
+.zw-nd__tab[data-selected='true'] {
+	background: var(--zw-accent);
+	color: #fff;
+}
+
+.zw-nd__tab:focus-visible {
+	outline: 2px solid var(--zw-accent);
+	outline-offset: 1px;
+}
+
+/* ── Content ─────────────────────────────────────────────────── */
+.zw-nd__content {
+	padding: 14px 16px 18px;
+	background: var(--zw-bg);
+	font-size: 12px;
+}
+
+/* V0 Tabs.Panel hides inactive panels via the native `hidden` HTML
+   attribute. Several panels below set `display: grid`, which would win
+   over the user-agent's `display: none` for `[hidden]` — force the
+   hidden state at higher specificity. */
+.zw-nd__content[hidden] {
+	display: none !important;
+}
+
+.zw-nd__summary {
+	display: grid;
+	grid-template-columns: 1fr;
+	gap: 12px;
+}
+
+@container zw-nd (min-width: 540px) {
+	.zw-nd__summary {
+		grid-template-columns: 1fr 1fr;
+	}
+}
+
+@container zw-nd (min-width: 820px) {
+	.zw-nd__summary {
+		grid-template-columns: 1fr 1fr 1fr;
+	}
+}
+
+.zw-nd__empty {
+	padding: 24px;
+	color: var(--zw-muted);
+	text-align: center;
+	font-style: italic;
+}
+
+.zw-nd__values-stub {
+	padding: 24px;
+	color: var(--zw-muted);
+	font-style: italic;
+}
+
+.zw-nd__updates {
+	display: flex;
+	flex-direction: column;
+	gap: 8px;
+}
+
+.zw-nd__update-card {
+	background: var(--zw-card);
+	border: 1px solid var(--zw-line);
+	border-radius: 6px;
+	padding: 12px;
+}
+
+.zw-nd__update-current {
+	font-family: var(--zw-mono);
+	font-size: 11px;
+	color: var(--zw-muted);
+	margin-bottom: 4px;
+}
+
+.zw-nd__update-line {
+	font-size: 13px;
+	color: var(--zw-fg);
+}
+
+.zw-nd__advanced {
+	display: grid;
+	grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+	gap: 8px;
+}
+
+.zw-nd__stats {
+	display: grid;
+	grid-template-columns: 1fr;
+	gap: 12px;
+}
+
+@container zw-nd (min-width: 540px) {
+	.zw-nd__stats {
+		grid-template-columns: 1fr 1fr;
+	}
+}
+</style>

--- a/src/components/dashboard/components/ZwNodeDetailsBody.vue
+++ b/src/components/dashboard/components/ZwNodeDetailsBody.vue
@@ -5,11 +5,15 @@
 				<span class="zw-nd__overline">PRIMARY</span>
 				<span class="zw-nd__status">
 					<ZwStatusDot
-						:status="device.isController ? 'controller' : device.status"
+						:status="
+							device.isController ? 'controller' : device.status
+						"
 					/>
 					<span class="zw-nd__status-label">{{ statusLabel }}</span>
 					<span class="zw-nd__bullet">·</span>
-					<span class="zw-nd__lastseen">last seen {{ device.lastSeen }}</span>
+					<span class="zw-nd__lastseen"
+						>last seen {{ device.lastSeen }}</span
+					>
 				</span>
 			</div>
 			<div class="zw-nd__primary">
@@ -59,10 +63,13 @@
 						Current {{ device.firmware?.node ?? '—' }}
 					</div>
 					<div class="zw-nd__update-line">
-						Update available — see the device drawer's footer to apply.
+						Update available — see the device drawer's footer to
+						apply.
 					</div>
 				</div>
-				<div v-else class="zw-nd__empty">No firmware update available.</div>
+				<div v-else class="zw-nd__empty">
+					No firmware update available.
+				</div>
 			</Tabs.Panel>
 
 			<Tabs.Panel value="events" class="zw-nd__content zw-nd__empty">
@@ -187,10 +194,7 @@ const debugRows = computed<[string, string | number][]>(() => [
 	['Endpoint count', '1'],
 	['Routing scheme', '—'],
 	['Tx power', String(props.device.txPower ?? 0) + ' dBm'],
-	[
-		'Wakeup interval',
-		props.device.power.type === 'battery' ? '3600s' : '—',
-	],
+	['Wakeup interval', props.device.power.type === 'battery' ? '3600s' : '—'],
 	['Generic device class', props.device.archetype.label],
 ])
 
@@ -203,9 +207,15 @@ const advancedCommands = computed<{ label: string; action: DeviceAction }[]>(
 					{ label: 'Restore NVM', action: { type: 'restore-nvm' } },
 					{ label: 'Reset stats', action: { type: 'reset-stats' } },
 					{ label: 'Export JSON', action: { type: 'export-json' } },
-					{ label: 'Update topics', action: { type: 'update-topics' } },
+					{
+						label: 'Update topics',
+						action: { type: 'update-topics' },
+					},
 					{ label: 'Hard reset', action: { type: 'hard-reset' } },
-					{ label: 'Restart driver', action: { type: 'restart-driver' } },
+					{
+						label: 'Restart driver',
+						action: { type: 'restart-driver' },
+					},
 				]
 			: [
 					{ label: 'Interview', action: { type: 'interview' } },

--- a/src/components/dashboard/components/ZwPrimaryDisplay.vue
+++ b/src/components/dashboard/components/ZwPrimaryDisplay.vue
@@ -10,10 +10,7 @@
 
 <script setup lang="ts">
 import { computed } from 'vue'
-import {
-	PRIMARY_RENDERERS,
-	type PrimaryKey,
-} from './primary-display/registry'
+import { PRIMARY_RENDERERS, type PrimaryKey } from './primary-display/registry'
 import type { Device, DeviceAction } from '@/lib/dashboard-types'
 
 const props = defineProps<{ device: Device; compact?: boolean }>()

--- a/src/components/dashboard/components/ZwPrimaryDisplay.vue
+++ b/src/components/dashboard/components/ZwPrimaryDisplay.vue
@@ -1,0 +1,30 @@
+<template>
+	<component
+		v-if="renderer"
+		:is="renderer"
+		:device="device"
+		:compact="compact"
+		@action="(d: Device, a: DeviceAction) => emit('action', d, a)"
+	/>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import {
+	PRIMARY_RENDERERS,
+	type PrimaryKey,
+} from './primary-display/registry'
+import type { Device, DeviceAction } from '@/lib/dashboard-types'
+
+const props = defineProps<{ device: Device; compact?: boolean }>()
+const emit = defineEmits<{ action: [Device, DeviceAction] }>()
+
+const key = computed<PrimaryKey | null>(() => {
+	if (props.device.isController) return 'controller'
+	return props.device.primaryValue?.type ?? null
+})
+
+const renderer = computed(() =>
+	key.value ? PRIMARY_RENDERERS[key.value] : null,
+)
+</script>

--- a/src/components/dashboard/components/ZwPropTable.vue
+++ b/src/components/dashboard/components/ZwPropTable.vue
@@ -1,0 +1,48 @@
+<template>
+	<div v-if="rows.length" class="zw-pt">
+		<div
+			v-for="(row, idx) in rows"
+			:key="idx"
+			class="zw-pt__row"
+			:class="{ 'zw-pt__row--last': idx === rows.length - 1 }"
+		>
+			<span class="zw-pt__label">{{ row[0] }}</span>
+			<span class="zw-pt__value">{{ row[1] }}</span>
+		</div>
+	</div>
+</template>
+
+<script setup lang="ts">
+defineProps<{ rows: [string, string | number][] }>()
+</script>
+
+<style scoped>
+.zw-pt {
+	background: var(--zw-card);
+	border: 1px solid var(--zw-line);
+	border-radius: 6px;
+	overflow: hidden;
+}
+
+.zw-pt__row {
+	display: grid;
+	grid-template-columns: 110px 1fr;
+	gap: 8px;
+	padding: 6px 10px;
+	border-bottom: 1px solid var(--zw-line);
+	font-family: var(--zw-mono);
+	font-size: 11px;
+}
+
+.zw-pt__row--last {
+	border-bottom: none;
+}
+
+.zw-pt__label {
+	color: var(--zw-muted);
+}
+
+.zw-pt__value {
+	color: var(--zw-fg);
+}
+</style>

--- a/src/components/dashboard/components/ZwSecurityPanel.vue
+++ b/src/components/dashboard/components/ZwSecurityPanel.vue
@@ -1,0 +1,84 @@
+<template>
+	<div class="zw-sec">
+		<div class="zw-sec__header">Security Keys</div>
+		<div
+			v-for="entry in entries"
+			:key="entry.id"
+			class="zw-sec__row"
+			:class="{ 'zw-sec__row--missing': !entry.granted }"
+		>
+			<span class="zw-sec__label">{{ entry.label }}</span>
+			<span class="zw-sec__state">
+				{{ entry.granted ? '✓ granted' : '—' }}
+			</span>
+		</div>
+	</div>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import type { Device, SecurityKey } from '@/lib/dashboard-types'
+
+const props = defineProps<{ device: Device }>()
+
+const KEYS: { id: SecurityKey; label: string }[] = [
+	{ id: 'S0', label: 'S0 Legacy' },
+	{ id: 'S2_UA', label: 'S2 Unauthenticated' },
+	{ id: 'S2_A', label: 'S2 Authenticated' },
+	{ id: 'S2_AC', label: 'S2 Access Control' },
+]
+
+const entries = computed(() =>
+	KEYS.map((k) => ({
+		...k,
+		granted: props.device.securityKeys.includes(k.id),
+	})),
+)
+</script>
+
+<style scoped>
+.zw-sec {
+	background: var(--zw-card);
+	border: 1px solid var(--zw-line);
+	border-radius: 6px;
+	overflow: hidden;
+}
+
+.zw-sec__header {
+	padding: 6px 10px;
+	font-family: var(--zw-mono);
+	font-size: 10px;
+	color: var(--zw-muted);
+	text-transform: uppercase;
+	letter-spacing: 0.6px;
+}
+
+.zw-sec__row {
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
+	padding: 5px 10px;
+	font-family: var(--zw-mono);
+	font-size: 11px;
+}
+
+.zw-sec__label {
+	color: var(--zw-fg);
+}
+
+.zw-sec__state {
+	color: #047857;
+}
+
+.zw-sec__row--missing {
+	opacity: 0.4;
+}
+
+.zw-sec__row--missing .zw-sec__state {
+	color: var(--zw-muted);
+}
+
+.zw-sec__row--missing .zw-sec__label {
+	color: var(--zw-muted);
+}
+</style>

--- a/src/components/dashboard/components/ZwSecurityPanel.vue
+++ b/src/components/dashboard/components/ZwSecurityPanel.vue
@@ -67,7 +67,7 @@ const entries = computed(() =>
 }
 
 .zw-sec__state {
-	color: #047857;
+	color: var(--zw-ok);
 }
 
 .zw-sec__row--missing {

--- a/src/components/dashboard/components/ZwStatsCard.vue
+++ b/src/components/dashboard/components/ZwStatsCard.vue
@@ -3,7 +3,9 @@
 		<div class="zw-sc__title">{{ title }}</div>
 		<div
 			class="zw-sc__body"
-			:style="{ gridTemplateColumns: `repeat(auto-fit, minmax(${minCellWidth}px, 1fr))` }"
+			:style="{
+				gridTemplateColumns: `repeat(auto-fit, minmax(${minCellWidth}px, 1fr))`,
+			}"
 		>
 			<div v-for="item in items" :key="item.label" class="zw-sc__cell">
 				<div class="zw-sc__label">{{ item.label }}</div>

--- a/src/components/dashboard/components/ZwStatsCard.vue
+++ b/src/components/dashboard/components/ZwStatsCard.vue
@@ -1,0 +1,99 @@
+<template>
+	<section class="zw-sc">
+		<div class="zw-sc__title">{{ title }}</div>
+		<div
+			class="zw-sc__body"
+			:style="{ gridTemplateColumns: `repeat(auto-fit, minmax(${minCellWidth}px, 1fr))` }"
+		>
+			<div v-for="item in items" :key="item.label" class="zw-sc__cell">
+				<div class="zw-sc__label">{{ item.label }}</div>
+				<div
+					class="zw-sc__value"
+					:class="{ 'zw-sc__value--muted': isMuted(item) }"
+				>
+					{{ formatValue(item) }}
+				</div>
+			</div>
+		</div>
+	</section>
+</template>
+
+<script setup lang="ts">
+export type StatsItem = {
+	label: string
+	value: number | string
+}
+
+withDefaults(
+	defineProps<{
+		title: string
+		items: StatsItem[]
+		minCellWidth?: number
+	}>(),
+	{ minCellWidth: 96 },
+)
+
+function isMuted(item: StatsItem) {
+	return typeof item.value === 'number' && item.value === 0
+}
+
+function formatValue(item: StatsItem) {
+	if (typeof item.value === 'number') {
+		return item.value === 0 ? '—' : item.value.toLocaleString()
+	}
+	return item.value
+}
+</script>
+
+<style scoped>
+.zw-sc {
+	background: var(--zw-card);
+	border: 1px solid var(--zw-line);
+	border-radius: 6px;
+	overflow: hidden;
+	padding-bottom: 8px;
+}
+
+.zw-sc__title {
+	padding: 6px 10px;
+	font-family: var(--zw-mono);
+	font-size: 10px;
+	color: var(--zw-muted);
+	text-transform: uppercase;
+	letter-spacing: 0.6px;
+}
+
+.zw-sc__body {
+	display: grid;
+	gap: 1px;
+	background: var(--zw-line);
+}
+
+.zw-sc__cell {
+	display: flex;
+	flex-direction: column;
+	gap: 3px;
+	padding: 8px 10px;
+	background: var(--zw-card);
+}
+
+.zw-sc__label {
+	font-family: var(--zw-mono);
+	font-size: 10px;
+	color: var(--zw-muted);
+	text-transform: uppercase;
+	letter-spacing: 0.4px;
+}
+
+.zw-sc__value {
+	font-family: var(--zw-mono);
+	font-size: 15px;
+	font-weight: 500;
+	color: var(--zw-fg);
+	font-variant-numeric: tabular-nums;
+}
+
+.zw-sc__value--muted {
+	color: var(--zw-muted);
+}
+</style>

--- a/src/components/dashboard/components/deviceRowGrid.ts
+++ b/src/components/dashboard/components/deviceRowGrid.ts
@@ -1,5 +1,9 @@
 // deviceRowGrid — DeviceRow column packing.
 //
+// TOGGLEABLE_COLS below is the single source of truth for the optional
+// columns — their ids, order and human labels. ZwColumnsMenu renders its
+// menu from it and ZwDeviceRow keys off the same `ToggleableCol` ids.
+//
 // The viewport drives whether columns are visible at all; the
 // `columns` array drives which optional columns participate.
 // Returns a string ready for `grid-template-columns`.
@@ -11,6 +15,17 @@ export type ToggleableCol =
 	| 'power'
 	| 'signal'
 	| 'lastSeen'
+
+// The toggleable columns in display order, with their menu labels. This is
+// the one place the list is declared; consumers import from here.
+export const TOGGLEABLE_COLS: { id: ToggleableCol; label: string }[] = [
+	{ id: 'activity', label: 'Activity' },
+	{ id: 'location', label: 'Location' },
+	{ id: 'value', label: 'State / Value' },
+	{ id: 'power', label: 'Power' },
+	{ id: 'signal', label: 'Link' },
+	{ id: 'lastSeen', label: 'Last seen' },
+]
 
 const WIDTHS: Record<ToggleableCol, string> = {
 	activity: '120px',

--- a/src/components/dashboard/components/deviceRowGrid.ts
+++ b/src/components/dashboard/components/deviceRowGrid.ts
@@ -8,6 +8,8 @@
 // `columns` array drives which optional columns participate.
 // Returns a string ready for `grid-template-columns`.
 
+import { MOBILE_BREAKPOINT } from '@/lib/dashboard-breakpoints.ts'
+
 export type ToggleableCol =
 	| 'activity'
 	| 'location'
@@ -40,7 +42,7 @@ export function deviceRowGrid(
 	viewport: number,
 	columns: readonly ToggleableCol[],
 ): string {
-	if (viewport < 600) {
+	if (viewport < MOBILE_BREAKPOINT) {
 		// Mobile collapse: status, id, name, value, chevron only.
 		return 'auto auto 1fr auto auto'
 	}

--- a/src/components/dashboard/components/deviceRowGrid.ts
+++ b/src/components/dashboard/components/deviceRowGrid.ts
@@ -1,9 +1,8 @@
 // deviceRowGrid — DeviceRow column packing.
 //
-// Mirrors direction-b.jsx:237-251. The viewport drives whether
-// columns are visible at all; the `columns` array drives which
-// optional columns participate. Returns a string ready for
-// `grid-template-columns`.
+// The viewport drives whether columns are visible at all; the
+// `columns` array drives which optional columns participate.
+// Returns a string ready for `grid-template-columns`.
 
 export type ToggleableCol =
 	| 'activity'

--- a/src/components/dashboard/components/deviceRowGrid.ts
+++ b/src/components/dashboard/components/deviceRowGrid.ts
@@ -1,0 +1,40 @@
+// deviceRowGrid — DeviceRow column packing.
+//
+// Mirrors direction-b.jsx:237-251. The viewport drives whether
+// columns are visible at all; the `columns` array drives which
+// optional columns participate. Returns a string ready for
+// `grid-template-columns`.
+
+export type ToggleableCol =
+	| 'activity'
+	| 'location'
+	| 'value'
+	| 'power'
+	| 'signal'
+	| 'lastSeen'
+
+const WIDTHS: Record<ToggleableCol, string> = {
+	activity: '120px',
+	location: '1fr',
+	value: '1.4fr',
+	power: '72px',
+	signal: '18px',
+	lastSeen: '88px',
+}
+
+export function deviceRowGrid(
+	viewport: number,
+	columns: readonly ToggleableCol[],
+): string {
+	if (viewport < 600) {
+		// Mobile collapse: status, id, name, value, chevron only.
+		return 'auto auto 1fr auto auto'
+	}
+
+	const parts: string[] = ['14px', '32px', '1.6fr']
+	for (const col of columns) {
+		parts.push(WIDTHS[col])
+	}
+	parts.push('14px')
+	return parts.join(' ')
+}

--- a/src/components/dashboard/components/primary-display/ZwPrimaryController.vue
+++ b/src/components/dashboard/components/primary-display/ZwPrimaryController.vue
@@ -1,0 +1,36 @@
+<template>
+	<div class="zw-pv-controller">
+		<div class="zw-pv-controller__node">
+			{{ device.firmware?.node ?? '—' }}
+		</div>
+		<div v-if="device.firmware?.sdk" class="zw-pv-controller__sdk">
+			SDK {{ device.firmware.sdk }}
+		</div>
+	</div>
+</template>
+
+<script setup lang="ts">
+import type { Device } from '@/lib/dashboard-types'
+
+defineProps<{ device: Device; compact?: boolean }>()
+</script>
+
+<style scoped>
+.zw-pv-controller {
+	display: flex;
+	flex-direction: column;
+	gap: 4px;
+}
+
+.zw-pv-controller__node {
+	font-size: 24px;
+	font-weight: 600;
+	color: var(--zw-fg);
+}
+
+.zw-pv-controller__sdk {
+	font-family: var(--zw-mono);
+	font-size: 11px;
+	color: var(--zw-muted);
+}
+</style>

--- a/src/components/dashboard/components/primary-display/ZwPrimaryDim.vue
+++ b/src/components/dashboard/components/primary-display/ZwPrimaryDim.vue
@@ -8,7 +8,9 @@
 		</div>
 		<ZwSlider
 			:model-value="pv.level"
-			@update:model-value="(level) => emit('action', device, { type: 'dim', level })"
+			@update:model-value="
+				(level) => emit('action', device, { type: 'dim', level })
+			"
 		/>
 	</div>
 </template>

--- a/src/components/dashboard/components/primary-display/ZwPrimaryDim.vue
+++ b/src/components/dashboard/components/primary-display/ZwPrimaryDim.vue
@@ -1,0 +1,69 @@
+<template>
+	<div class="zw-pv-dim" @click.stop>
+		<div class="zw-pv-dim__top">
+			<span class="zw-pv-dim__value">
+				{{ pv.level }}<span class="zw-pv-dim__pct">%</span>
+			</span>
+			<span class="zw-pv-dim__caption">{{ caption }}</span>
+		</div>
+		<ZwSlider
+			:model-value="pv.level"
+			@update:model-value="(level) => emit('action', device, { type: 'dim', level })"
+		/>
+	</div>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import ZwSlider from '@/components/dashboard/atoms/ZwSlider.vue'
+import type {
+	Device,
+	DeviceAction,
+	PrimaryValueDim,
+} from '@/lib/dashboard-types'
+
+const props = defineProps<{ device: Device; compact?: boolean }>()
+const emit = defineEmits<{ action: [Device, DeviceAction] }>()
+
+const pv = computed(() => props.device.primaryValue as PrimaryValueDim)
+
+const caption = computed(() =>
+	props.device.archetype.kind === 'shade' ? 'Open' : 'Bright',
+)
+</script>
+
+<style scoped>
+.zw-pv-dim {
+	display: flex;
+	flex-direction: column;
+	gap: 10px;
+}
+
+.zw-pv-dim__top {
+	display: flex;
+	align-items: baseline;
+	justify-content: space-between;
+	gap: 8px;
+}
+
+.zw-pv-dim__value {
+	font-size: 22px;
+	font-weight: 600;
+	color: var(--zw-fg);
+	line-height: 1;
+}
+
+.zw-pv-dim__pct {
+	font-size: 14px;
+	color: var(--zw-muted);
+	margin-left: 2px;
+}
+
+.zw-pv-dim__caption {
+	font-size: 11px;
+	font-weight: 600;
+	color: var(--zw-muted);
+	text-transform: uppercase;
+	letter-spacing: 0.4px;
+}
+</style>

--- a/src/components/dashboard/components/primary-display/ZwPrimaryDim.vue
+++ b/src/components/dashboard/components/primary-display/ZwPrimaryDim.vue
@@ -1,5 +1,5 @@
 <template>
-	<div class="zw-pv-dim" @click.stop>
+	<div v-if="pv" class="zw-pv-dim" @click.stop>
 		<div class="zw-pv-dim__top">
 			<span class="zw-pv-dim__value">
 				{{ pv.level }}<span class="zw-pv-dim__pct">%</span>
@@ -18,16 +18,13 @@
 <script setup lang="ts">
 import { computed } from 'vue'
 import ZwSlider from '@/components/dashboard/atoms/ZwSlider.vue'
-import type {
-	Device,
-	DeviceAction,
-	PrimaryValueDim,
-} from '@/lib/dashboard-types'
+import { usePrimaryValue } from './usePrimaryValue'
+import type { Device, DeviceAction } from '@/lib/dashboard-types'
 
 const props = defineProps<{ device: Device; compact?: boolean }>()
 const emit = defineEmits<{ action: [Device, DeviceAction] }>()
 
-const pv = computed(() => props.device.primaryValue as PrimaryValueDim)
+const pv = usePrimaryValue(() => props.device, 'dim')
 
 const caption = computed(() =>
 	props.device.archetype.kind === 'shade' ? 'Open' : 'Bright',

--- a/src/components/dashboard/components/primary-display/ZwPrimaryLock.vue
+++ b/src/components/dashboard/components/primary-display/ZwPrimaryLock.vue
@@ -1,0 +1,52 @@
+<template>
+	<div class="zw-pv-lock" @click.stop>
+		<div class="zw-pv-lock__label-col">
+			<div
+				class="zw-pv-lock__label"
+				:class="{ 'zw-pv-lock__label--unlocked': !pv.locked }"
+			>
+				{{ pv.locked ? 'Locked' : 'Unlocked' }}
+			</div>
+		</div>
+		<ZwToggle
+			:model-value="pv.locked"
+			size="md"
+			@update:model-value="(locked) => emit('action', device, { type: 'lock', locked })"
+		/>
+	</div>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import ZwToggle from '@/components/dashboard/atoms/ZwToggle.vue'
+import type {
+	Device,
+	DeviceAction,
+	PrimaryValueLock,
+} from '@/lib/dashboard-types'
+
+const props = defineProps<{ device: Device; compact?: boolean }>()
+const emit = defineEmits<{ action: [Device, DeviceAction] }>()
+
+const pv = computed(() => props.device.primaryValue as PrimaryValueLock)
+</script>
+
+<style scoped>
+.zw-pv-lock {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: 12px;
+}
+
+.zw-pv-lock__label {
+	font-size: 22px;
+	font-weight: 600;
+	color: var(--zw-fg);
+	line-height: 1.1;
+}
+
+.zw-pv-lock__label--unlocked {
+	color: #a14b1f;
+}
+</style>

--- a/src/components/dashboard/components/primary-display/ZwPrimaryLock.vue
+++ b/src/components/dashboard/components/primary-display/ZwPrimaryLock.vue
@@ -11,7 +11,9 @@
 		<ZwToggle
 			:model-value="pv.locked"
 			size="md"
-			@update:model-value="(locked) => emit('action', device, { type: 'lock', locked })"
+			@update:model-value="
+				(locked) => emit('action', device, { type: 'lock', locked })
+			"
 		/>
 	</div>
 </template>

--- a/src/components/dashboard/components/primary-display/ZwPrimaryLock.vue
+++ b/src/components/dashboard/components/primary-display/ZwPrimaryLock.vue
@@ -1,5 +1,5 @@
 <template>
-	<div class="zw-pv-lock" @click.stop>
+	<div v-if="pv" class="zw-pv-lock" @click.stop>
 		<div class="zw-pv-lock__label-col">
 			<div
 				class="zw-pv-lock__label"
@@ -19,18 +19,14 @@
 </template>
 
 <script setup lang="ts">
-import { computed } from 'vue'
 import ZwToggle from '@/components/dashboard/atoms/ZwToggle.vue'
-import type {
-	Device,
-	DeviceAction,
-	PrimaryValueLock,
-} from '@/lib/dashboard-types'
+import { usePrimaryValue } from './usePrimaryValue'
+import type { Device, DeviceAction } from '@/lib/dashboard-types'
 
 const props = defineProps<{ device: Device; compact?: boolean }>()
 const emit = defineEmits<{ action: [Device, DeviceAction] }>()
 
-const pv = computed(() => props.device.primaryValue as PrimaryValueLock)
+const pv = usePrimaryValue(() => props.device, 'lock')
 </script>
 
 <style scoped>

--- a/src/components/dashboard/components/primary-display/ZwPrimaryLock.vue
+++ b/src/components/dashboard/components/primary-display/ZwPrimaryLock.vue
@@ -45,6 +45,6 @@ const pv = usePrimaryValue(() => props.device, 'lock')
 }
 
 .zw-pv-lock__label--unlocked {
-	color: #a14b1f;
+	color: var(--zw-warning);
 }
 </style>

--- a/src/components/dashboard/components/primary-display/ZwPrimaryReading.vue
+++ b/src/components/dashboard/components/primary-display/ZwPrimaryReading.vue
@@ -1,17 +1,17 @@
 <template>
-	<div class="zw-pv-reading">
+	<div v-if="pv" class="zw-pv-reading">
 		<span class="zw-pv-reading__value">{{ pv.value }}</span>
 		<span class="zw-pv-reading__unit">{{ pv.unit }}</span>
 	</div>
 </template>
 
 <script setup lang="ts">
-import { computed } from 'vue'
-import type { Device, PrimaryValueReading } from '@/lib/dashboard-types'
+import { usePrimaryValue } from './usePrimaryValue'
+import type { Device } from '@/lib/dashboard-types'
 
 const props = defineProps<{ device: Device; compact?: boolean }>()
 
-const pv = computed(() => props.device.primaryValue as PrimaryValueReading)
+const pv = usePrimaryValue(() => props.device, 'reading')
 </script>
 
 <style scoped>

--- a/src/components/dashboard/components/primary-display/ZwPrimaryReading.vue
+++ b/src/components/dashboard/components/primary-display/ZwPrimaryReading.vue
@@ -1,0 +1,35 @@
+<template>
+	<div class="zw-pv-reading">
+		<span class="zw-pv-reading__value">{{ pv.value }}</span>
+		<span class="zw-pv-reading__unit">{{ pv.unit }}</span>
+	</div>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import type { Device, PrimaryValueReading } from '@/lib/dashboard-types'
+
+const props = defineProps<{ device: Device; compact?: boolean }>()
+
+const pv = computed(() => props.device.primaryValue as PrimaryValueReading)
+</script>
+
+<style scoped>
+.zw-pv-reading {
+	display: inline-flex;
+	align-items: baseline;
+	gap: 4px;
+}
+
+.zw-pv-reading__value {
+	font-size: 28px;
+	font-weight: 600;
+	color: var(--zw-fg);
+	line-height: 1;
+}
+
+.zw-pv-reading__unit {
+	font-size: 14px;
+	color: var(--zw-muted);
+}
+</style>

--- a/src/components/dashboard/components/primary-display/ZwPrimaryState.vue
+++ b/src/components/dashboard/components/primary-display/ZwPrimaryState.vue
@@ -1,5 +1,5 @@
 <template>
-	<div class="zw-pv-state">
+	<div v-if="pv" class="zw-pv-state">
 		<div
 			class="zw-pv-state__value"
 			:class="{ 'zw-pv-state__value--alert': isAlert }"
@@ -12,11 +12,12 @@
 
 <script setup lang="ts">
 import { computed } from 'vue'
-import type { Device, PrimaryValueState } from '@/lib/dashboard-types'
+import { usePrimaryValue } from './usePrimaryValue'
+import type { Device } from '@/lib/dashboard-types'
 
 const props = defineProps<{ device: Device; compact?: boolean }>()
 
-const pv = computed(() => props.device.primaryValue as PrimaryValueState)
+const pv = usePrimaryValue(() => props.device, 'state')
 
 const isAlert = computed(() => {
 	const v = pv.value

--- a/src/components/dashboard/components/primary-display/ZwPrimaryState.vue
+++ b/src/components/dashboard/components/primary-display/ZwPrimaryState.vue
@@ -38,7 +38,7 @@ const isAlert = computed(() => (pv.value ? isStateAlert(pv.value) : false))
 }
 
 .zw-pv-state__value--alert {
-	color: #a14b1f;
+	color: var(--zw-warning);
 }
 
 .zw-pv-state__caption {

--- a/src/components/dashboard/components/primary-display/ZwPrimaryState.vue
+++ b/src/components/dashboard/components/primary-display/ZwPrimaryState.vue
@@ -13,19 +13,14 @@
 <script setup lang="ts">
 import { computed } from 'vue'
 import { usePrimaryValue } from './usePrimaryValue'
+import { isStateAlert } from '@/lib/primaryValue'
 import type { Device } from '@/lib/dashboard-types'
 
 const props = defineProps<{ device: Device; compact?: boolean }>()
 
 const pv = usePrimaryValue(() => props.device, 'state')
 
-const isAlert = computed(() => {
-	const v = pv.value
-	if (!v) return false
-	return (
-		v.stateIdx === 1 && (v.colors[1] === 'red' || v.colors[1] === 'amber')
-	)
-})
+const isAlert = computed(() => (pv.value ? isStateAlert(pv.value) : false))
 </script>
 
 <style scoped>

--- a/src/components/dashboard/components/primary-display/ZwPrimaryState.vue
+++ b/src/components/dashboard/components/primary-display/ZwPrimaryState.vue
@@ -1,6 +1,9 @@
 <template>
 	<div class="zw-pv-state">
-		<div class="zw-pv-state__value" :class="{ 'zw-pv-state__value--alert': isAlert }">
+		<div
+			class="zw-pv-state__value"
+			:class="{ 'zw-pv-state__value--alert': isAlert }"
+		>
 			{{ pv.value }}
 		</div>
 		<div class="zw-pv-state__caption">{{ device.archetype.label }}</div>
@@ -18,7 +21,9 @@ const pv = computed(() => props.device.primaryValue as PrimaryValueState)
 const isAlert = computed(() => {
 	const v = pv.value
 	if (!v) return false
-	return v.stateIdx === 1 && (v.colors[1] === 'red' || v.colors[1] === 'amber')
+	return (
+		v.stateIdx === 1 && (v.colors[1] === 'red' || v.colors[1] === 'amber')
+	)
 })
 </script>
 

--- a/src/components/dashboard/components/primary-display/ZwPrimaryState.vue
+++ b/src/components/dashboard/components/primary-display/ZwPrimaryState.vue
@@ -1,0 +1,47 @@
+<template>
+	<div class="zw-pv-state">
+		<div class="zw-pv-state__value" :class="{ 'zw-pv-state__value--alert': isAlert }">
+			{{ pv.value }}
+		</div>
+		<div class="zw-pv-state__caption">{{ device.archetype.label }}</div>
+	</div>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import type { Device, PrimaryValueState } from '@/lib/dashboard-types'
+
+const props = defineProps<{ device: Device; compact?: boolean }>()
+
+const pv = computed(() => props.device.primaryValue as PrimaryValueState)
+
+const isAlert = computed(() => {
+	const v = pv.value
+	if (!v) return false
+	return v.stateIdx === 1 && (v.colors[1] === 'red' || v.colors[1] === 'amber')
+})
+</script>
+
+<style scoped>
+.zw-pv-state {
+	display: flex;
+	flex-direction: column;
+	gap: 4px;
+}
+
+.zw-pv-state__value {
+	font-size: 22px;
+	font-weight: 600;
+	color: var(--zw-fg);
+	line-height: 1.1;
+}
+
+.zw-pv-state__value--alert {
+	color: #a14b1f;
+}
+
+.zw-pv-state__caption {
+	font-size: 11px;
+	color: var(--zw-muted);
+}
+</style>

--- a/src/components/dashboard/components/primary-display/ZwPrimaryThermostat.vue
+++ b/src/components/dashboard/components/primary-display/ZwPrimaryThermostat.vue
@@ -1,0 +1,66 @@
+<template>
+	<div class="zw-pv-thermostat">
+		<div class="zw-pv-thermostat__row">
+			<span class="zw-pv-thermostat__current">{{ pv.value }}</span>
+			<span class="zw-pv-thermostat__unit">{{ pv.unit }}</span>
+			<span class="zw-pv-thermostat__setpoint">
+				→ {{ pv.setpoint }}{{ pv.unit }}
+			</span>
+		</div>
+		<div class="zw-pv-thermostat__mode">{{ pv.mode }}</div>
+	</div>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import type {
+	Device,
+	DeviceAction,
+	PrimaryValueThermostat,
+} from '@/lib/dashboard-types'
+
+const props = defineProps<{ device: Device; compact?: boolean }>()
+// Setpoint / mode editing controls live in the drawer; the card variant
+// of this renderer is read-only. The emit is still declared so the
+// dispatcher's @action passthrough is type-correct.
+defineEmits<{ action: [Device, DeviceAction] }>()
+
+const pv = computed(() => props.device.primaryValue as PrimaryValueThermostat)
+</script>
+
+<style scoped>
+.zw-pv-thermostat {
+	display: flex;
+	flex-direction: column;
+	gap: 4px;
+}
+
+.zw-pv-thermostat__row {
+	display: inline-flex;
+	align-items: baseline;
+	gap: 6px;
+}
+
+.zw-pv-thermostat__current {
+	font-size: 24px;
+	font-weight: 600;
+	color: var(--zw-fg);
+	line-height: 1;
+}
+
+.zw-pv-thermostat__unit {
+	font-size: 13px;
+	color: var(--zw-muted);
+}
+
+.zw-pv-thermostat__setpoint {
+	font-size: 11px;
+	color: var(--zw-muted);
+}
+
+.zw-pv-thermostat__mode {
+	font-size: 11px;
+	color: var(--zw-muted);
+	text-transform: capitalize;
+}
+</style>

--- a/src/components/dashboard/components/primary-display/ZwPrimaryThermostat.vue
+++ b/src/components/dashboard/components/primary-display/ZwPrimaryThermostat.vue
@@ -1,5 +1,5 @@
 <template>
-	<div class="zw-pv-thermostat">
+	<div v-if="pv" class="zw-pv-thermostat">
 		<div class="zw-pv-thermostat__row">
 			<span class="zw-pv-thermostat__current">{{ pv.value }}</span>
 			<span class="zw-pv-thermostat__unit">{{ pv.unit }}</span>
@@ -12,12 +12,8 @@
 </template>
 
 <script setup lang="ts">
-import { computed } from 'vue'
-import type {
-	Device,
-	DeviceAction,
-	PrimaryValueThermostat,
-} from '@/lib/dashboard-types'
+import { usePrimaryValue } from './usePrimaryValue'
+import type { Device, DeviceAction } from '@/lib/dashboard-types'
 
 const props = defineProps<{ device: Device; compact?: boolean }>()
 // Setpoint / mode editing controls live in the drawer; the card variant
@@ -25,7 +21,7 @@ const props = defineProps<{ device: Device; compact?: boolean }>()
 // dispatcher's @action passthrough is type-correct.
 defineEmits<{ action: [Device, DeviceAction] }>()
 
-const pv = computed(() => props.device.primaryValue as PrimaryValueThermostat)
+const pv = usePrimaryValue(() => props.device, 'thermostat')
 </script>
 
 <style scoped>

--- a/src/components/dashboard/components/primary-display/ZwPrimaryToggle.vue
+++ b/src/components/dashboard/components/primary-display/ZwPrimaryToggle.vue
@@ -1,0 +1,67 @@
+<template>
+	<div class="zw-pv-toggle" @click.stop>
+		<div class="zw-pv-toggle__label-col">
+			<div
+				class="zw-pv-toggle__label"
+				:class="{ 'zw-pv-toggle__label--off': !pv.on }"
+			>
+				{{ pv.on ? 'On' : 'Off' }}
+			</div>
+			<div v-if="pv.on && pv.watts != null" class="zw-pv-toggle__caption">
+				{{ pv.watts }} W
+			</div>
+		</div>
+		<ZwToggle
+			:model-value="pv.on"
+			size="md"
+			@update:model-value="(on) => emit('action', device, { type: 'toggle', on })"
+		/>
+	</div>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import ZwToggle from '@/components/dashboard/atoms/ZwToggle.vue'
+import type {
+	Device,
+	DeviceAction,
+	PrimaryValueToggle,
+} from '@/lib/dashboard-types'
+
+const props = defineProps<{ device: Device; compact?: boolean }>()
+const emit = defineEmits<{ action: [Device, DeviceAction] }>()
+
+const pv = computed(() => props.device.primaryValue as PrimaryValueToggle)
+</script>
+
+<style scoped>
+.zw-pv-toggle {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: 12px;
+}
+
+.zw-pv-toggle__label-col {
+	display: flex;
+	flex-direction: column;
+	gap: 2px;
+}
+
+.zw-pv-toggle__label {
+	font-size: 22px;
+	font-weight: 600;
+	color: var(--zw-fg);
+	line-height: 1.1;
+}
+
+.zw-pv-toggle__label--off {
+	color: var(--zw-muted);
+}
+
+.zw-pv-toggle__caption {
+	font-family: var(--zw-mono);
+	font-size: 11px;
+	color: var(--zw-muted);
+}
+</style>

--- a/src/components/dashboard/components/primary-display/ZwPrimaryToggle.vue
+++ b/src/components/dashboard/components/primary-display/ZwPrimaryToggle.vue
@@ -1,5 +1,5 @@
 <template>
-	<div class="zw-pv-toggle" @click.stop>
+	<div v-if="pv" class="zw-pv-toggle" @click.stop>
 		<div class="zw-pv-toggle__label-col">
 			<div
 				class="zw-pv-toggle__label"
@@ -22,18 +22,14 @@
 </template>
 
 <script setup lang="ts">
-import { computed } from 'vue'
 import ZwToggle from '@/components/dashboard/atoms/ZwToggle.vue'
-import type {
-	Device,
-	DeviceAction,
-	PrimaryValueToggle,
-} from '@/lib/dashboard-types'
+import { usePrimaryValue } from './usePrimaryValue'
+import type { Device, DeviceAction } from '@/lib/dashboard-types'
 
 const props = defineProps<{ device: Device; compact?: boolean }>()
 const emit = defineEmits<{ action: [Device, DeviceAction] }>()
 
-const pv = computed(() => props.device.primaryValue as PrimaryValueToggle)
+const pv = usePrimaryValue(() => props.device, 'toggle')
 </script>
 
 <style scoped>

--- a/src/components/dashboard/components/primary-display/ZwPrimaryToggle.vue
+++ b/src/components/dashboard/components/primary-display/ZwPrimaryToggle.vue
@@ -14,7 +14,9 @@
 		<ZwToggle
 			:model-value="pv.on"
 			size="md"
-			@update:model-value="(on) => emit('action', device, { type: 'toggle', on })"
+			@update:model-value="
+				(on) => emit('action', device, { type: 'toggle', on })
+			"
 		/>
 	</div>
 </template>

--- a/src/components/dashboard/components/primary-display/registry.ts
+++ b/src/components/dashboard/components/primary-display/registry.ts
@@ -1,0 +1,33 @@
+// Per-type renderer registry for ZwPrimaryDisplay.
+//
+// Adding a new primary-value type is:
+//   1. Extend PrimaryValueType in @/lib/dashboard-types.
+//   2. Map the projection in plan 70 (`projectPrimaryValue`).
+//   3. Add the corresponding shape to DeviceAction.
+//   4. Create ZwPrimary<NewType>.vue here.
+//   5. Add the entry to PRIMARY_RENDERERS — TypeScript's
+//      `Record<PrimaryKey, Component>` exhaustiveness will fail the
+//      build until this is done.
+
+import type { Component } from 'vue'
+import type { PrimaryValueType } from '@/lib/dashboard-types'
+
+import Controller from './ZwPrimaryController.vue'
+import Toggle from './ZwPrimaryToggle.vue'
+import Dim from './ZwPrimaryDim.vue'
+import Lock from './ZwPrimaryLock.vue'
+import Reading from './ZwPrimaryReading.vue'
+import State from './ZwPrimaryState.vue'
+import Thermostat from './ZwPrimaryThermostat.vue'
+
+export type PrimaryKey = PrimaryValueType | 'controller'
+
+export const PRIMARY_RENDERERS: Record<PrimaryKey, Component> = {
+	controller: Controller,
+	toggle: Toggle,
+	dim: Dim,
+	lock: Lock,
+	reading: Reading,
+	state: State,
+	thermostat: Thermostat,
+}

--- a/src/components/dashboard/components/primary-display/usePrimaryValue.ts
+++ b/src/components/dashboard/components/primary-display/usePrimaryValue.ts
@@ -1,0 +1,30 @@
+// Type-safe access to a device's primary value for the per-type renderers.
+//
+// Each renderer in this folder handles exactly one PrimaryValueType. Rather
+// than assert the shape with a bare `as PrimaryValueX` — which severs the
+// link between the registry key and the subtype, so a mis-wire (e.g. mapping
+// the `state` key to the Toggle renderer) type-checks and only fails at
+// runtime — a renderer narrows with `usePrimaryValue(() => props.device,
+// 'state')` and receives `PrimaryValueState | null`.
+//
+// The discriminant is CHECKED at runtime, so a mis-wire renders nothing
+// (the `v-if="pv"` guard short-circuits) instead of reading fields off the
+// wrong shape. The single internal cast is sound precisely because it sits
+// behind that `pv.type === type` guard — narrowing is verified, not asserted.
+
+import { computed, type ComputedRef } from 'vue'
+import type {
+	Device,
+	PrimaryValueByType,
+	PrimaryValueType,
+} from '@/lib/dashboard-types'
+
+export function usePrimaryValue<T extends PrimaryValueType>(
+	device: () => Device,
+	type: T,
+): ComputedRef<PrimaryValueByType[T] | null> {
+	return computed(() => {
+		const pv = device().primaryValue
+		return pv?.type === type ? (pv as PrimaryValueByType[T]) : null
+	})
+}

--- a/src/components/dashboard/layout/ZwDeviceDrawer.vue
+++ b/src/components/dashboard/layout/ZwDeviceDrawer.vue
@@ -1,0 +1,193 @@
+<template>
+	<Dialog.Root v-model="open">
+		<Dialog.Content
+			class="zw-drawer__panel"
+			:close-on-click-outside="true"
+		>
+			<template v-if="device">
+				<header class="zw-drawer__header">
+					<div class="zw-drawer__icon">
+						<component
+							:is="device.archetype.icon"
+							:size="ICON_SIZE.drawerHeader"
+						/>
+					</div>
+					<div class="zw-drawer__name-col">
+						<div class="zw-drawer__name">{{ device.name }}</div>
+						<div class="zw-drawer__sub">
+							Node {{ paddedNodeId }}
+							<template v-if="device.manufacturer">
+								· {{ device.manufacturer }}
+							</template>
+							<template v-if="device.productCode">
+								· {{ device.productCode }}
+							</template>
+						</div>
+					</div>
+					<Dialog.Close
+						as="button"
+						class="zw-drawer__close"
+						aria-label="Close drawer"
+					>
+						<XIcon :size="ICON_SIZE.topbar" />
+					</Dialog.Close>
+				</header>
+				<div class="zw-drawer__body">
+					<ZwNodeDetailsBody
+						:device="device"
+						@action="(d, a) => emit('action', d, a)"
+					/>
+				</div>
+			</template>
+		</Dialog.Content>
+	</Dialog.Root>
+</template>
+
+<script setup lang="ts">
+import { computed, ref, watch } from 'vue'
+import { Dialog } from '@vuetify/v0'
+import ZwNodeDetailsBody from '@/components/dashboard/components/ZwNodeDetailsBody.vue'
+import { ICON_SIZE, XIcon } from '@/lib/icons'
+import type { Device, DeviceAction } from '@/lib/dashboard-types'
+
+const props = defineProps<{ device: Device | null; viewport: number }>()
+const emit = defineEmits<{
+	close: []
+	action: [Device, DeviceAction]
+}>()
+
+const paddedNodeId = computed(() =>
+	String(props.device?.nodeId ?? 0).padStart(3, '0'),
+)
+
+const panelWidth = computed(() => {
+	if (props.viewport < 600) return props.viewport
+	return Math.max(460, Math.min(Math.round(props.viewport * 0.6), 1000))
+})
+
+// Bridge prop ↔ Dialog v-model. When the dialog closes itself (ESC, native
+// cancel, click-outside), emit `close` so the parent can null the prop.
+const open = ref(props.device !== null)
+
+watch(
+	() => props.device,
+	(d) => {
+		open.value = d !== null
+	},
+)
+
+watch(open, (v) => {
+	if (!v && props.device !== null) emit('close')
+})
+</script>
+
+<style>
+/* Unscoped — V0 primitives set inheritAttrs:false; .zw-drawer namespace is
+   unique to this component. Native <dialog> is rendered by Dialog.Content;
+   showModal() supplies focus trap, ESC handling, and the top-layer backdrop. */
+.zw-drawer__panel {
+	display: flex;
+	flex-direction: column;
+	position: fixed;
+	inset: 0 0 0 auto;
+	margin: 0;
+	width: v-bind('panelWidth + "px"');
+	max-width: 100%;
+	height: 100%;
+	max-height: 100%;
+	background: var(--zw-card);
+	box-shadow: var(--zw-e-drawer);
+	border: none;
+	padding: 0;
+	overflow: hidden;
+	color: var(--zw-fg);
+}
+
+/* Native <dialog> UA style hides closed dialogs via `dialog:not([open])`,
+   but the author class above beats that selector in the cascade. Restate
+   the hidden state explicitly so the panel is invisible until showModal(). */
+.zw-drawer__panel:not([open]) {
+	display: none;
+}
+
+.zw-drawer__panel[open] {
+	animation: zw-slide-in-right 0.22s cubic-bezier(0.2, 0.7, 0.2, 1);
+}
+
+.zw-drawer__panel::backdrop {
+	background: rgba(30, 25, 20, 0.32);
+	animation: zw-fade-in 0.18s;
+}
+
+@media (max-width: 600px) {
+	.zw-drawer__panel {
+		width: 100% !important;
+	}
+}
+
+.zw-drawer__header {
+	display: flex;
+	align-items: center;
+	gap: 12px;
+	padding: 18px;
+	border-bottom: 1px solid var(--zw-line);
+}
+
+.zw-drawer__icon {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	width: 44px;
+	height: 44px;
+	border-radius: 12px;
+	background: var(--zw-chip-bg);
+	color: var(--zw-fg);
+	flex: 0 0 44px;
+}
+
+.zw-drawer__name-col {
+	flex: 1;
+	min-width: 0;
+}
+
+.zw-drawer__name {
+	font-size: 16px;
+	font-weight: 600;
+	color: var(--zw-fg);
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+.zw-drawer__sub {
+	font-family: var(--zw-mono);
+	font-size: 11px;
+	color: var(--zw-muted);
+	margin-top: 2px;
+}
+
+.zw-drawer__close {
+	appearance: none;
+	background: transparent;
+	border: none;
+	cursor: pointer;
+	color: var(--zw-fg-soft);
+	padding: 6px;
+	border-radius: 999px;
+	transition: background 0.12s;
+}
+
+.zw-drawer__close:hover {
+	background: rgba(0, 0, 0, 0.04);
+}
+
+.zw-drawer__close:focus-visible {
+	outline: 2px solid var(--zw-accent);
+	outline-offset: 1px;
+}
+
+.zw-drawer__body {
+	flex: 1;
+	overflow-y: auto;
+}
+</style>

--- a/src/components/dashboard/layout/ZwDeviceDrawer.vue
+++ b/src/components/dashboard/layout/ZwDeviceDrawer.vue
@@ -45,6 +45,7 @@ import { computed, ref, watch } from 'vue'
 import { Dialog } from '@vuetify/v0'
 import ZwNodeDetailsBody from '@/components/dashboard/components/ZwNodeDetailsBody.vue'
 import { ICON_SIZE, XIcon } from '@/lib/icons'
+import { MOBILE_BREAKPOINT } from '@/lib/dashboard-breakpoints'
 import type { Device, DeviceAction } from '@/lib/dashboard-types'
 
 const props = defineProps<{ device: Device | null; viewport: number }>()
@@ -58,7 +59,7 @@ const paddedNodeId = computed(() =>
 )
 
 const panelWidth = computed(() => {
-	if (props.viewport < 600) return props.viewport
+	if (props.viewport < MOBILE_BREAKPOINT) return props.viewport
 	return Math.max(460, Math.min(Math.round(props.viewport * 0.6), 1000))
 })
 

--- a/src/components/dashboard/layout/ZwDeviceDrawer.vue
+++ b/src/components/dashboard/layout/ZwDeviceDrawer.vue
@@ -1,9 +1,6 @@
 <template>
 	<Dialog.Root v-model="open">
-		<Dialog.Content
-			class="zw-drawer__panel"
-			:close-on-click-outside="true"
-		>
+		<Dialog.Content class="zw-drawer__panel" :close-on-click-outside="true">
 			<template v-if="device">
 				<header class="zw-drawer__header">
 					<div class="zw-drawer__icon">

--- a/src/lib/dashboard-breakpoints.ts
+++ b/src/lib/dashboard-breakpoints.ts
@@ -1,0 +1,14 @@
+// Dashboard layout breakpoints.
+
+// The mobile cutoff, in pixels. This is a CONTAINER-width threshold: the
+// dashboard measures its own content area with a ResizeObserver and passes
+// it down as `viewport`, so the device row grid (deviceRowGrid) and the
+// drawer (ZwDeviceDrawer) collapse on available space, not window size.
+//
+// It deliberately does NOT derive from Vuetify's display thresholds
+// (480 / 760 / 1100 / 1380, see plugins/vuetify.js) — those are window-based
+// and none of them is 600 — so a single shared constant is the source of
+// truth across the three JS sites that read `viewport`. The drawer's CSS
+// `@media (max-width: 600px)` stays a literal (a stylesheet can't read a JS
+// constant); keep the two in sync if this ever changes.
+export const MOBILE_BREAKPOINT = 600

--- a/src/lib/dashboard-types.ts
+++ b/src/lib/dashboard-types.ts
@@ -194,7 +194,6 @@ export type DeviceAction =
 	| { type: 'interview' }
 	| { type: 'refresh' }
 	| { type: 'rebuild' }
-	| { type: 'replace' }
 	| { type: 'remove' }
 	| { type: 'export' }
 	| { type: 'clear' }

--- a/src/lib/dashboard-types.ts
+++ b/src/lib/dashboard-types.ts
@@ -11,6 +11,8 @@
 // backwards compatibility — components import from `@/lib/dashboard-types`
 // today.
 
+import type { Component } from 'vue'
+
 // ── Primary value ──────────────────────────────────────────────
 
 export type PrimaryValueType =
@@ -100,8 +102,10 @@ export type ArchetypeKind =
 export interface Archetype {
 	kind: ArchetypeKind
 	label: string
-	// Aliased Lucide component (e.g. SwitchIcon from @/lib/icons).
-	icon: unknown
+	// Aliased Lucide component (e.g. SwitchIcon from @/lib/icons), rendered
+	// via `<component :is="archetype.icon">`. Typed as Vue's `Component` —
+	// the same contract `primary-display/registry.ts` uses for its renderers.
+	icon: Component
 	power: PowerType
 }
 

--- a/src/lib/dashboard-types.ts
+++ b/src/lib/dashboard-types.ts
@@ -72,6 +72,19 @@ export type PrimaryValue =
 	| PrimaryValueState
 	| PrimaryValueThermostat
 
+// Maps each discriminant to its concrete shape. A renderer declares the
+// one variant it handles (`usePrimaryValue(device, 'state')`) and gets
+// back exactly `PrimaryValueState | null`, so the registry stays
+// type-checked end-to-end instead of relying on scattered `as` casts.
+export interface PrimaryValueByType {
+	toggle: PrimaryValueToggle
+	dim: PrimaryValueDim
+	lock: PrimaryValueLock
+	reading: PrimaryValueReading
+	state: PrimaryValueState
+	thermostat: PrimaryValueThermostat
+}
+
 // ── Power / status / archetype ─────────────────────────────────
 
 export type PowerType = 'mains' | 'battery' | 'usb'

--- a/src/lib/dashboard-types.ts
+++ b/src/lib/dashboard-types.ts
@@ -147,7 +147,7 @@ export interface Device {
 	archetype: Archetype
 	power: PowerInfo
 	status: DeviceStatus
-	interviewState: 'complete' | 'interview' | 'failed' | string
+	interviewState: 'complete' | 'interview' | 'failed'
 	security?: SecurityKey | 'none'
 	securityKeys: SecurityKey[]
 	firmware?: { node?: string; sdk?: string }

--- a/src/lib/dashboard-types.ts
+++ b/src/lib/dashboard-types.ts
@@ -1,0 +1,194 @@
+// src/lib/dashboard-types.ts
+//
+// Type contract that the new dashboard components consume. The
+// authoritative shape and the runtime projection (Z-Wave node → UI
+// Device) ship with plan 70 (`fn · device projection`); these stubs
+// stand in for the contract so the visual components compile and stay
+// statically checked while plan 70 is in review.
+//
+// When plan 70 lands, move these declarations to `src/lib/device-projection.ts`
+// (and `src/lib/device-actions.ts`) and re-export from this module for
+// backwards compatibility — components import from `@/lib/dashboard-types`
+// today.
+
+// ── Primary value ──────────────────────────────────────────────
+
+export type PrimaryValueType =
+	| 'toggle'
+	| 'dim'
+	| 'lock'
+	| 'reading'
+	| 'state'
+	| 'thermostat'
+
+export interface PrimaryValueToggle {
+	type: 'toggle'
+	label?: string
+	on: boolean
+	watts?: number | null
+}
+
+export interface PrimaryValueDim {
+	type: 'dim'
+	label?: string
+	level: number
+}
+
+export interface PrimaryValueLock {
+	type: 'lock'
+	label?: string
+	locked: boolean
+}
+
+export interface PrimaryValueReading {
+	type: 'reading'
+	value: number | string
+	unit: string
+}
+
+export interface PrimaryValueState {
+	type: 'state'
+	value: string
+	stateIdx: number
+	states: string[]
+	colors: string[]
+}
+
+export interface PrimaryValueThermostat {
+	type: 'thermostat'
+	value: number
+	unit: string
+	setpoint: number
+	mode: string
+}
+
+export type PrimaryValue =
+	| PrimaryValueToggle
+	| PrimaryValueDim
+	| PrimaryValueLock
+	| PrimaryValueReading
+	| PrimaryValueState
+	| PrimaryValueThermostat
+
+// ── Power / status / archetype ─────────────────────────────────
+
+export type PowerType = 'mains' | 'battery' | 'usb'
+
+export interface PowerInfo {
+	type: PowerType
+	battery?: number | null
+}
+
+export type DeviceStatus = 'alive' | 'awake' | 'asleep' | 'dead'
+
+export type ArchetypeKind =
+	| 'switch'
+	| 'dimmer'
+	| 'plug'
+	| 'thermostat'
+	| 'lock'
+	| 'motion'
+	| 'contact'
+	| 'leak'
+	| 'tempsensor'
+	| 'shade'
+	| 'siren'
+	| 'remote'
+	| 'rgb'
+	| 'controller'
+
+export interface Archetype {
+	kind: ArchetypeKind
+	label: string
+	// Aliased Lucide component (e.g. SwitchIcon from @/lib/icons).
+	icon: unknown
+	power: PowerType
+}
+
+// ── Activity ─────────────────────────────────────────────────
+
+export type ActivityType = 'ota' | 'rebuild' | 'interview'
+
+export interface Activity {
+	type: ActivityType
+	label: string
+	progress?: number
+}
+
+// ── Security ──────────────────────────────────────────────────
+
+export type SecurityKey = 'S0' | 'S2_UA' | 'S2_A' | 'S2_AC'
+
+// ── Comm stats (controller) ───────────────────────────────────
+
+export interface CommStats {
+	can: number
+	nak: number
+	timeoutACK: number
+	timeoutResponse: number
+	timeoutCallback: number
+	messagesTX: number
+	messagesRX: number
+	messagesDroppedTX: number
+	messagesDroppedRX: number
+}
+
+// ── Device ────────────────────────────────────────────────────
+
+export interface Device {
+	id: number | string
+	nodeId: number
+	isController: boolean
+	name: string
+	location: string
+	manufacturer?: string
+	product?: string
+	productCode?: string
+	archetype: Archetype
+	power: PowerInfo
+	status: DeviceStatus
+	interviewState: 'complete' | 'interview' | 'failed' | string
+	security?: SecurityKey | 'none'
+	securityKeys: SecurityKey[]
+	firmware?: { node?: string; sdk?: string }
+	protocol?: string
+	lastSeen: string
+	primaryValue: PrimaryValue | null
+	activity: Activity[]
+	health?: 'ok' | 'weak' | 'unknown'
+	hasUpdate?: boolean
+	txPower?: number
+	commStats?: CommStats
+}
+
+// ── Action contract ───────────────────────────────────────────
+//
+// Components emit `action(device, { type, ... })` rather than
+// verb-specific events. Plan 70 owns the dispatcher that routes each
+// action shape to the matching socket call.
+
+export type DeviceAction =
+	| { type: 'toggle'; on: boolean }
+	| { type: 'dim'; level: number }
+	| { type: 'lock'; locked: boolean }
+	| { type: 'thermostat-setpoint'; setpoint: number }
+	| { type: 'thermostat-mode'; mode: string }
+	| { type: 'ping' }
+	| { type: 'interview' }
+	| { type: 'refresh' }
+	| { type: 'rebuild' }
+	| { type: 'replace' }
+	| { type: 'remove' }
+	| { type: 'export' }
+	| { type: 'clear' }
+	| { type: 'heal' }
+	| { type: 'backup-nvm' }
+	| { type: 'restore-nvm' }
+	| { type: 'reset-stats' }
+	| { type: 'export-json' }
+	| { type: 'update-topics' }
+	| { type: 'hard-reset' }
+	| { type: 'restart-driver' }
+	| { type: 'include' }
+	| { type: 'replace-failed' }
+	| { type: 'exclude' }

--- a/src/lib/primaryValue.ts
+++ b/src/lib/primaryValue.ts
@@ -1,0 +1,16 @@
+// Shared predicates over a device's primary value.
+
+import type { PrimaryValueState } from '@/lib/dashboard-types'
+
+// True when a `state` primary value sits in its alert slot: the second
+// state (index 1) tinted red or amber. This is the single definition of
+// "is this state an alert" — ZwPrimaryState, ZwDeviceCard and
+// ZwCompactPrimary all read it, so the rule can't drift between the row,
+// card and detail surfaces. Mapping an alert to a specific chip tone
+// (red → danger, amber → warn) stays at the call site.
+export function isStateAlert(state: PrimaryValueState): boolean {
+	return (
+		state.stateIdx === 1 &&
+		(state.colors[1] === 'red' || state.colors[1] === 'amber')
+	)
+}

--- a/tsconfig.eslint.json
+++ b/tsconfig.eslint.json
@@ -1,5 +1,9 @@
 {
     "extends": "./tsconfig.json",
+    "compilerOptions": {
+        "baseUrl": ".",
+        "paths": { "@/*": ["src/*"] }
+    },
     "include": [
         "**/*.ts"
     ],


### PR DESCRIPTION
This PR builds the composite component layer on top of the atoms we added in #4647.
These are the reusable building blocks the dashboard shell (followup work) assembles into views.

Primary-value display system — a type-dispatched renderer for a device's main control/value:
- `ZwPrimaryDisplay.vue` (dispatcher) + `registry.ts` mapping each `PrimaryValueType` to a renderer
- For now there are 7 renderers under primary-display/: Toggle, Dim, Lock, Reading, State, Thermostat, Controller
- `ZwCompactPrimary.vue` — condensed variant for dense rows

Device list presentation
- `ZwDeviceCard.vue` — card-view device chrome
- `ZwDeviceRow.vue` + gridTemplateB.ts — table-view row sharing a single column-grid template

Node-details surfaces
- `ZwNodeDetailsBody.vue` — shared detail body (used by both drawer and inline expansion)
- `ZwDeviceDrawer.vue` — right-side overlay drawer; `ZwExpandedRow.vue` — inline row expansion wrapper
- `ZwPropTable.vue` (mono key-value table), `ZwStatsCard.vue` (label/value stats), `ZwSecurityPanel.vue` (S0/S2 key-grant panel)

Top-bar / toolbar pieces — `ZwAddDeviceSplitButton.vue` (split CTA), `ZwColumnsMenu.vue` (table column visibility)

Supporting
- `src/lib/dashboard-types.ts` — the `Device` / `PrimaryValue` / `Activity` / `DeviceAction` type contract these components consume
- `tsconfig.eslint.json` — adds `@/*` path-alias resolution so type-aware lint resolves the new imports

---

Sneak preview:
<img width="1720" height="1279" alt="image" src="https://github.com/user-attachments/assets/4d03c2d6-efdc-4727-8a26-28bb5f63ce7f" />
