### PR TITLE
feat: implement values table and polish events log

### DIFF
--- a/src/assets/css/tokens.css
+++ b/src/assets/css/tokens.css
@@ -172,6 +172,18 @@
 	}
 }
 
+@keyframes zw-spin {
+	to {
+		transform: rotate(360deg);
+	}
+}
+
+/* Utility: spin an icon (e.g. a refresh glyph) while an op is in flight. */
+.zw-spin {
+	animation: zw-spin 0.9s linear infinite;
+	transform-origin: 50% 50%;
+}
+
 @keyframes zw-slide-in-right {
 	from {
 		transform: translateX(20px);

--- a/src/components/dashboard/components/ZwDeviceRow.vue
+++ b/src/components/dashboard/components/ZwDeviceRow.vue
@@ -78,9 +78,9 @@
 			class="zw-row__cell"
 		>
 			<component
-				:is="signalIcon"
+				:is="signal.icon"
 				:size="14"
-				:style="{ color: signalIconColor }"
+				:style="{ color: signal.color }"
 			/>
 		</span>
 
@@ -120,13 +120,8 @@ import ZwActivityReadout from '@/components/dashboard/atoms/ZwActivityReadout.vu
 import ZwCompactPrimary from './ZwCompactPrimary.vue'
 import { deviceRowGrid, type ToggleableCol } from './deviceRowGrid'
 import { MOBILE_BREAKPOINT } from '@/lib/dashboard-breakpoints'
-import {
-	ChevronDownIcon,
-	DownloadIcon,
-	ICON_SIZE,
-	SignalHighIcon,
-	SignalLowIcon,
-} from '@/lib/icons'
+import { ChevronDownIcon, DownloadIcon, ICON_SIZE } from '@/lib/icons'
+import { signalDisplay } from '@/lib/deviceSignal'
 import { padNumber } from '@/lib/utils'
 import type { Device, DeviceAction } from '@/lib/dashboard-types'
 
@@ -161,13 +156,7 @@ function hasCol(c: ToggleableCol): boolean {
 	return props.columns.includes(c)
 }
 
-const signalIcon = computed(() =>
-	props.device.health === 'weak' ? SignalLowIcon : SignalHighIcon,
-)
-
-const signalIconColor = computed(() =>
-	props.device.health === 'weak' ? 'var(--zw-warning)' : 'var(--zw-fg-soft)',
-)
+const signal = computed(() => signalDisplay(props.device.health))
 </script>
 
 <style scoped>
@@ -191,8 +180,10 @@ const signalIconColor = computed(() =>
 	background: var(--zw-row-hover);
 }
 
+/* Opaque (not the translucent chip tint) because this row is rendered as
+   a sticky overlay over scrolling detail content — it must not bleed. */
 .zw-row--expanded {
-	background: var(--zw-chip-bg);
+	background: var(--zw-bg-soft);
 }
 
 .zw-row__id {

--- a/src/components/dashboard/components/ZwExpandedRow.vue
+++ b/src/components/dashboard/components/ZwExpandedRow.vue
@@ -2,6 +2,7 @@
 	<div class="zw-expanded-row">
 		<ZwNodeDetailsBody
 			:device="device"
+			:viewport="viewport"
 			@action="(d, a) => emit('action', d, a)"
 		/>
 	</div>
@@ -11,7 +12,9 @@
 import ZwNodeDetailsBody from './ZwNodeDetailsBody.vue'
 import type { Device, DeviceAction } from '@/lib/dashboard-types'
 
-defineProps<{ device: Device }>()
+// `viewport` (the shell width) flows through to NodeDetailsBody, which uses
+// it to pick the two-pane vs stacked layout for the inline expansion.
+defineProps<{ device: Device; viewport: number }>()
 const emit = defineEmits<{ action: [Device, DeviceAction] }>()
 </script>
 

--- a/src/components/dashboard/components/ZwNodeDetailsBody.vue
+++ b/src/components/dashboard/components/ZwNodeDetailsBody.vue
@@ -164,7 +164,12 @@ import ZwStatsCard, { type StatsItem } from './ZwStatsCard.vue'
 import ZwNodeEvents from './ZwNodeEvents.vue'
 import ZwValuesView from './ZwValuesView.vue'
 import { signalDisplay } from '@/lib/deviceSignal'
-import { TWO_PANE_BREAKPOINT } from '@/lib/dashboard-breakpoints'
+import {
+	RAIL_WIDTH_BREAKPOINT,
+	RAIL_WIDTH_COMPACT,
+	RAIL_WIDTH_SPACIOUS,
+	TWO_PANE_BREAKPOINT,
+} from '@/lib/dashboard-breakpoints'
 import type { Device, DeviceAction } from '@/lib/dashboard-types'
 
 // `viewport` is the host panel's available width (the shell width passed down
@@ -220,8 +225,11 @@ const tabs = computed(() =>
 		: ALL_TABS,
 )
 
-// Rail follows the design's two widths: roomier on desktop, tighter below.
-const railWidth = computed(() => (props.viewport >= 1200 ? 340 : 300))
+const railWidth = computed(() =>
+	props.viewport >= RAIL_WIDTH_BREAKPOINT
+		? RAIL_WIDTH_SPACIOUS
+		: RAIL_WIDTH_COMPACT,
+)
 
 function defaultTab(): TabId {
 	return props.device.isController ? 'summary' : 'values'

--- a/src/components/dashboard/components/ZwNodeDetailsBody.vue
+++ b/src/components/dashboard/components/ZwNodeDetailsBody.vue
@@ -1,14 +1,54 @@
 <template>
-	<div class="zw-nd">
-		<header class="zw-nd__header">
+	<div class="zw-nd" :class="`zw-nd--${mode}`">
+		<!-- ── Two-pane left rail: primary · status · signal · activity ──
+		     Only in the wide (split) layout. The rail surfaces what would
+		     otherwise be the Events tab, which is dropped from the tab bar
+		     in this mode. -->
+		<aside
+			v-if="mode === 'split'"
+			class="zw-nd__rail"
+			:style="{ width: railWidth + 'px' }"
+		>
+			<div class="zw-nd__rail-primary">
+				<span class="zw-nd__overline">PRIMARY</span>
+				<div class="zw-nd__primary">
+					<ZwPrimaryDisplay :device="device" @action="onAction" />
+				</div>
+			</div>
+			<div class="zw-nd__rail-section">
+				<span class="zw-nd__overline">STATUS</span>
+				<span class="zw-nd__status">
+					<ZwStatusDot :status="dotStatus" />
+					<span class="zw-nd__status-label">{{ statusLabel }}</span>
+					<span class="zw-nd__bullet">·</span>
+					<span class="zw-nd__lastseen"
+						>last seen {{ device.lastSeen }}</span
+					>
+				</span>
+			</div>
+			<div class="zw-nd__rail-section">
+				<span class="zw-nd__overline">SIGNAL</span>
+				<span class="zw-nd__signal">
+					<component
+						:is="signal.icon"
+						:size="14"
+						:style="{ color: signal.color }"
+					/>
+					<span>{{ signal.label }}</span>
+				</span>
+			</div>
+			<div class="zw-nd__rail-activity">
+				<span class="zw-nd__overline">RECENT ACTIVITY</span>
+				<ZwNodeEvents :device="device" :max="25" />
+			</div>
+		</aside>
+
+		<!-- ── Stacked header: full-width above the tabs (drawer / mobile) ── -->
+		<header v-else class="zw-nd__header">
 			<div class="zw-nd__header-top">
 				<span class="zw-nd__overline">PRIMARY</span>
 				<span class="zw-nd__status">
-					<ZwStatusDot
-						:status="
-							device.isController ? 'controller' : device.status
-						"
-					/>
+					<ZwStatusDot :status="dotStatus" />
 					<span class="zw-nd__status-label">{{ statusLabel }}</span>
 					<span class="zw-nd__bullet">·</span>
 					<span class="zw-nd__lastseen"
@@ -17,112 +57,98 @@
 				</span>
 			</div>
 			<div class="zw-nd__primary">
-				<ZwPrimaryDisplay
-					:device="device"
-					@action="(d, a) => emit('action', d, a)"
-				/>
+				<ZwPrimaryDisplay :device="device" @action="onAction" />
 			</div>
 		</header>
 
-		<Tabs.Root v-model="tab">
-			<Tabs.List as="nav" class="zw-nd__tabs">
-				<Tabs.Item
-					v-for="t in tabs"
-					:key="t.id"
-					:value="t.id"
-					class="zw-nd__tab"
-				>
-					{{ t.label }}
-				</Tabs.Item>
-			</Tabs.List>
-
-			<Tabs.Panel value="values" class="zw-nd__content">
-				<div v-if="device.isController" class="zw-nd__empty">
-					Controller exposes no command-class values.
-				</div>
-				<div v-else class="zw-nd__values-stub">
-					<!-- Placeholder until the full values view is built. -->
-					Values pane — full view coming soon.
-				</div>
-			</Tabs.Panel>
-
-			<Tabs.Panel value="summary" class="zw-nd__content zw-nd__summary">
-				<ZwPropTable :rows="manufacturerRows" />
-				<ZwPropTable :rows="firmwareRows" />
-				<ZwSecurityPanel :device="device" />
-			</Tabs.Panel>
-
-			<Tabs.Panel value="groups" class="zw-nd__content">
-				<ZwPropTable :rows="groupsStub" />
-			</Tabs.Panel>
-
-			<Tabs.Panel value="updates" class="zw-nd__content zw-nd__updates">
-				<div v-if="device.hasUpdate" class="zw-nd__update-card">
-					<div class="zw-nd__update-current">
-						Current {{ device.firmware?.node ?? '—' }}
-					</div>
-					<div class="zw-nd__update-line">
-						Update available — see the device drawer's footer to
-						apply.
-					</div>
-				</div>
-				<div v-else class="zw-nd__empty">
-					No firmware update available.
-				</div>
-			</Tabs.Panel>
-
-			<Tabs.Panel value="events" class="zw-nd__content zw-nd__events">
-				<template v-if="events.length === 0">
-					<div class="zw-nd__empty">No recent events</div>
-				</template>
-				<template v-else>
-					<div
-						v-for="(ev, i) in events"
-						:key="i"
-						class="zw-nd__event"
+		<!-- ── Tabbed detail content — identical in both layouts. Sits in
+		     the right pane (split) or below the header (stacked). -->
+		<div class="zw-nd__main">
+			<Tabs.Root v-model="tab">
+				<Tabs.List as="nav" class="zw-nd__tabs">
+					<Tabs.Item
+						v-for="t in tabs"
+						:key="t.id"
+						:value="t.id"
+						class="zw-nd__tab"
 					>
-						<span class="zw-nd__event-time">{{
-							relativeTime(toMs(ev.time), now)
-						}}</span>
-						<div class="zw-nd__event-body">
-							<div class="zw-nd__event-name">{{ ev.event }}</div>
-							<div
-								v-if="eventDetail(ev)"
-								class="zw-nd__event-detail"
-							>
-								{{ eventDetail(ev) }}
-							</div>
+						{{ t.label }}
+					</Tabs.Item>
+				</Tabs.List>
+
+				<Tabs.Panel value="values" class="zw-nd__content">
+					<div v-if="device.isController" class="zw-nd__empty">
+						Controller exposes no command-class values.
+					</div>
+					<ZwValuesView v-else :device="device" @action="onAction" />
+				</Tabs.Panel>
+
+				<Tabs.Panel
+					value="summary"
+					class="zw-nd__content zw-nd__summary"
+				>
+					<ZwPropTable :rows="manufacturerRows" />
+					<ZwPropTable :rows="firmwareRows" />
+					<ZwSecurityPanel :device="device" />
+				</Tabs.Panel>
+
+				<Tabs.Panel value="groups" class="zw-nd__content">
+					<ZwPropTable :rows="groupsStub" />
+				</Tabs.Panel>
+
+				<Tabs.Panel
+					value="updates"
+					class="zw-nd__content zw-nd__updates"
+				>
+					<div v-if="device.hasUpdate" class="zw-nd__update-card">
+						<div class="zw-nd__update-current">
+							Current {{ device.firmware?.node ?? '—' }}
+						</div>
+						<div class="zw-nd__update-line">
+							Update available — see the device drawer's footer to
+							apply.
 						</div>
 					</div>
-					<div
-						v-if="totalEvents > MAX_EVENTS"
-						class="zw-nd__event-footer"
-					>
-						+{{ totalEvents - MAX_EVENTS }} earlier events
+					<div v-else class="zw-nd__empty">
+						No firmware update available.
 					</div>
-				</template>
-			</Tabs.Panel>
+				</Tabs.Panel>
 
-			<Tabs.Panel value="debug" class="zw-nd__content">
-				<div v-if="device.isController" class="zw-nd__stats">
-					<ZwStatsCard title="Communication" :items="commStats" />
-					<ZwStatsCard title="Messages" :items="messageStats" />
-				</div>
-				<ZwPropTable v-else :rows="debugRows" />
-			</Tabs.Panel>
-
-			<Tabs.Panel value="advanced" class="zw-nd__content zw-nd__advanced">
-				<ZwButton
-					v-for="cmd in advancedCommands"
-					:key="cmd.label"
-					variant="mono-outline"
-					size="sm"
-					@click="emit('action', device, cmd.action)"
+				<!-- Events is omitted from the tab bar in the split layout
+				     (its content lives in the rail), so the panel is only
+				     mounted in the stacked layout. -->
+				<Tabs.Panel
+					v-if="mode === 'stacked'"
+					value="events"
+					class="zw-nd__content"
 				>
-					{{ cmd.label }}
-				</ZwButton>
-			</Tabs.Panel>
-		</Tabs.Root>
+					<ZwNodeEvents :device="device" />
+				</Tabs.Panel>
+
+				<Tabs.Panel value="debug" class="zw-nd__content">
+					<div v-if="device.isController" class="zw-nd__stats">
+						<ZwStatsCard title="Communication" :items="commStats" />
+						<ZwStatsCard title="Messages" :items="messageStats" />
+					</div>
+					<ZwPropTable v-else :rows="debugRows" />
+				</Tabs.Panel>
+
+				<Tabs.Panel
+					value="advanced"
+					class="zw-nd__content zw-nd__advanced"
+				>
+					<ZwButton
+						v-for="cmd in advancedCommands"
+						:key="cmd.label"
+						variant="mono-outline"
+						size="sm"
+						@click="emit('action', device, cmd.action)"
+					>
+						{{ cmd.label }}
+					</ZwButton>
+				</Tabs.Panel>
+			</Tabs.Root>
+		</div>
 	</div>
 </template>
 
@@ -135,12 +161,29 @@ import ZwPrimaryDisplay from './ZwPrimaryDisplay.vue'
 import ZwPropTable from './ZwPropTable.vue'
 import ZwSecurityPanel from './ZwSecurityPanel.vue'
 import ZwStatsCard, { type StatsItem } from './ZwStatsCard.vue'
+import ZwNodeEvents from './ZwNodeEvents.vue'
+import ZwValuesView from './ZwValuesView.vue'
+import { signalDisplay } from '@/lib/deviceSignal'
+import { TWO_PANE_BREAKPOINT } from '@/lib/dashboard-breakpoints'
 import type { Device, DeviceAction } from '@/lib/dashboard-types'
-import useBaseStore from '@/stores/base'
-import { relativeTime, useNow } from '@/lib/time'
 
-const props = defineProps<{ device: Device }>()
+// `viewport` is the host panel's available width (the shell width passed down
+// by the table, NOT the device viewport). It selects the layout and feeds the
+// rail width. `layout="stacked"` forces the single-column layout regardless of
+// width — the card-view drawer uses it so it always keeps the stacked layout.
+const props = withDefaults(
+	defineProps<{
+		device: Device
+		viewport?: number
+		layout?: 'auto' | 'stacked'
+	}>(),
+	{ viewport: 0, layout: 'auto' },
+)
 const emit = defineEmits<{ action: [Device, DeviceAction] }>()
+
+function onAction(d: Device, a: DeviceAction) {
+	emit('action', d, a)
+}
 
 type TabId =
 	| 'values'
@@ -151,7 +194,7 @@ type TabId =
 	| 'debug'
 	| 'advanced'
 
-const tabs: { id: TabId; label: string }[] = [
+const ALL_TABS: { id: TabId; label: string }[] = [
 	{ id: 'values', label: 'Values' },
 	{ id: 'summary', label: 'Summary' },
 	{ id: 'groups', label: 'Groups' },
@@ -161,20 +204,54 @@ const tabs: { id: TabId; label: string }[] = [
 	{ id: 'advanced', label: 'Advanced' },
 ]
 
-const tab = ref<TabId>(props.device.isController ? 'summary' : 'values')
+// Two-pane on wider panels; stacked in the drawer and on narrow screens.
+const mode = computed<'split' | 'stacked'>(() =>
+	props.layout === 'stacked'
+		? 'stacked'
+		: props.viewport >= TWO_PANE_BREAKPOINT
+			? 'split'
+			: 'stacked',
+)
+
+// In split mode the Events tab is dropped — its content lives in the rail.
+const tabs = computed(() =>
+	mode.value === 'split'
+		? ALL_TABS.filter((t) => t.id !== 'events')
+		: ALL_TABS,
+)
+
+// Rail follows the design's two widths: roomier on desktop, tighter below.
+const railWidth = computed(() => (props.viewport >= 1200 ? 340 : 300))
+
+function defaultTab(): TabId {
+	return props.device.isController ? 'summary' : 'values'
+}
+
+const tab = ref<TabId>(defaultTab())
 
 // Switching to a different device resets to that device's default tab.
 watch(
 	() => props.device.nodeId,
 	() => {
-		tab.value = props.device.isController ? 'summary' : 'values'
+		tab.value = defaultTab()
 	},
+)
+
+// Collapsing to two-pane drops the Events tab — fall back to the default.
+watch(mode, (m) => {
+	if (m === 'split' && tab.value === 'events') tab.value = defaultTab()
+})
+
+const dotStatus = computed(() =>
+	props.device.isController ? 'controller' : props.device.status,
 )
 
 const statusLabel = computed(() => {
 	const s = props.device.isController ? 'controller' : props.device.status
 	return s.charAt(0).toUpperCase() + s.slice(1)
 })
+
+const signal = computed(() => signalDisplay(props.device.health))
 
 const manufacturerRows = computed<[string, string | number][]>(() => [
 	['Manufacturer', props.device.manufacturer ?? '—'],
@@ -226,66 +303,6 @@ const debugRows = computed<[string, string | number][]>(() => [
 	['Generic device class', props.device.archetype.label],
 ])
 
-// ── events tab ───────────────────────────────────────────────
-// Reads `node.eventsQueue` from the base store, looked up by
-// `device.nodeId`, so it tracks socket events live.
-const baseStore = useBaseStore()
-const now = useNow()
-const MAX_EVENTS = 50
-
-interface NodeEventEntry {
-	event: string
-	args?: unknown[]
-	time?: Date | string | number
-}
-
-const eventsQueue = computed<NodeEventEntry[]>(() => {
-	const node = baseStore.getNode(props.device.nodeId)
-	const q = node?.eventsQueue
-	return Array.isArray(q) ? (q as NodeEventEntry[]) : []
-})
-
-const totalEvents = computed(() => eventsQueue.value.length)
-
-const events = computed<NodeEventEntry[]>(() =>
-	eventsQueue.value.slice(-MAX_EVENTS).reverse(),
-)
-
-function toMs(t: NodeEventEntry['time']): number | undefined {
-	if (!t) return undefined
-	if (t instanceof Date) return t.getTime()
-	if (typeof t === 'number') return t
-	const d = new Date(t)
-	const n = d.getTime()
-	return Number.isNaN(n) ? undefined : n
-}
-
-function eventDetail(ev: NodeEventEntry): string {
-	// Event arg shapes vary: treat the first arg as the new value when
-	// present, and stringify the rest.
-	if (!Array.isArray(ev.args) || ev.args.length === 0) return ''
-	const first = ev.args[0] as unknown
-	if (first && typeof first === 'object') {
-		const o = first as { propertyName?: string; newValue?: unknown }
-		if (o.propertyName !== undefined && o.newValue !== undefined) {
-			return `${o.propertyName} → ${formatValue(o.newValue)}`
-		}
-	}
-	return ev.args.map((a) => formatValue(a)).join(' · ')
-}
-
-function formatValue(v: unknown): string {
-	if (v === null || v === undefined) return '—'
-	if (typeof v === 'object') {
-		try {
-			return JSON.stringify(v)
-		} catch {
-			return String(v)
-		}
-	}
-	return String(v)
-}
-
 const advancedCommands = computed<{ label: string; action: DeviceAction }[]>(
 	() =>
 		props.device.isController
@@ -324,12 +341,74 @@ const advancedCommands = computed<{ label: string; action: DeviceAction }[]>(
    namespace is unique to this component. */
 .zw-nd {
 	display: flex;
+	min-width: 0;
+}
+
+.zw-nd--stacked {
 	flex-direction: column;
+}
+
+/* Two-pane: rail on the left, tabbed content on the right. `stretch`
+   (the flex default) keeps the rail's right border full-height regardless
+   of which column is taller. */
+.zw-nd--split {
+	flex-direction: row;
+	align-items: stretch;
+}
+
+/* The tabbed content well. Carries the container so summary/debug grids
+   pack to the content width — NOT the whole component — which matters in
+   the split layout where the rail eats 300–340px. */
+.zw-nd__main {
+	display: flex;
+	flex-direction: column;
+	flex: 1;
+	min-width: 0;
 	container-type: inline-size;
 	container-name: zw-nd;
 }
 
-/* ── Header ──────────────────────────────────────────────────── */
+/* ── Left rail (split only) ──────────────────────────────────── */
+.zw-nd__rail {
+	flex-shrink: 0;
+	display: flex;
+	flex-direction: column;
+	gap: 16px;
+	padding: 16px;
+	background: var(--zw-bg-soft);
+	border-right: 1px solid var(--zw-line);
+}
+
+.zw-nd__rail-primary {
+	display: flex;
+	flex-direction: column;
+	gap: 8px;
+}
+
+.zw-nd__rail-section {
+	display: flex;
+	flex-direction: column;
+	gap: 6px;
+}
+
+.zw-nd__rail-activity {
+	border-top: 1px solid var(--zw-line);
+	padding-top: 14px;
+	display: flex;
+	flex-direction: column;
+	gap: 8px;
+}
+
+.zw-nd__signal {
+	display: inline-flex;
+	align-items: center;
+	gap: 6px;
+	font-size: 12px;
+	font-weight: 500;
+	color: var(--zw-fg);
+}
+
+/* ── Stacked header ──────────────────────────────────────────── */
 .zw-nd__header {
 	padding: 16px;
 	background: var(--zw-bg-soft);
@@ -457,12 +536,6 @@ const advancedCommands = computed<{ label: string; action: DeviceAction }[]>(
 	font-style: italic;
 }
 
-.zw-nd__values-stub {
-	padding: 24px;
-	color: var(--zw-muted);
-	font-style: italic;
-}
-
 .zw-nd__updates {
 	display: flex;
 	flex-direction: column;
@@ -504,57 +577,5 @@ const advancedCommands = computed<{ label: string; action: DeviceAction }[]>(
 	.zw-nd__stats {
 		grid-template-columns: 1fr 1fr;
 	}
-}
-
-/* ── Events tab ──────────────────────────────────────────────── */
-.zw-nd__events {
-	display: flex;
-	flex-direction: column;
-	gap: 0;
-}
-
-.zw-nd__event {
-	display: flex;
-	gap: 10px;
-	padding: 8px 0;
-	border-bottom: 1px dashed var(--zw-line);
-}
-
-.zw-nd__event:last-of-type {
-	border-bottom: none;
-}
-
-.zw-nd__event-time {
-	font-family: var(--zw-mono);
-	font-size: 11px;
-	color: var(--zw-muted);
-	width: 72px;
-	flex-shrink: 0;
-}
-
-.zw-nd__event-body {
-	min-width: 0;
-}
-
-.zw-nd__event-name {
-	font-size: 12px;
-	font-weight: 500;
-}
-
-.zw-nd__event-detail {
-	font-size: 11px;
-	color: var(--zw-muted);
-	margin-top: 2px;
-	word-break: break-word;
-}
-
-.zw-nd__event-footer {
-	margin-top: 8px;
-	padding-top: 8px;
-	border-top: 1px dashed var(--zw-line);
-	font-family: var(--zw-mono);
-	font-size: 11px;
-	color: var(--zw-muted);
-	text-align: center;
 }
 </style>

--- a/src/components/dashboard/components/ZwNodeEvents.vue
+++ b/src/components/dashboard/components/ZwNodeEvents.vue
@@ -4,7 +4,7 @@
 			No recent events
 		</div>
 		<template v-else>
-			<div v-for="(row, i) in rows" :key="i" class="zw-node-events__row">
+			<div v-for="row in rows" :key="row.key" class="zw-node-events__row">
 				<span class="zw-node-events__time">{{
 					relativeTime(row.timeMs, now)
 				}}</span>
@@ -32,7 +32,7 @@ import type {
 import type { Device } from '@/lib/dashboard-types'
 import useBaseStore from '@/stores/base'
 import { relativeTime, useNow } from '@/lib/time'
-import { valueIdKey } from '@/components/dashboard/deviceActionPending.ts'
+import { valueIdKey } from '@/lib/deviceActionPending.ts'
 
 // Live feed of a node's recent events, shared by the Events tab and the rail's
 // "Recent activity". `max` caps entries (the rail passes a smaller cap).
@@ -118,11 +118,18 @@ function eventDetail(ev: NodeEventEntry): string {
 // Pre-resolve display strings per data change, so the `now` tick re-runs only
 // the cheap relative-time format, not the per-event label lookup.
 const rows = computed(() =>
-	events.value.map((ev) => ({
-		name: ev.event,
-		timeMs: toMs(ev.time),
-		detail: eventDetail(ev),
-	})),
+	events.value.map((ev) => {
+		const timeMs = toMs(ev.time)
+		const detail = eventDetail(ev)
+		// Content-derived key so prepending a new event doesn't reshuffle every
+		// row's key (index keys force a full re-patch of the reversed list).
+		return {
+			key: `${timeMs}|${ev.event}|${detail}`,
+			name: ev.event,
+			timeMs,
+			detail,
+		}
+	}),
 )
 
 function formatValue(v: unknown): string {

--- a/src/components/dashboard/components/ZwNodeEvents.vue
+++ b/src/components/dashboard/components/ZwNodeEvents.vue
@@ -1,0 +1,198 @@
+<template>
+	<div class="zw-node-events">
+		<div v-if="rows.length === 0" class="zw-node-events__empty">
+			No recent events
+		</div>
+		<template v-else>
+			<div v-for="(row, i) in rows" :key="i" class="zw-node-events__row">
+				<span class="zw-node-events__time">{{
+					relativeTime(row.timeMs, now)
+				}}</span>
+				<div class="zw-node-events__body">
+					<div class="zw-node-events__name">{{ row.name }}</div>
+					<div v-if="row.detail" class="zw-node-events__detail">
+						{{ row.detail }}
+					</div>
+				</div>
+			</div>
+			<div v-if="overflow > 0" class="zw-node-events__footer">
+				+{{ overflow }} earlier events
+			</div>
+		</template>
+	</div>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import type {
+	TranslatedValueID,
+	ValueUpdatedArgs,
+	ValueNotificationArgs,
+} from '@zwave-js/core'
+import type { Device } from '@/lib/dashboard-types'
+import useBaseStore from '@/stores/base'
+import { relativeTime, useNow } from '@/lib/time'
+import { valueIdKey } from '@/components/dashboard/deviceActionPending.ts'
+
+// Live feed of a node's recent events, shared by the Events tab and the rail's
+// "Recent activity". `max` caps entries (the rail passes a smaller cap).
+const props = withDefaults(defineProps<{ device: Device; max?: number }>(), {
+	max: 50,
+})
+
+const baseStore = useBaseStore()
+const now = useNow()
+
+interface NodeEventEntry {
+	event: string
+	args?: unknown[]
+	time?: Date | string | number
+}
+
+// `node.eventsQueue` from the store, so it tracks socket events live.
+const eventsQueue = computed<NodeEventEntry[]>(() => {
+	const node = baseStore.getNode(props.device.nodeId)
+	const q = node?.eventsQueue
+	return Array.isArray(q) ? (q as NodeEventEntry[]) : []
+})
+
+const events = computed<NodeEventEntry[]>(() =>
+	eventsQueue.value.slice(-props.max).reverse(),
+)
+
+const overflow = computed(() =>
+	Math.max(0, eventsQueue.value.length - props.max),
+)
+
+function toMs(t: NodeEventEntry['time']): number | undefined {
+	if (!t) return undefined
+	if (t instanceof Date) return t.getTime()
+	if (typeof t === 'number') return t
+	const d = new Date(t)
+	const n = d.getTime()
+	return Number.isNaN(n) ? undefined : n
+}
+
+// A value-updated/notification event arg, loosely typed — queue args are
+// untyped, so every field may be absent.
+type ValueEventArg = Partial<
+	TranslatedValueID & ValueUpdatedArgs & ValueNotificationArgs
+>
+
+// value-id → metadata label, rebuilt per node-values change. O(1) lookup avoids
+// re-scanning values per event per render; raw event payloads lack the label.
+const valueLabelIndex = computed(() => {
+	const node = baseStore.getNode(props.device.nodeId) as
+		| { values?: (ValueEventArg & { label?: string })[] }
+		| undefined
+	const map = new Map<string, string>()
+	if (Array.isArray(node?.values)) {
+		for (const v of node.values) {
+			if (v?.label) map.set(valueIdKey(v), v.label)
+		}
+	}
+	return map
+})
+
+function eventDetail(ev: NodeEventEntry): string {
+	// Prefer a value's metadata label over its raw property for value events.
+	if (!Array.isArray(ev.args) || ev.args.length === 0) return ''
+	const first = ev.args[0] as unknown
+	if (first && typeof first === 'object') {
+		const o = first as ValueEventArg
+		const next = o.newValue !== undefined ? o.newValue : o.value
+		if (
+			next !== undefined &&
+			(o.property !== undefined || o.propertyName)
+		) {
+			const label =
+				valueLabelIndex.value.get(valueIdKey(o)) ??
+				o.propertyName ??
+				String(o.property)
+			return `${label} → ${formatValue(next)}`
+		}
+	}
+	return ev.args.map((a) => formatValue(a)).join(' · ')
+}
+
+// Pre-resolve display strings per data change, so the `now` tick re-runs only
+// the cheap relative-time format, not the per-event label lookup.
+const rows = computed(() =>
+	events.value.map((ev) => ({
+		name: ev.event,
+		timeMs: toMs(ev.time),
+		detail: eventDetail(ev),
+	})),
+)
+
+function formatValue(v: unknown): string {
+	if (v === null || v === undefined) return '—'
+	if (typeof v === 'object') {
+		try {
+			return JSON.stringify(v)
+		} catch {
+			return String(v)
+		}
+	}
+	return String(v)
+}
+</script>
+
+<style scoped>
+.zw-node-events {
+	display: flex;
+	flex-direction: column;
+}
+
+.zw-node-events__row {
+	display: flex;
+	gap: 10px;
+	padding: 8px 0;
+	border-bottom: 1px dashed var(--zw-line);
+}
+
+.zw-node-events__row:last-of-type {
+	border-bottom: none;
+}
+
+.zw-node-events__time {
+	font-family: var(--zw-mono);
+	font-size: 11px;
+	color: var(--zw-muted);
+	width: 72px;
+	flex-shrink: 0;
+}
+
+.zw-node-events__body {
+	min-width: 0;
+}
+
+.zw-node-events__name {
+	font-size: 12px;
+	font-weight: 500;
+}
+
+.zw-node-events__detail {
+	font-size: 11px;
+	color: var(--zw-muted);
+	margin-top: 2px;
+	word-break: break-word;
+}
+
+.zw-node-events__footer {
+	margin-top: 8px;
+	padding-top: 8px;
+	border-top: 1px dashed var(--zw-line);
+	font-family: var(--zw-mono);
+	font-size: 11px;
+	color: var(--zw-muted);
+	text-align: center;
+}
+
+.zw-node-events__empty {
+	padding: 24px;
+	color: var(--zw-muted);
+	text-align: center;
+	font-style: italic;
+}
+</style>

--- a/src/components/dashboard/components/ZwValueGroup.vue
+++ b/src/components/dashboard/components/ZwValueGroup.vue
@@ -63,13 +63,13 @@
 </template>
 
 <script setup lang="ts">
-import { computed, inject } from 'vue'
+import { computed, inject, shallowRef } from 'vue'
 import ZwValueRow from './ZwValueRow.vue'
 import { ChevronDownIcon, ICON_SIZE, RefreshIcon, ResetIcon } from '@/lib/icons'
 import {
 	ccPendingKey,
 	DeviceActionPendingKey,
-} from '@/components/dashboard/deviceActionPending.ts'
+} from '@/lib/deviceActionPending.ts'
 import type { ValueGroup } from '@/lib/valueGroups.ts'
 import type { ValueID } from '@zwave-js/core'
 
@@ -87,9 +87,12 @@ const emit = defineEmits<{
 }>()
 
 // Spins only while the CC refresh is actually in flight (see deviceActionPending).
-const pending = inject(DeviceActionPendingKey, new Set<string>())
+const pending = inject(
+	DeviceActionPendingKey,
+	shallowRef<ReadonlySet<string>>(new Set()),
+)
 const refreshing = computed(() =>
-	pending.has(ccPendingKey(props.nodeId, props.group.ccId)),
+	pending.value.has(ccPendingKey(props.nodeId, props.group.ccId)),
 )
 
 function onRefresh() {

--- a/src/components/dashboard/components/ZwValueGroup.vue
+++ b/src/components/dashboard/components/ZwValueGroup.vue
@@ -1,0 +1,216 @@
+<template>
+	<div class="zw-vgroup">
+		<div
+			class="zw-vgroup__head"
+			role="button"
+			tabindex="0"
+			:aria-expanded="open"
+			@click="emit('toggle')"
+			@keydown.enter.prevent="emit('toggle')"
+			@keydown.space.prevent="emit('toggle')"
+		>
+			<ChevronDownIcon
+				:size="ICON_SIZE.chip"
+				class="zw-vgroup__chev"
+				:class="{ 'zw-vgroup__chev--collapsed': !open }"
+			/>
+			<span class="zw-vgroup__label">{{ group.ccLabel }}</span>
+			<span class="zw-vgroup__version">v{{ group.version }}</span>
+			<span class="zw-vgroup__spacer" />
+			<span class="zw-vgroup__actions" @click.stop>
+				<button
+					type="button"
+					class="zw-vgroup__act zw-focus-ring"
+					:disabled="refreshing"
+					:title="refreshing ? 'Refreshing…' : 'Refresh values'"
+					@click="onRefresh"
+				>
+					<RefreshIcon
+						:size="ICON_SIZE.dense"
+						:class="{ 'zw-spin': refreshing }"
+					/>
+				</button>
+				<button
+					v-if="group.canResetAll"
+					type="button"
+					class="zw-vgroup__act zw-vgroup__act--danger zw-focus-ring"
+					title="Reset all to default"
+					@click="onResetAll"
+				>
+					<ResetIcon :size="ICON_SIZE.dense" />
+				</button>
+			</span>
+		</div>
+
+		<div v-if="open" class="zw-vgroup__body">
+			<template v-if="group.params.length">
+				<div
+					v-for="p in group.params"
+					:key="p.id"
+					class="zw-vgroup__cell"
+				>
+					<ZwValueRow
+						:param="p"
+						:node-id="nodeId"
+						@set="(id, val) => emit('set', id, val)"
+						@poll="(id) => emit('poll', id)"
+					/>
+				</div>
+			</template>
+			<div v-else class="zw-vgroup__empty">No values</div>
+		</div>
+	</div>
+</template>
+
+<script setup lang="ts">
+import { computed, inject } from 'vue'
+import ZwValueRow from './ZwValueRow.vue'
+import { ChevronDownIcon, ICON_SIZE, RefreshIcon, ResetIcon } from '@/lib/icons'
+import {
+	ccPendingKey,
+	DeviceActionPendingKey,
+} from '@/components/dashboard/deviceActionPending.ts'
+import type { ValueGroup } from '@/lib/valueGroups.ts'
+import type { ValueID } from '@zwave-js/core'
+
+const props = defineProps<{
+	group: ValueGroup
+	open: boolean
+	nodeId: number
+}>()
+
+const emit = defineEmits<{
+	toggle: []
+	set: [ValueID, unknown]
+	poll: [ValueID]
+	refreshCc: [number]
+}>()
+
+// Spins only while the CC refresh is actually in flight (see deviceActionPending).
+const pending = inject(DeviceActionPendingKey, new Set<string>())
+const refreshing = computed(() =>
+	pending.has(ccPendingKey(props.nodeId, props.group.ccId)),
+)
+
+function onRefresh() {
+	if (refreshing.value) return
+	emit('refreshCc', props.group.ccId)
+}
+
+function onResetAll() {
+	for (const p of props.group.params) {
+		if (p.modified && p.default !== undefined)
+			emit('set', p.target, p.default)
+	}
+}
+</script>
+
+<style scoped>
+.zw-vgroup {
+	background: var(--zw-card);
+	border: 1px solid var(--zw-line);
+	border-radius: 6px;
+	overflow: hidden;
+}
+
+.zw-vgroup__head {
+	display: flex;
+	align-items: center;
+	gap: 10px;
+	padding: 8px 12px;
+	cursor: pointer;
+}
+
+.zw-vgroup__head:focus-visible {
+	outline: 2px solid var(--zw-accent);
+	outline-offset: -2px;
+}
+
+.zw-vgroup__chev {
+	color: var(--zw-muted);
+	transition: transform 0.15s;
+	flex-shrink: 0;
+}
+
+.zw-vgroup__chev--collapsed {
+	transform: rotate(-90deg);
+}
+
+.zw-vgroup__label {
+	font-size: 12px;
+	font-weight: 600;
+	color: var(--zw-fg);
+}
+
+.zw-vgroup__version {
+	font-family: var(--zw-mono);
+	font-size: 10px;
+	color: var(--zw-muted);
+	padding: 1px 5px;
+	background: var(--zw-chip-bg);
+	border-radius: 3px;
+}
+
+.zw-vgroup__spacer {
+	flex: 1;
+}
+
+.zw-vgroup__actions {
+	display: inline-flex;
+	align-items: center;
+	gap: 4px;
+}
+
+.zw-vgroup__act {
+	appearance: none;
+	border: 1px solid var(--zw-line);
+	background: transparent;
+	color: var(--zw-muted);
+	width: 26px;
+	height: 26px;
+	border-radius: 5px;
+	padding: 0;
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	cursor: pointer;
+}
+
+.zw-vgroup__act:disabled {
+	cursor: default;
+	opacity: 0.65;
+}
+
+.zw-vgroup__act--danger {
+	color: var(--zw-danger);
+}
+
+/* Responsive grid in every host (card drawer and table two-pane) so the
+   wrap breakpoints match. Cell rules are the 1px gap over a line-colored
+   backdrop; `background-clip: padding-box` keeps that tint from painting
+   under the header border-top (which would read darker than nearby 1px
+   lines). */
+.zw-vgroup__body {
+	border-top: 1px solid var(--zw-line);
+	display: grid;
+	grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+	gap: 1px;
+	background: var(--zw-line);
+	background-clip: padding-box;
+}
+
+/* Flex so the single ZwValueRow stretches to the cell's (grid-equalized)
+   height — letting a short row (e.g. a button command) center vertically. */
+.zw-vgroup__cell {
+	background: var(--zw-card);
+	display: flex;
+}
+
+.zw-vgroup__empty {
+	padding: 12px;
+	font-size: 11px;
+	color: var(--zw-muted);
+	font-family: var(--zw-mono);
+	background: var(--zw-card);
+}
+</style>

--- a/src/components/dashboard/components/ZwValueRow.vue
+++ b/src/components/dashboard/components/ZwValueRow.vue
@@ -136,15 +136,20 @@
 				</select>
 			</template>
 
-			<!-- number -->
-			<template v-else-if="param.kind === 'number'">
+			<!-- number / text input (shared scaffold) -->
+			<template
+				v-else-if="param.kind === 'number' || param.kind === 'text'"
+			>
 				<input
 					class="zw-vrow__input"
-					type="number"
+					:class="{ 'zw-vrow__input--text': param.kind === 'text' }"
+					:type="param.kind === 'number' ? 'number' : 'text'"
 					:value="cur"
-					:min="param.min"
-					:max="param.max"
-					:step="param.step || 1"
+					:min="param.kind === 'number' ? param.min : undefined"
+					:max="param.kind === 'number' ? param.max : undefined"
+					:step="
+						param.kind === 'number' ? param.step || 1 : undefined
+					"
 					:disabled="busy"
 					@input="onInput"
 					@keydown.enter="send"
@@ -157,6 +162,7 @@
 					type="button"
 					class="zw-vrow__apply"
 					title="Apply"
+					:disabled="busy"
 					@click="send"
 				>
 					<CheckIcon :size="ICON_SIZE.dense" />
@@ -180,30 +186,6 @@
 				<span class="zw-vrow__mono zw-vrow__pct"
 					>{{ levelValue }}%</span
 				>
-			</template>
-
-			<!-- text -->
-			<template v-else-if="param.kind === 'text'">
-				<input
-					class="zw-vrow__input zw-vrow__input--text"
-					type="text"
-					:value="cur"
-					:disabled="busy"
-					@input="onInput"
-					@keydown.enter="send"
-				/>
-				<span v-if="param.unit" class="zw-vrow__unit">{{
-					param.unit
-				}}</span>
-				<button
-					v-if="dirty"
-					type="button"
-					class="zw-vrow__apply"
-					title="Apply"
-					@click="send"
-				>
-					<CheckIcon :size="ICON_SIZE.dense" />
-				</button>
 			</template>
 
 			<!-- color (writeable values render display-only in this theme) -->
@@ -235,13 +217,13 @@
 			"
 			class="zw-vrow__range"
 		>
-			{{ rangeMeta }}
+			{{ rangeHint }}
 		</div>
 	</div>
 </template>
 
 <script setup lang="ts">
-import { computed, inject, ref, useId, watch } from 'vue'
+import { computed, inject, ref, shallowRef, useId, watch } from 'vue'
 import { Popover } from '@vuetify/v0'
 import ZwToggle from '@/components/dashboard/atoms/ZwToggle.vue'
 import ZwSlider from '@/components/dashboard/atoms/ZwSlider.vue'
@@ -259,7 +241,7 @@ import {
 	DeviceActionPendingKey,
 	pollPendingKey,
 	setPendingKey,
-} from '@/components/dashboard/deviceActionPending.ts'
+} from '@/lib/deviceActionPending.ts'
 import type { ValueID } from '@zwave-js/core'
 
 const props = defineProps<{
@@ -272,7 +254,12 @@ const emit = defineEmits<{
 }>()
 
 // Pending edit until applied; null = show the live value. Clears on confirm.
+// (null is safe as the "no edit" sentinel: drafts only come from user input on
+// editable controls, never a literal null value.)
 const draft = ref<unknown>(null)
+
+// How long the "copied" checkmark shows before reverting to the copy icon.
+const COPY_FEEDBACK_MS = 1200
 const copied = ref(false)
 const menuOpen = ref(false)
 const menuId = `zw-vrow-${useId()}`
@@ -280,12 +267,15 @@ const menuId = `zw-vrow-${useId()}`
 usePopoverFallback({ open: menuOpen, contentId: menuId })
 
 // Busy state from the host's pending set — clears the instant `apiRequest` resolves.
-const pending = inject(DeviceActionPendingKey, new Set<string>())
+const pending = inject(
+	DeviceActionPendingKey,
+	shallowRef<ReadonlySet<string>>(new Set()),
+)
 const sending = computed(() =>
-	pending.has(setPendingKey(props.nodeId, props.param.target)),
+	pending.value.has(setPendingKey(props.nodeId, props.param.target)),
 )
 const refreshing = computed(() =>
-	pending.has(pollPendingKey(props.nodeId, props.param.target)),
+	pending.value.has(pollPendingKey(props.nodeId, props.param.target)),
 )
 
 const cur = computed(() =>
@@ -300,7 +290,7 @@ const busy = computed(() => sending.value || refreshing.value)
 const levelValue = computed(() => Number(cur.value) || 0)
 
 // Range hint under an editable number; default segment only when one exists.
-const rangeMeta = computed(() => {
+const rangeHint = computed(() => {
 	const p = props.param
 	const range = `min ${p.min} · max ${p.max}`
 	return p.default !== undefined ? `${range} · default ${p.default}` : range
@@ -323,14 +313,22 @@ function coerce(raw: unknown): unknown {
 
 function commit(value: unknown) {
 	menuOpen.value = false
-	// Hold an optimistic draft only for readable params (the watch clears it on
-	// confirm). Write-only params never report back, so a draft would stick dirty.
-	draft.value = props.param.readable ? value : null
+	// Don't optimistically pin the value. On a failed or un-acked write the
+	// device never confirms, so a pinned draft would keep showing the attempted
+	// value while the error toast says it failed. Show the live value instead;
+	// `busy` covers the in-flight window and the watch reflects the real result.
+	draft.value = null
 	emit('set', props.param.target, value)
 }
 
 function send() {
-	if (dirty.value) commit(coerce(draft.value))
+	if (!dirty.value) return
+	// An empty number input coerces to 0; don't send a spurious 0 / NaN.
+	if (props.param.kind === 'number') {
+		const n = Number(draft.value)
+		if (draft.value === '' || Number.isNaN(n)) return
+	}
+	commit(coerce(draft.value))
 }
 
 function onInput(e: Event) {
@@ -371,7 +369,7 @@ function copyId() {
 	copied.value = true
 	setTimeout(() => {
 		copied.value = false
-	}, 1200)
+	}, COPY_FEEDBACK_MS)
 }
 </script>
 
@@ -597,11 +595,14 @@ function copyId() {
 }
 
 .zw-vrow__input {
+	/* Narrow: numbers are short and right-aligned like the readouts. */
 	width: 80px;
 	text-align: right;
 }
 
 .zw-vrow__input--text {
+	/* Wider for free text, but still bounded so a long value can't push the
+	   control line past the cell. */
 	width: 180px;
 	text-align: left;
 }

--- a/src/components/dashboard/components/ZwValueRow.vue
+++ b/src/components/dashboard/components/ZwValueRow.vue
@@ -323,7 +323,9 @@ function coerce(raw: unknown): unknown {
 
 function commit(value: unknown) {
 	menuOpen.value = false
-	draft.value = value
+	// Hold an optimistic draft only for readable params (the watch clears it on
+	// confirm). Write-only params never report back, so a draft would stick dirty.
+	draft.value = props.param.readable ? value : null
 	emit('set', props.param.target, value)
 }
 
@@ -363,11 +365,9 @@ function resetDefault() {
 }
 
 function copyId() {
-	try {
-		void navigator.clipboard?.writeText(props.param.id)
-	} catch {
-		// Clipboard may be unavailable (insecure context); ignore.
-	}
+	// Clipboard API is absent in insecure contexts (`?.`) and can reject
+	// (permission denied / not focused); swallow both — it's only feedback.
+	void navigator.clipboard?.writeText(props.param.id).catch(() => {})
 	copied.value = true
 	setTimeout(() => {
 		copied.value = false

--- a/src/components/dashboard/components/ZwValueRow.vue
+++ b/src/components/dashboard/components/ZwValueRow.vue
@@ -1,0 +1,689 @@
+<template>
+	<div
+		class="zw-vrow"
+		:class="{
+			'zw-vrow--dirty': dirty,
+			'zw-vrow--button': param.kind === 'button',
+		}"
+	>
+		<!-- label line -->
+		<div
+			class="zw-vrow__head"
+			:class="{ 'zw-vrow__head--center': param.kind === 'button' }"
+		>
+			<div class="zw-vrow__label-wrap">
+				<!-- A button command carries its label on the button itself, so
+				     it lives on this row (centered) instead of a control line. -->
+				<template v-if="param.kind === 'button'">
+					<button
+						type="button"
+						class="zw-vrow__cmd"
+						:disabled="busy"
+						@click="commit(true)"
+					>
+						{{ param.label || 'Run' }}
+					</button>
+					<span v-if="busy" class="zw-vrow__status">
+						<RefreshIcon :size="ICON_SIZE.chip" class="zw-spin" />
+						Setting…
+					</span>
+				</template>
+				<template v-else>
+					<span
+						v-if="param.modified"
+						class="zw-vrow__moddot"
+						:title="`Modified — default: ${param.default}`"
+					/>
+					<span v-if="param.paramNumber" class="zw-vrow__num"
+						>#{{ param.paramNumber }}</span
+					>
+					<span class="zw-vrow__label">{{ param.label }}</span>
+				</template>
+			</div>
+
+			<Popover.Root v-model="menuOpen" :id="menuId">
+				<Popover.Activator
+					as="button"
+					class="zw-vrow__menu-btn zw-focus-ring"
+					title="More"
+				>
+					<MoreIcon :size="ICON_SIZE.inline" />
+				</Popover.Activator>
+				<Popover.Content as="div" class="zw-vrow__menu" role="menu">
+					<button
+						type="button"
+						class="zw-vrow__menu-item zw-vrow__menu-item--id"
+						title="Click to copy"
+						@click="copyId"
+					>
+						<span class="zw-vrow__menu-id"
+							>Value ID: {{ param.id }}</span
+						>
+						<component
+							:is="copied ? CheckIcon : CopyIcon"
+							:size="ICON_SIZE.chip"
+							class="zw-vrow__menu-copy"
+							:class="{ 'zw-vrow__menu-copy--done': copied }"
+						/>
+					</button>
+					<button
+						v-if="param.readable"
+						type="button"
+						class="zw-vrow__menu-item"
+						@click="refresh"
+					>
+						<RefreshIcon :size="ICON_SIZE.dense" /> Refresh value
+					</button>
+					<button
+						v-if="param.paramNumber"
+						type="button"
+						class="zw-vrow__menu-item"
+						:disabled="!param.modified"
+						@click="param.modified && resetDefault()"
+					>
+						<ResetIcon :size="ICON_SIZE.dense" /> Reset to default
+					</button>
+				</Popover.Content>
+			</Popover.Root>
+		</div>
+
+		<!-- value / control line (the button kind renders inline above) -->
+		<div
+			v-if="param.kind !== 'button'"
+			class="zw-vrow__control"
+			:class="{ 'zw-vrow__control--busy': busy }"
+		>
+			<!-- read-only display -->
+			<template v-if="param.readonly">
+				<span
+					v-if="param.kind === 'color'"
+					class="zw-vrow__swatch"
+					:style="{ background: String(param.value) }"
+				/>
+				<span
+					class="zw-vrow__display"
+					:class="{ 'zw-vrow__display--enum': param.kind === 'enum' }"
+					>{{ param.display }}</span
+				>
+			</template>
+
+			<!-- switch -->
+			<template v-else-if="param.kind === 'switch'">
+				<ZwToggle
+					:model-value="!!cur"
+					size="sm"
+					:disabled="busy"
+					@update:model-value="commit($event)"
+				/>
+				<span class="zw-vrow__mono">{{ cur ? 'ON' : 'OFF' }}</span>
+			</template>
+
+			<!-- enum select -->
+			<template v-else-if="param.kind === 'enum'">
+				<select
+					class="zw-vrow__select"
+					:value="String(cur)"
+					:disabled="busy"
+					@change="onEnumChange"
+				>
+					<option
+						v-for="o in param.options"
+						:key="o.value"
+						:value="String(o.value)"
+					>
+						[{{ o.value }}] {{ o.label }}
+					</option>
+				</select>
+			</template>
+
+			<!-- number -->
+			<template v-else-if="param.kind === 'number'">
+				<input
+					class="zw-vrow__input"
+					type="number"
+					:value="cur"
+					:min="param.min"
+					:max="param.max"
+					:step="param.step || 1"
+					:disabled="busy"
+					@input="onInput"
+					@keydown.enter="send"
+				/>
+				<span v-if="param.unit" class="zw-vrow__unit">{{
+					param.unit
+				}}</span>
+				<button
+					v-if="dirty"
+					type="button"
+					class="zw-vrow__apply"
+					title="Apply"
+					@click="send"
+				>
+					<CheckIcon :size="ICON_SIZE.dense" />
+				</button>
+			</template>
+
+			<!-- level slider — commits on release -->
+			<template v-else-if="param.kind === 'level'">
+				<span
+					class="zw-vrow__slider"
+					@pointerup.capture="commitLevel"
+					@keyup.capture="commitLevel"
+				>
+					<ZwSlider
+						:model-value="levelValue"
+						size="sm"
+						:disabled="busy"
+						@update:model-value="draft = $event"
+					/>
+				</span>
+				<span class="zw-vrow__mono zw-vrow__pct"
+					>{{ levelValue }}%</span
+				>
+			</template>
+
+			<!-- text -->
+			<template v-else-if="param.kind === 'text'">
+				<input
+					class="zw-vrow__input zw-vrow__input--text"
+					type="text"
+					:value="cur"
+					:disabled="busy"
+					@input="onInput"
+					@keydown.enter="send"
+				/>
+				<span v-if="param.unit" class="zw-vrow__unit">{{
+					param.unit
+				}}</span>
+				<button
+					v-if="dirty"
+					type="button"
+					class="zw-vrow__apply"
+					title="Apply"
+					@click="send"
+				>
+					<CheckIcon :size="ICON_SIZE.dense" />
+				</button>
+			</template>
+
+			<!-- color (writeable values render display-only in this theme) -->
+			<template v-else-if="param.kind === 'color'">
+				<span
+					class="zw-vrow__swatch"
+					:style="{ background: String(param.value) }"
+				/>
+				<span class="zw-vrow__mono">{{ param.display }}</span>
+			</template>
+
+			<span v-if="busy" class="zw-vrow__status">
+				<RefreshIcon :size="ICON_SIZE.chip" class="zw-spin" />
+				{{ sending ? 'Setting…' : 'Refreshing…' }}
+			</span>
+		</div>
+
+		<!-- description -->
+		<div v-if="param.description" class="zw-vrow__desc">
+			{{ param.description }}
+		</div>
+
+		<!-- numeric range meta — only for editable numbers -->
+		<div
+			v-if="
+				param.kind === 'number' &&
+				!param.readonly &&
+				param.min !== undefined
+			"
+			class="zw-vrow__range"
+		>
+			{{ rangeMeta }}
+		</div>
+	</div>
+</template>
+
+<script setup lang="ts">
+import { computed, inject, ref, useId, watch } from 'vue'
+import { Popover } from '@vuetify/v0'
+import ZwToggle from '@/components/dashboard/atoms/ZwToggle.vue'
+import ZwSlider from '@/components/dashboard/atoms/ZwSlider.vue'
+import {
+	CheckIcon,
+	CopyIcon,
+	ICON_SIZE,
+	MoreIcon,
+	RefreshIcon,
+	ResetIcon,
+} from '@/lib/icons'
+import { usePopoverFallback } from '@/lib/popover-fallback.ts'
+import type { ValueParam } from '@/lib/valueGroups.ts'
+import {
+	DeviceActionPendingKey,
+	pollPendingKey,
+	setPendingKey,
+} from '@/components/dashboard/deviceActionPending.ts'
+import type { ValueID } from '@zwave-js/core'
+
+const props = defineProps<{
+	param: ValueParam
+	nodeId: number
+}>()
+const emit = defineEmits<{
+	set: [ValueID, unknown]
+	poll: [ValueID]
+}>()
+
+// Pending edit until applied; null = show the live value. Clears on confirm.
+const draft = ref<unknown>(null)
+const copied = ref(false)
+const menuOpen = ref(false)
+const menuId = `zw-vrow-${useId()}`
+
+usePopoverFallback({ open: menuOpen, contentId: menuId })
+
+// Busy state from the host's pending set — clears the instant `apiRequest` resolves.
+const pending = inject(DeviceActionPendingKey, new Set<string>())
+const sending = computed(() =>
+	pending.has(setPendingKey(props.nodeId, props.param.target)),
+)
+const refreshing = computed(() =>
+	pending.has(pollPendingKey(props.nodeId, props.param.target)),
+)
+
+const cur = computed(() =>
+	draft.value !== null ? draft.value : props.param.value,
+)
+const dirty = computed(
+	() =>
+		draft.value !== null &&
+		String(draft.value) !== String(props.param.value),
+)
+const busy = computed(() => sending.value || refreshing.value)
+const levelValue = computed(() => Number(cur.value) || 0)
+
+// Range hint under an editable number; default segment only when one exists.
+const rangeMeta = computed(() => {
+	const p = props.param
+	const range = `min ${p.min} · max ${p.max}`
+	return p.default !== undefined ? `${range} · default ${p.default}` : range
+})
+
+// Once the confirmed value updates, drop the optimistic draft.
+watch(
+	() => props.param.value,
+	() => {
+		draft.value = null
+	},
+)
+
+function coerce(raw: unknown): unknown {
+	if (props.param.kind === 'number' || props.param.kind === 'level') {
+		return Number(raw)
+	}
+	return raw
+}
+
+function commit(value: unknown) {
+	menuOpen.value = false
+	draft.value = value
+	emit('set', props.param.target, value)
+}
+
+function send() {
+	if (dirty.value) commit(coerce(draft.value))
+}
+
+function onInput(e: Event) {
+	draft.value = (e.target as HTMLInputElement).value
+}
+
+function onEnumChange(e: Event) {
+	const raw = (e.target as HTMLSelectElement).value
+	const opt = props.param.options?.find((o) => String(o.value) === raw)
+	commit(opt ? opt.value : raw)
+}
+
+function commitLevel() {
+	if (draft.value === null) return
+	// Multilevel Switch tops out at 99 (100/255 mean "restore"); the slider
+	// track is 0–100, so clamp before writing.
+	const level = Math.min(99, Math.max(0, Number(draft.value)))
+	if (level !== Number(props.param.value)) {
+		commit(level)
+	} else {
+		draft.value = null
+	}
+}
+
+function refresh() {
+	menuOpen.value = false
+	emit('poll', props.param.target)
+}
+
+function resetDefault() {
+	if (props.param.default !== undefined) commit(props.param.default)
+}
+
+function copyId() {
+	try {
+		void navigator.clipboard?.writeText(props.param.id)
+	} catch {
+		// Clipboard may be unavailable (insecure context); ignore.
+	}
+	copied.value = true
+	setTimeout(() => {
+		copied.value = false
+	}, 1200)
+}
+</script>
+
+<style>
+/* Unscoped — the V0 Popover primitive sets inheritAttrs:false, so the
+   scoped data-v-* hash never reaches the menu. .zw-vrow is unique here. */
+.zw-vrow {
+	padding: 10px 12px;
+	display: flex;
+	flex-direction: column;
+	gap: 6px;
+	/* Fill the (equal-height) grid cell so a short row can center its
+	   content vertically; see .zw-vgroup__cell. */
+	flex: 1;
+	min-width: 0;
+	background: transparent;
+	/* Row separation comes from the .zw-vgroup__body grid gap, not a per-row
+	   border — each row is the only cell in its grid track. */
+	transition: background 0.15s;
+}
+
+/* A button command has a single short row — center it in the tall cell. */
+.zw-vrow--button {
+	justify-content: center;
+}
+
+.zw-vrow--dirty {
+	background: rgba(var(--v0-primary), 0.05);
+}
+
+/* ── label line ── */
+.zw-vrow__head {
+	display: flex;
+	align-items: flex-start;
+	gap: 8px;
+}
+
+/* A button command is the whole row — center the menu against the button. */
+.zw-vrow__head--center {
+	align-items: center;
+}
+
+.zw-vrow__head--center .zw-vrow__label-wrap {
+	align-items: center;
+}
+
+.zw-vrow__label-wrap {
+	min-width: 0;
+	flex: 1;
+	display: flex;
+	align-items: flex-start;
+	gap: 6px;
+}
+
+.zw-vrow__moddot {
+	width: 6px;
+	height: 6px;
+	border-radius: 50%;
+	background: var(--zw-accent);
+	flex-shrink: 0;
+	margin-top: 6px;
+}
+
+.zw-vrow__num {
+	font-family: var(--zw-mono);
+	font-size: 11px;
+	font-weight: 600;
+	color: var(--zw-accent);
+	flex-shrink: 0;
+	line-height: 17px;
+}
+
+.zw-vrow__label {
+	font-size: 12px;
+	font-weight: 500;
+	color: var(--zw-fg);
+	min-width: 0;
+	line-height: 17px;
+	overflow-wrap: anywhere;
+}
+
+.zw-vrow__menu-btn {
+	appearance: none;
+	border: none;
+	background: transparent;
+	color: var(--zw-muted);
+	cursor: pointer;
+	padding: 3px;
+	border-radius: 4px;
+	display: inline-flex;
+	align-items: center;
+	flex-shrink: 0;
+}
+
+.zw-vrow__menu-btn[data-open] {
+	background: var(--zw-chip-bg);
+}
+
+/* See ZwToggleMenu for why these position overrides need !important. */
+.zw-vrow__menu {
+	position-area: none !important;
+	position-anchor: auto !important;
+	min-width: 210px;
+	background: var(--zw-card);
+	border: 1px solid var(--zw-line2);
+	border-radius: 6px;
+	box-shadow: var(--zw-e8);
+	padding: 0;
+	overflow: hidden;
+	animation: zw-fade-in 0.12s;
+}
+
+.zw-vrow__menu::backdrop {
+	display: none;
+}
+
+.zw-vrow__menu-item {
+	width: 100%;
+	appearance: none;
+	border: none;
+	background: transparent;
+	cursor: pointer;
+	text-align: left;
+	color: var(--zw-fg);
+	padding: 8px 10px;
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	font: var(--zw-text-body-s);
+	border-top: 1px solid var(--zw-line);
+}
+
+.zw-vrow__menu-item:first-child {
+	border-top: none;
+}
+
+.zw-vrow__menu-item:not(:disabled):hover {
+	background: var(--zw-row-hover);
+}
+
+.zw-vrow__menu-item:disabled {
+	color: var(--zw-muted);
+	cursor: default;
+	opacity: 0.5;
+}
+
+.zw-vrow__menu-item--id {
+	cursor: copy;
+}
+
+.zw-vrow__menu-id {
+	font-family: var(--zw-mono);
+	font-size: 10px;
+	color: var(--zw-muted);
+	flex: 1;
+	min-width: 0;
+	word-break: break-all;
+}
+
+.zw-vrow__menu-copy {
+	color: var(--zw-muted);
+	flex-shrink: 0;
+}
+
+.zw-vrow__menu-copy--done {
+	color: var(--zw-accent);
+}
+
+/* ── control line ── */
+.zw-vrow__control {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	min-width: 0;
+	transition: opacity 0.15s;
+}
+
+.zw-vrow__control--busy {
+	opacity: 0.55;
+}
+
+.zw-vrow__display {
+	font-family: var(--zw-mono);
+	font-size: 14px;
+	font-weight: 600;
+	font-variant-numeric: tabular-nums;
+	overflow-wrap: anywhere;
+}
+
+.zw-vrow__display--enum {
+	font-weight: 600;
+	font-size: 13px;
+}
+
+.zw-vrow__mono {
+	font-family: var(--zw-mono);
+	font-size: 11px;
+	color: var(--zw-fg);
+}
+
+.zw-vrow__pct {
+	min-width: 34px;
+	text-align: right;
+}
+
+.zw-vrow__select,
+.zw-vrow__input {
+	appearance: none;
+	border: 1px solid var(--zw-line);
+	border-radius: 4px;
+	padding: 3px 8px;
+	font-size: 11px;
+	background: var(--zw-bg);
+	color: var(--zw-fg);
+	font-family: var(--zw-mono);
+}
+
+.zw-vrow__select {
+	padding-right: 22px;
+	cursor: pointer;
+	max-width: 240px;
+	text-overflow: ellipsis;
+}
+
+.zw-vrow__input {
+	width: 80px;
+	text-align: right;
+}
+
+.zw-vrow__input--text {
+	width: 180px;
+	text-align: left;
+}
+
+.zw-vrow__unit {
+	font-family: var(--zw-mono);
+	font-size: 11px;
+	color: var(--zw-muted);
+}
+
+.zw-vrow__slider {
+	flex: 1;
+	min-width: 80px;
+	max-width: 160px;
+	display: inline-flex;
+	align-items: center;
+}
+
+.zw-vrow__apply {
+	appearance: none;
+	border: none;
+	background: var(--zw-accent);
+	color: #fff;
+	width: 26px;
+	height: 26px;
+	border-radius: 6px;
+	cursor: pointer;
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	flex-shrink: 0;
+	box-shadow: 0 1px 2px rgba(var(--v0-on-surface), 0.2);
+}
+
+.zw-vrow__cmd {
+	appearance: none;
+	border: none;
+	background: var(--zw-accent);
+	color: #fff;
+	padding: 5px 12px;
+	border-radius: 6px;
+	font: var(--zw-text-label);
+	cursor: pointer;
+	max-width: 100%;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+.zw-vrow__cmd:disabled {
+	opacity: 0.55;
+	cursor: default;
+}
+
+.zw-vrow__swatch {
+	width: 16px;
+	height: 16px;
+	border-radius: 4px;
+	border: 1px solid var(--zw-line);
+	flex-shrink: 0;
+}
+
+.zw-vrow__status {
+	display: inline-flex;
+	align-items: center;
+	gap: 4px;
+	font-size: 10px;
+	font-family: var(--zw-mono);
+	color: var(--zw-accent);
+	white-space: nowrap;
+}
+
+/* ── meta ── */
+.zw-vrow__desc {
+	font-size: 11px;
+	color: var(--zw-muted);
+	line-height: 1.45;
+}
+
+.zw-vrow__range {
+	font-family: var(--zw-mono);
+	font-size: 9px;
+	color: var(--zw-muted);
+}
+</style>

--- a/src/components/dashboard/components/ZwValuesView.vue
+++ b/src/components/dashboard/components/ZwValuesView.vue
@@ -1,0 +1,138 @@
+<template>
+	<div class="zw-values">
+		<ZwSearchInput
+			v-model="query"
+			class="zw-values__search"
+			placeholder="Filter values…"
+			aria-label="Filter values"
+		/>
+
+		<ZwValueGroup
+			v-for="g in filtered"
+			:key="g.ccId"
+			:group="g"
+			:open="isOpen(g.ccId)"
+			:node-id="device.nodeId"
+			@toggle="toggle(g.ccId)"
+			@set="onSet"
+			@poll="onPoll"
+			@refresh-cc="onRefreshCc"
+		/>
+
+		<div v-if="groups.length === 0" class="zw-values__empty">
+			This node exposes no command-class values yet.
+		</div>
+		<div v-else-if="filtered.length === 0" class="zw-values__empty">
+			No values match “{{ query }}”.
+		</div>
+	</div>
+</template>
+
+<script setup lang="ts">
+import { computed, ref, watch } from 'vue'
+import ZwSearchInput from '@/components/dashboard/atoms/ZwSearchInput.vue'
+import ZwValueGroup from './ZwValueGroup.vue'
+import useBaseStore from '@/stores/base'
+import {
+	buildValueGroups,
+	DEFAULT_OPEN_CCS,
+	type ValueGroup,
+} from '@/lib/valueGroups.ts'
+import type { Device, DeviceAction } from '@/lib/dashboard-types.ts'
+import type { ValueID } from '@zwave-js/core'
+
+const props = defineProps<{ device: Device }>()
+const emit = defineEmits<{ action: [Device, DeviceAction] }>()
+
+const baseStore = useBaseStore()
+
+// Reads live from the store so writes/polls re-render as values land.
+const groups = computed<ValueGroup[]>(() =>
+	buildValueGroups(baseStore.getNode(props.device.nodeId)),
+)
+
+const query = ref('')
+const open = ref<Set<number>>(new Set())
+
+// Seed the open set once per node: default-open CCs that exist, else first two.
+let seededFor: number | null = null
+watch(
+	groups,
+	(gs) => {
+		if (seededFor === props.device.nodeId || gs.length === 0) return
+		const next = new Set<number>()
+		for (const g of gs) if (DEFAULT_OPEN_CCS.has(g.ccId)) next.add(g.ccId)
+		if (next.size === 0) for (const g of gs.slice(0, 2)) next.add(g.ccId)
+		open.value = next
+		seededFor = props.device.nodeId
+	},
+	{ immediate: true },
+)
+
+watch(
+	() => props.device.nodeId,
+	() => {
+		query.value = ''
+		seededFor = null
+	},
+)
+
+const filtered = computed<ValueGroup[]>(() => {
+	const q = query.value.trim().toLowerCase()
+	if (!q) return groups.value
+	return groups.value
+		.map((g) => ({
+			...g,
+			params: g.params.filter(
+				(p) =>
+					p.label.toLowerCase().includes(q) ||
+					p.id.toLowerCase().includes(q),
+			),
+		}))
+		.filter(
+			(g) => g.params.length > 0 || g.ccLabel.toLowerCase().includes(q),
+		)
+})
+
+// An active filter force-expands all groups so matches aren't hidden.
+function isOpen(ccId: number): boolean {
+	return query.value.trim() ? true : open.value.has(ccId)
+}
+
+function toggle(ccId: number) {
+	const next = new Set(open.value)
+	if (next.has(ccId)) next.delete(ccId)
+	else next.add(ccId)
+	open.value = next
+}
+
+function onSet(valueId: ValueID, value: unknown) {
+	emit('action', props.device, { type: 'set-value', valueId, value })
+}
+
+function onPoll(valueId: ValueID) {
+	emit('action', props.device, { type: 'poll-value', valueId })
+}
+
+function onRefreshCc(commandClass: number) {
+	emit('action', props.device, { type: 'refresh-cc', commandClass })
+}
+</script>
+
+<style scoped>
+.zw-values {
+	display: flex;
+	flex-direction: column;
+	gap: 10px;
+}
+
+.zw-values__empty {
+	padding: 20px 12px;
+	text-align: center;
+	font-size: 12px;
+	color: var(--zw-muted);
+	font-family: var(--zw-mono);
+	border: 1px dashed var(--zw-line);
+	border-radius: 6px;
+}
+</style>

--- a/src/components/dashboard/deviceActionPending.ts
+++ b/src/components/dashboard/deviceActionPending.ts
@@ -1,0 +1,50 @@
+// Reactive Set of in-flight value-pane request keys. The host fills it around
+// `apiRequest` so spinners clear on response (not a timer, and not only when a
+// value changes — a poll often re-reads the same value).
+
+import type { InjectionKey } from 'vue'
+import type { ValueID } from '@zwave-js/core'
+import type { Device, DeviceAction } from '@/lib/dashboard-types.ts'
+
+export type PendingSet = Set<string>
+
+export const DeviceActionPendingKey: InjectionKey<PendingSet> = Symbol(
+	'zwDeviceActionPending',
+)
+
+// Stable per-node value identity (`cc-endpoint-property-key`); keys pending
+// requests and matches event args back to values. Partial: event args may
+// carry only some of the fields.
+export function valueIdKey(v: Partial<ValueID>): string {
+	return `${v.commandClass}-${v.endpoint ?? 0}-${String(v.property)}-${v.propertyKey ?? ''}`
+}
+
+// Node-scoped — two nodes can share a ValueID shape.
+export function setPendingKey(nodeId: number, v: ValueID): string {
+	return `${nodeId}:set:${valueIdKey(v)}`
+}
+
+export function pollPendingKey(nodeId: number, v: ValueID): string {
+	return `${nodeId}:poll:${valueIdKey(v)}`
+}
+
+export function ccPendingKey(nodeId: number, cc: number): string {
+	return `${nodeId}:cc:${cc}`
+}
+
+// Pending key for an action, or null if the Values pane doesn't track it.
+export function actionPendingKey(
+	device: Device,
+	action: DeviceAction,
+): string | null {
+	switch (action.type) {
+		case 'set-value':
+			return setPendingKey(device.nodeId, action.valueId)
+		case 'poll-value':
+			return pollPendingKey(device.nodeId, action.valueId)
+		case 'refresh-cc':
+			return ccPendingKey(device.nodeId, action.commandClass)
+		default:
+			return null
+	}
+}

--- a/src/components/dashboard/layout/ZwDeviceDrawer.vue
+++ b/src/components/dashboard/layout/ZwDeviceDrawer.vue
@@ -40,6 +40,7 @@
 			<div class="zw-drawer__body">
 				<ZwNodeDetailsBody
 					:device="device"
+					layout="stacked"
 					@action="(d, a) => emit('action', d, a)"
 				/>
 			</div>

--- a/src/components/dashboard/layout/ZwTableBody.vue
+++ b/src/components/dashboard/layout/ZwTableBody.vue
@@ -80,10 +80,12 @@
 							{{ item.count }}
 						</span>
 					</div>
+					<!-- The expanded device's summary row is rendered by the
+					     sticky overlay below, not here, so it can pin. -->
 					<ZwDeviceRow
-						v-else
+						v-else-if="item.device.nodeId !== expandedId"
 						:device="item.device"
-						:expanded="expandedId === item.device.nodeId"
+						:expanded="false"
 						:columns="columns as ToggleableCol[]"
 						:viewport="viewport"
 						:style="absStyle(item)"
@@ -102,8 +104,60 @@
 				>
 					<ZwExpandedRow
 						:device="expandedDevice"
+						:viewport="viewport"
 						@action="(dev, a) => emit('action', dev, a)"
 					/>
+				</div>
+
+				<!-- Sticky summary row — keeps the expanded device pinned
+				     just beneath the group header while its detail scrolls. -->
+				<div
+					v-if="expandedDevice && stickyRowTop != null"
+					class="zw-table__sticky-row"
+					:style="{ top: stickyRowTop + 'px' }"
+				>
+					<ZwDeviceRow
+						:device="expandedDevice"
+						:expanded="true"
+						:columns="columns as ToggleableCol[]"
+						:viewport="viewport"
+						@open="(dev) => emit('open', dev)"
+						@action="(dev, a) => emit('action', dev, a)"
+					/>
+				</div>
+
+				<!-- Sticky group header — pinned to the top of the scroll
+				     viewport as the active group scrolls. -->
+				<div
+					v-if="stickyGroup"
+					class="zw-table__group-head zw-table__group-head--sticky"
+					:style="{
+						top: stickyGroup.top + 'px',
+						height: GROUP_HEAD_HEIGHT + 'px',
+					}"
+					@click="emit('toggleGroup', stickyGroup.key)"
+				>
+					<ChevronDownIcon
+						:size="ICON_SIZE.caret"
+						class="zw-table__group-chev"
+						:class="{
+							'zw-table__group-chev--collapsed':
+								stickyGroup.collapsed,
+						}"
+					/>
+					<span class="zw-table__group-name">
+						{{
+							stickyGroup.key === CONTROLLER_KEY
+								? 'Controller'
+								: stickyGroup.key
+						}}
+					</span>
+					<span
+						v-if="stickyGroup.key !== CONTROLLER_KEY"
+						class="zw-table__group-count"
+					>
+						{{ stickyGroup.count }}
+					</span>
 				</div>
 			</div>
 		</div>
@@ -329,6 +383,62 @@ const expandedBodyTop = computed<number | null>(() => {
 	return null
 })
 
+// ── sticky group header + expanded summary row ─────────────────────
+// Absolute positioning (the virtualization) defeats native
+// `position: sticky`, so we re-create it: derive each group's vertical
+// span, then render the active group's header — and, while a row is
+// expanded, its summary row just below — as overlays whose `top` is
+// pinned to the scroll viewport. The expanded row is dropped from the
+// normal loop (see template) so the overlay is its sole render.
+
+interface GroupSpan {
+	key: string
+	count: number
+	collapsed: boolean
+	headTop: number
+	endTop: number
+}
+
+const groupSpans = computed<GroupSpan[]>(() => {
+	const spans: GroupSpan[] = []
+	for (const it of layoutItems.value) {
+		if (it.kind !== 'group-head') continue
+		if (spans.length) spans[spans.length - 1].endTop = it.top
+		spans.push({
+			key: it.key,
+			count: it.count,
+			collapsed: it.collapsed,
+			headTop: it.top,
+			endTop: totalHeight.value,
+		})
+	}
+	return spans
+})
+
+// The group whose span contains the current scroll offset, with its
+// header `top` clamped so the next group pushes it up at the boundary.
+const stickyGroup = computed(() => {
+	const st = scrollTop.value
+	for (const g of groupSpans.value) {
+		if (st >= g.headTop && st < g.endTop) {
+			return { ...g, top: Math.min(st, g.endTop - GROUP_HEAD_HEIGHT) }
+		}
+	}
+	return null
+})
+
+// Top for the pinned summary row: just under the group header, clamped
+// to the expanded region so it rides up out of view past the panel.
+const stickyRowTop = computed<number | null>(() => {
+	if (expandedBodyTop.value == null) return null
+	const rowTop = expandedBodyTop.value - ROW_HEIGHT
+	const regionBottom = expandedBodyTop.value + expandedBodyHeight.value
+	return Math.min(
+		Math.max(scrollTop.value + GROUP_HEAD_HEIGHT, rowTop),
+		regionBottom - ROW_HEIGHT,
+	)
+})
+
 function absStyle(item: LayoutItem) {
 	return {
 		position: 'absolute' as const,
@@ -486,6 +596,25 @@ onBeforeUnmount(() => {
 	position: absolute;
 	left: 0;
 	right: 0;
+}
+
+/* Sticky overlays — opaque backgrounds (so scrolling content doesn't
+   bleed through) and a hair of lift. The group header sits above the
+   summary row, which sits above the detail panel. */
+.zw-table__group-head--sticky {
+	position: absolute;
+	left: 0;
+	right: 0;
+	z-index: 3;
+	box-shadow: 0 2px 4px rgba(var(--v0-on-surface), 0.06);
+}
+
+.zw-table__sticky-row {
+	position: absolute;
+	left: 0;
+	right: 0;
+	z-index: 2;
+	box-shadow: 0 2px 5px rgba(var(--v0-on-surface), 0.06);
 }
 
 .zw-table__group-head {

--- a/src/lib/dashboard-breakpoints.ts
+++ b/src/lib/dashboard-breakpoints.ts
@@ -12,3 +12,10 @@
 // `@media (max-width: 600px)` stays a literal (a stylesheet can't read a JS
 // constant); keep the two in sync if this ever changes.
 export const MOBILE_BREAKPOINT = 600
+
+// Container-width threshold (px) at which the table-row expansion switches
+// from the stacked layout to the two-pane layout (left rail + tabbed detail).
+// Below this — and always inside the card-view drawer — the stacked layout is
+// used. Like MOBILE_BREAKPOINT this is measured against the shell's own width
+// (the `viewport` passed down), so it tracks available space, not the window.
+export const TWO_PANE_BREAKPOINT = 900

--- a/src/lib/dashboard-breakpoints.ts
+++ b/src/lib/dashboard-breakpoints.ts
@@ -19,3 +19,9 @@ export const MOBILE_BREAKPOINT = 600
 // used. Like MOBILE_BREAKPOINT this is measured against the shell's own width
 // (the `viewport` passed down), so it tracks available space, not the window.
 export const TWO_PANE_BREAKPOINT = 900
+
+// Two-pane left-rail sizing. At/above RAIL_WIDTH_BREAKPOINT the rail uses the
+// spacious width, below it the compact one (matches the design's two widths).
+export const RAIL_WIDTH_BREAKPOINT = 1200
+export const RAIL_WIDTH_SPACIOUS = 340
+export const RAIL_WIDTH_COMPACT = 300

--- a/src/lib/dashboard-types.ts
+++ b/src/lib/dashboard-types.ts
@@ -202,6 +202,11 @@ export type DeviceAction =
 	| { type: 'lock'; locked: boolean; valueId: ValueID }
 	| { type: 'thermostat-setpoint'; setpoint: number; valueId: ValueID }
 	| { type: 'thermostat-mode'; mode: string; valueId: ValueID }
+	// Generic value-pane interactions: write any value, re-read a single
+	// value, or re-read every value of a command class.
+	| { type: 'set-value'; valueId: ValueID; value: unknown }
+	| { type: 'poll-value'; valueId: ValueID }
+	| { type: 'refresh-cc'; commandClass: number }
 	| { type: 'ping' }
 	| { type: 'interview' }
 	| { type: 'refresh' }

--- a/src/lib/device-actions.ts
+++ b/src/lib/device-actions.ts
@@ -50,6 +50,19 @@ export const ACTION_DISPATCHERS: {
 		api: 'writeValue',
 		args: [{ nodeId: d.nodeId, ...a.valueId }, a.mode],
 	}),
+	// Generic value-pane interactions.
+	'set-value': (d, a) => ({
+		api: 'writeValue',
+		args: [{ nodeId: d.nodeId, ...a.valueId }, a.value],
+	}),
+	'poll-value': (d, a) => ({
+		api: 'pollValue',
+		args: [{ nodeId: d.nodeId, ...a.valueId }],
+	}),
+	'refresh-cc': (d, a) => ({
+		api: 'refreshCCValues',
+		args: [d.nodeId, a.commandClass],
+	}),
 	// Controller- and node-management actions, mapped to their
 	// bookkeeping APIs.
 	ping: (d) => ({ api: 'pingNode', args: [d.nodeId] }),

--- a/src/lib/device-actions.ts
+++ b/src/lib/device-actions.ts
@@ -50,7 +50,8 @@ export const ACTION_DISPATCHERS: {
 		api: 'writeValue',
 		args: [{ nodeId: d.nodeId, ...a.valueId }, a.mode],
 	}),
-	// Generic value-pane interactions.
+	// Generic value-pane interactions. `set-value` writes the value verbatim —
+	// no clamping or coercion; the caller is responsible for a sensible value.
 	'set-value': (d, a) => ({
 		api: 'writeValue',
 		args: [{ nodeId: d.nodeId, ...a.valueId }, a.value],

--- a/src/lib/deviceActionPending.test.ts
+++ b/src/lib/deviceActionPending.test.ts
@@ -1,0 +1,94 @@
+// Pending-key helper tests.
+//
+// These strings drive every value-pane spinner; a format or collision bug here
+// silently breaks pending state, so the format and edge cases are pinned here.
+
+import { describe, it, expect } from 'vitest'
+import { CommandClasses, type ValueID } from '@zwave-js/core'
+import {
+	valueIdKey,
+	setPendingKey,
+	pollPendingKey,
+	ccPendingKey,
+	actionPendingKey,
+} from './deviceActionPending.ts'
+import type { Device } from './dashboard-types.ts'
+
+const meterValue: ValueID = {
+	commandClass: CommandClasses.Meter,
+	endpoint: 0,
+	property: 'value',
+	propertyKey: 65537,
+}
+
+describe('valueIdKey', () => {
+	it('formats cc-endpoint-property-propertyKey', () => {
+		expect(valueIdKey(meterValue)).to.equal('50-0-value-65537')
+	})
+
+	it('defaults a missing endpoint to 0 and a missing propertyKey to empty', () => {
+		expect(
+			valueIdKey({
+				commandClass: CommandClasses['Binary Switch'],
+				property: 'currentValue',
+			}),
+		).to.equal('37-0-currentValue-')
+	})
+
+	it('distinguishes values that differ only by propertyKey', () => {
+		const a = valueIdKey({ ...meterValue, propertyKey: 65537 })
+		const b = valueIdKey({ ...meterValue, propertyKey: 66049 })
+		expect(a).to.not.equal(b)
+	})
+})
+
+describe('pending keys', () => {
+	it('namespaces by node and operation', () => {
+		expect(setPendingKey(8, meterValue)).to.equal('8:set:50-0-value-65537')
+		expect(pollPendingKey(8, meterValue)).to.equal(
+			'8:poll:50-0-value-65537',
+		)
+		expect(ccPendingKey(8, CommandClasses.Meter)).to.equal('8:cc:50')
+	})
+
+	it('does not collide across nodes, operations, or CCs', () => {
+		const keys = new Set([
+			setPendingKey(8, meterValue),
+			setPendingKey(9, meterValue), // different node
+			pollPendingKey(8, meterValue), // different op
+			ccPendingKey(8, CommandClasses.Meter),
+			ccPendingKey(8, CommandClasses.Battery),
+		])
+		expect(keys.size).to.equal(5)
+	})
+})
+
+describe('actionPendingKey', () => {
+	const device = { nodeId: 8 } as Device
+
+	it('keys set / poll / refresh-cc actions', () => {
+		expect(
+			actionPendingKey(device, {
+				type: 'set-value',
+				valueId: meterValue,
+				value: 1,
+			}),
+		).to.equal('8:set:50-0-value-65537')
+		expect(
+			actionPendingKey(device, {
+				type: 'poll-value',
+				valueId: meterValue,
+			}),
+		).to.equal('8:poll:50-0-value-65537')
+		expect(
+			actionPendingKey(device, {
+				type: 'refresh-cc',
+				commandClass: CommandClasses.Meter,
+			}),
+		).to.equal('8:cc:50')
+	})
+
+	it('returns null for actions the Values pane does not track', () => {
+		expect(actionPendingKey(device, { type: 'ping' })).to.equal(null)
+	})
+})

--- a/src/lib/deviceActionPending.ts
+++ b/src/lib/deviceActionPending.ts
@@ -2,11 +2,15 @@
 // `apiRequest` so spinners clear on response (not a timer, and not only when a
 // value changes — a poll often re-reads the same value).
 
-import type { InjectionKey } from 'vue'
+import type { InjectionKey, ShallowRef } from 'vue'
 import type { ValueID } from '@zwave-js/core'
-import type { Device, DeviceAction } from '@/lib/dashboard-types.ts'
+import type { Device, DeviceAction } from './dashboard-types.ts'
 
-export type PendingSet = Set<string>
+// A shallowRef holding an immutable Set, replaced on each change. Members are
+// read via `.value.has(...)`, so a row's check re-runs only when the set is
+// actually swapped — not via Vue's reactive-Set per-key tracking, which
+// invalidates every `.has()` watcher in every mounted row on any mutation.
+export type PendingSet = ShallowRef<ReadonlySet<string>>
 
 export const DeviceActionPendingKey: InjectionKey<PendingSet> = Symbol(
 	'zwDeviceActionPending',

--- a/src/lib/deviceSignal.test.ts
+++ b/src/lib/deviceSignal.test.ts
@@ -1,0 +1,23 @@
+// Signal-display helper tests.
+
+import { describe, it, expect } from 'vitest'
+import { signalDisplay } from './deviceSignal.ts'
+import { SignalHighIcon, SignalLowIcon } from './icons.ts'
+
+describe('signalDisplay', () => {
+	it('maps weak health to the low icon, warning color and "Weak"', () => {
+		const s = signalDisplay('weak')
+		expect(s.icon).to.equal(SignalLowIcon)
+		expect(s.color).to.equal('var(--zw-warning)')
+		expect(s.label).to.equal('Weak')
+	})
+
+	it('maps any non-weak health to the high icon, soft color and "Strong"', () => {
+		for (const health of ['ok', 'unknown', undefined] as const) {
+			const s = signalDisplay(health)
+			expect(s.icon).to.equal(SignalHighIcon)
+			expect(s.color).to.equal('var(--zw-fg-soft)')
+			expect(s.label).to.equal('Strong')
+		}
+	})
+})

--- a/src/lib/deviceSignal.ts
+++ b/src/lib/deviceSignal.ts
@@ -1,0 +1,20 @@
+import type { Component } from 'vue'
+import { SignalHighIcon, SignalLowIcon } from './icons.ts'
+import type { Device } from './dashboard-types.ts'
+
+export interface SignalDisplay {
+	icon: Component // Lucide, rendered via `<component :is>`
+	color: string
+	label: string
+}
+
+// Device link health → signal glyph/color/label, shared by the table row and
+// the details rail. Only `weak` reads as degraded today.
+export function signalDisplay(health: Device['health']): SignalDisplay {
+	const weak = health === 'weak'
+	return {
+		icon: weak ? SignalLowIcon : SignalHighIcon,
+		color: weak ? 'var(--zw-warning)' : 'var(--zw-fg-soft)',
+		label: weak ? 'Weak' : 'Strong',
+	}
+}

--- a/src/lib/icons.ts
+++ b/src/lib/icons.ts
@@ -21,6 +21,7 @@ export {
 	CircleHelp as UnknownIcon,
 	ClipboardList as InterviewIcon,
 	Clock as ClockIcon,
+	Copy as CopyIcon,
 	Cpu as ControllerIcon,
 	DoorClosed as ContactIcon,
 	Download as DownloadIcon,
@@ -44,6 +45,7 @@ export {
 	// Lucide has no motion/PIR glyph; Radio's waves are the closest.
 	Radio as MotionIcon,
 	RefreshCw as RefreshIcon,
+	Undo2 as ResetIcon,
 	Search as SearchIcon,
 	Settings as SettingsIcon,
 	Signal as SignalIcon,

--- a/src/lib/valueGroups.test.ts
+++ b/src/lib/valueGroups.test.ts
@@ -1,0 +1,200 @@
+// Value-pane projection tests.
+//
+// `paramKind` / `formatValue` / `projectParam` are internal; they're exercised
+// through the public `buildValueGroups`, asserting the projected `ValueParam`.
+
+import { describe, it, expect } from 'vitest'
+import { CommandClasses } from '@zwave-js/core'
+import { buildValueGroups, DEFAULT_OPEN_CCS } from './valueGroups.ts'
+import type { ZUINode } from '../../api/lib/ZwaveClient.ts'
+
+// Minimal value with sensible defaults; override per test.
+function val(o: Record<string, any> = {}): any {
+	return {
+		id: '1-37-0-currentValue',
+		commandClass: CommandClasses['Binary Switch'],
+		commandClassName: 'Binary Switch',
+		commandClassVersion: 1,
+		property: 'currentValue',
+		type: 'boolean',
+		writeable: true,
+		readable: true,
+		...o,
+	}
+}
+
+function project(o: Record<string, any>) {
+	const node = { values: [val(o)] } as unknown as ZUINode
+	return buildValueGroups(node)[0].params[0]
+}
+
+describe('paramKind (via buildValueGroups)', () => {
+	it('write-only boolean is a button, not a switch', () => {
+		expect(
+			project({ type: 'boolean', writeable: true, readable: false }).kind,
+		).to.equal('button')
+	})
+
+	it('readable boolean is a switch', () => {
+		expect(project({ type: 'boolean', readable: true }).kind).to.equal(
+			'switch',
+		)
+	})
+
+	it('Multilevel Switch currentValue is a level', () => {
+		expect(
+			project({
+				commandClass: CommandClasses['Multilevel Switch'],
+				property: 'currentValue',
+				type: 'number',
+			}).kind,
+		).to.equal('level')
+	})
+
+	it('a 0–99 number is a level, but only without discrete states', () => {
+		const base = { type: 'number', min: 0, max: 99, property: 'foo' }
+		expect(project(base).kind).to.equal('level')
+		// With states the enum (more specific) wins over the generic level.
+		expect(
+			project({
+				...base,
+				states: [
+					{ value: 0, text: 'Off' },
+					{ value: 99, text: 'On' },
+				],
+			}).kind,
+		).to.equal('enum')
+	})
+
+	it('states render as enum unless free entry is allowed', () => {
+		const states = [{ value: 1, text: 'One' }]
+		expect(project({ type: 'number', states }).kind).to.equal('enum')
+		expect(
+			project({
+				type: 'number',
+				states,
+				writeable: true,
+				allowManualEntry: true,
+			}).kind,
+		).to.equal('number')
+	})
+
+	it('string and buffer are text; unsupported types are read-only readings', () => {
+		expect(project({ type: 'string' }).kind).to.equal('text')
+		expect(project({ type: 'buffer' }).kind).to.equal('text')
+		expect(project({ type: 'duration' }).kind).to.equal('reading')
+	})
+
+	it('forces a writeable reading to read-only so it never renders an empty control', () => {
+		const p = project({ type: 'duration', writeable: true })
+		expect(p.kind).to.equal('reading')
+		expect(p.readonly).to.equal(true)
+	})
+})
+
+describe('formatValue (via buildValueGroups)', () => {
+	it('formats switch / level / enum / number-with-unit', () => {
+		expect(project({ type: 'boolean', value: true }).display).to.equal('ON')
+		expect(
+			project({
+				commandClass: CommandClasses['Multilevel Switch'],
+				property: 'currentValue',
+				type: 'number',
+				value: 50,
+			}).display,
+		).to.equal('50 %')
+		expect(
+			project({
+				type: 'number',
+				value: 1,
+				states: [{ value: 1, text: 'One' }],
+			}).display,
+		).to.equal('[1] One')
+		expect(
+			project({ type: 'number', value: 42, unit: 'W' }).display,
+		).to.equal('42 W')
+	})
+
+	it('renders unknown for null/undefined and JSON for objects', () => {
+		expect(project({ type: 'number', value: undefined }).display).to.equal(
+			'unknown',
+		)
+		expect(project({ type: 'any', value: { a: 1 } }).display).to.equal(
+			'{"a":1}',
+		)
+	})
+})
+
+describe('projectParam (Configuration CC)', () => {
+	const config = {
+		commandClass: CommandClasses.Configuration,
+		commandClassName: 'Configuration',
+		property: 7,
+		type: 'number',
+	}
+
+	it('flags a modified param and surfaces its number', () => {
+		const p = project({ ...config, value: 5, default: 3 })
+		expect(p.modified).to.equal(true)
+		expect(p.paramNumber).to.equal('7')
+	})
+
+	it('is not modified when the value equals the default', () => {
+		expect(project({ ...config, value: 3, default: 3 }).modified).to.equal(
+			false,
+		)
+	})
+
+	it('never flags modified for a non-Configuration value', () => {
+		expect(
+			project({ type: 'number', value: 5, default: 3 }).modified,
+		).to.equal(false)
+	})
+})
+
+describe('buildValueGroups', () => {
+	it('returns [] for a node without values', () => {
+		expect(buildValueGroups(null)).to.deep.equal([])
+		expect(buildValueGroups({} as ZUINode)).to.deep.equal([])
+	})
+
+	it('groups values by command class in first-seen order', () => {
+		const node = {
+			values: [
+				val({ id: 'a', commandClass: CommandClasses.Meter }),
+				val({ id: 'b', commandClass: CommandClasses['Binary Switch'] }),
+				val({ id: 'c', commandClass: CommandClasses.Meter }),
+			],
+		} as unknown as ZUINode
+		const groups = buildValueGroups(node)
+		expect(groups.map((g) => g.ccId)).to.deep.equal([
+			CommandClasses.Meter,
+			CommandClasses['Binary Switch'],
+		])
+		expect(groups[0].params).to.have.length(2)
+	})
+
+	it('offers reset-all only for Configuration CC v4+', () => {
+		const make = (cc: number, version: number) =>
+			buildValueGroups({
+				values: [
+					val({ commandClass: cc, commandClassVersion: version }),
+				],
+			} as unknown as ZUINode)[0].canResetAll
+		expect(make(CommandClasses.Configuration, 4)).to.equal(true)
+		expect(make(CommandClasses.Configuration, 3)).to.equal(false)
+		expect(make(CommandClasses['Binary Switch'], 4)).to.equal(false)
+	})
+})
+
+describe('DEFAULT_OPEN_CCS', () => {
+	it('contains the common interactive CCs', () => {
+		expect(
+			DEFAULT_OPEN_CCS.has(CommandClasses['Multilevel Switch']),
+		).to.equal(true)
+		expect(DEFAULT_OPEN_CCS.has(CommandClasses.Meter)).to.equal(true)
+		expect(DEFAULT_OPEN_CCS.has(CommandClasses.Configuration)).to.equal(
+			false,
+		)
+	})
+})

--- a/src/lib/valueGroups.ts
+++ b/src/lib/valueGroups.ts
@@ -2,7 +2,11 @@
 // pane renders. Pure — the component memoizes it with a computed.
 
 import { CommandClasses, type ValueID } from '@zwave-js/core'
-import type { ZUINode, ZUIValueId } from '../../api/lib/ZwaveClient.ts'
+import type {
+	ZUINode,
+	ZUIValueId,
+	ZUIValueIdState,
+} from '../../api/lib/ZwaveClient.ts'
 
 const CONFIGURATION_CC = CommandClasses.Configuration
 const MULTILEVEL_SWITCH_CC = CommandClasses['Multilevel Switch']
@@ -19,7 +23,7 @@ export type ValueParamKind =
 	| 'reading'
 
 export interface ValueOption {
-	value: number | string
+	value: number | string | boolean
 	label: string
 }
 
@@ -82,7 +86,9 @@ function toValueId(v: ZUIValueId): ValueID {
 	return id
 }
 
-function hasStates(v: ZUIValueId): boolean {
+function hasStates(
+	v: ZUIValueId,
+): v is ZUIValueId & { states: ZUIValueIdState[] } {
 	return Array.isArray(v.states) && v.states.length > 0
 }
 
@@ -94,7 +100,8 @@ function isLevel(v: ZUIValueId): boolean {
 	) {
 		return true
 	}
-	return v.type === 'number' && v.min === 0 && v.max === 99
+	// A 0–99 number with discrete states is an enum (more specific), not a level.
+	return v.type === 'number' && v.min === 0 && v.max === 99 && !hasStates(v)
 }
 
 // Picks the control *shape* (editability is `readonly`, set elsewhere). A value
@@ -138,7 +145,21 @@ function formatValue(v: ZUIValueId, kind: ValueParamKind): string {
 	}
 }
 
+// Caches projected params by their source value object. The store *replaces* a
+// value object on update (splice), so unchanged values keep a stable reference
+// here — and so each row's `param` prop stays referentially stable, letting Vue
+// skip re-rendering every row when a single value changes.
+const paramCache = new WeakMap<ZUIValueId, ValueParam>()
+
 function projectParam(v: ZUIValueId): ValueParam {
+	const cached = paramCache.get(v)
+	if (cached) return cached
+	const param = buildParam(v)
+	paramCache.set(v, param)
+	return param
+}
+
+function buildParam(v: ZUIValueId): ValueParam {
 	const kind = paramKind(v)
 	const isConfig = v.commandClass === CONFIGURATION_CC
 	const hasDefault = v.default !== undefined && v.default !== null
@@ -149,7 +170,9 @@ function projectParam(v: ZUIValueId): ValueParam {
 		kind,
 		value: v.value,
 		display: formatValue(v, kind),
-		readonly: !v.writeable,
+		// `reading` has no editable control, so it must render read-only even
+		// when the value is technically writeable (avoids an empty control).
+		readonly: kind === 'reading' || !v.writeable,
 		readable: !!v.readable,
 		unit: v.unit,
 		min: v.min,

--- a/src/lib/valueGroups.ts
+++ b/src/lib/valueGroups.ts
@@ -1,0 +1,191 @@
+// Projects a node's `values` into the grouped, control-ready shape the Values
+// pane renders. Pure — the component memoizes it with a computed.
+
+import { CommandClasses, type ValueID } from '@zwave-js/core'
+import type { ZUINode, ZUIValueId } from '../../api/lib/ZwaveClient.ts'
+
+const CONFIGURATION_CC = CommandClasses.Configuration
+const MULTILEVEL_SWITCH_CC = CommandClasses['Multilevel Switch']
+
+// Which control a value renders (most-specific wins — see `paramKind`).
+export type ValueParamKind =
+	| 'switch'
+	| 'button'
+	| 'enum'
+	| 'number'
+	| 'level'
+	| 'text'
+	| 'color'
+	| 'reading'
+
+export interface ValueOption {
+	value: number | string
+	label: string
+}
+
+export interface ValueParam {
+	// Stable value id (e.g. `5-112-0-9`), used as the v-for key.
+	id: string
+	label: string
+	kind: ValueParamKind
+	value: unknown
+	// Pre-formatted current value for read-only / collapsed display.
+	display: string
+	readonly: boolean
+	// Whether the value can be read back — write-only commands can't be polled.
+	readable: boolean
+	unit?: string
+	min?: number
+	max?: number
+	step?: number
+	default?: unknown
+	// Configuration param whose value differs from its default.
+	modified: boolean
+	description?: string
+	options?: ValueOption[]
+	// Configuration param number (the value's `property`), surfaced as `#N`.
+	paramNumber?: string
+	// Write/poll target for the action layer.
+	target: ValueID
+}
+
+export interface ValueGroup {
+	ccId: number
+	ccLabel: string
+	version: number
+	params: ValueParam[]
+	// "Reset all to default" is offered for Configuration CC ≥ v4 only.
+	canResetAll: boolean
+}
+
+// CCs that start expanded — the most-used ones.
+export const DEFAULT_OPEN_CCS: ReadonlySet<number> = new Set([
+	CommandClasses['Binary Switch'],
+	CommandClasses['Multilevel Switch'],
+	CommandClasses['Multilevel Sensor'],
+	CommandClasses['Thermostat Mode'],
+	CommandClasses['Thermostat Setpoint'],
+	CommandClasses['Door Lock'],
+	CommandClasses.Notification,
+	CommandClasses['Binary Sensor'],
+	CommandClasses.Meter,
+	CommandClasses.Battery,
+])
+
+function toValueId(v: ZUIValueId): ValueID {
+	const id: ValueID = {
+		commandClass: v.commandClass,
+		endpoint: v.endpoint ?? 0,
+		property: v.property,
+	}
+	if (v.propertyKey !== undefined) id.propertyKey = v.propertyKey
+	return id
+}
+
+function hasStates(v: ZUIValueId): boolean {
+	return Array.isArray(v.states) && v.states.length > 0
+}
+
+// 0–99 dimmer-style value: Multilevel Switch current/target, or any 0–99 number.
+function isLevel(v: ZUIValueId): boolean {
+	if (
+		v.commandClass === MULTILEVEL_SWITCH_CC &&
+		(v.property === 'currentValue' || v.property === 'targetValue')
+	) {
+		return true
+	}
+	return v.type === 'number' && v.min === 0 && v.max === 99
+}
+
+// Picks the control *shape* (editability is `readonly`, set elsewhere). A value
+// can match several predicates, so order matters — most specific first.
+function paramKind(v: ZUIValueId): ValueParamKind {
+	// write-only boolean = a command (e.g. Meter reset), not a toggle
+	if (v.type === 'boolean' && v.writeable && !v.readable) return 'button'
+	if (v.type === 'boolean') return 'switch'
+	if (v.type === 'color') return 'color'
+	if (isLevel(v)) return 'level'
+	// states → dropdown, unless free entry is allowed (keep arbitrary values reachable)
+	if (hasStates(v) && !(v.writeable && v.allowManualEntry)) return 'enum'
+	if (v.type === 'number') return 'number'
+	if (v.type === 'string' || v.type === 'buffer') return 'text'
+	return 'reading' // duration / any / unsupported → read-only, never written
+}
+
+function formatValue(v: ZUIValueId, kind: ValueParamKind): string {
+	const val = v.value
+	if (val === null || val === undefined) return 'unknown'
+	switch (kind) {
+		case 'switch':
+			return val ? 'ON' : 'OFF'
+		case 'level':
+			return `${val} %`
+		case 'enum': {
+			const opt = v.states?.find((s) => s.value === val)
+			return opt ? `[${val}] ${opt.text}` : String(val)
+		}
+		case 'color':
+			return String(val)
+		default:
+			if (typeof val === 'object') {
+				try {
+					return JSON.stringify(val)
+				} catch {
+					return String(val)
+				}
+			}
+			return `${val}${v.unit ? ' ' + v.unit : ''}`
+	}
+}
+
+function projectParam(v: ZUIValueId): ValueParam {
+	const kind = paramKind(v)
+	const isConfig = v.commandClass === CONFIGURATION_CC
+	const hasDefault = v.default !== undefined && v.default !== null
+	const isDefault = hasDefault && String(v.value) === String(v.default)
+	return {
+		id: v.id,
+		label: v.label || v.propertyName || String(v.property),
+		kind,
+		value: v.value,
+		display: formatValue(v, kind),
+		readonly: !v.writeable,
+		readable: !!v.readable,
+		unit: v.unit,
+		min: v.min,
+		max: v.max,
+		step: v.step,
+		default: v.default,
+		modified: isConfig && hasDefault && !isDefault,
+		description: v.description,
+		options: hasStates(v)
+			? v.states.map((s) => ({ value: s.value, label: s.text }))
+			: undefined,
+		paramNumber: isConfig ? String(v.property) : undefined,
+		target: toValueId(v),
+	}
+}
+
+// Groups a node's values by command class (first-seen order), each projected to
+// a render-ready `ValueParam`. `[]` for a node without values (e.g. controller).
+export function buildValueGroups(node?: ZUINode | null): ValueGroup[] {
+	if (!node || !Array.isArray(node.values)) return []
+	const byCc = new Map<number, ValueGroup>()
+	for (const v of node.values) {
+		if (v == null) continue
+		let g = byCc.get(v.commandClass)
+		if (!g) {
+			const version = v.commandClassVersion ?? 0
+			g = {
+				ccId: v.commandClass,
+				ccLabel: v.commandClassName ?? `CC ${v.commandClass}`,
+				version,
+				params: [],
+				canResetAll: v.commandClass === CONFIGURATION_CC && version > 3,
+			}
+			byCc.set(v.commandClass, g)
+		}
+		g.params.push(projectParam(v))
+	}
+	return [...byCc.values()]
+}

--- a/src/views/ControlPanelNew.vue
+++ b/src/views/ControlPanelNew.vue
@@ -15,9 +15,15 @@
 // full-bleed. Device actions are resolved by `dispatchAction` and sent
 // through `apiRequest()` on the App instance, reached via `instanceManager`.
 
+import { provide, reactive } from 'vue'
 import ZwAppShell from '@/components/dashboard/layout/ZwAppShell.vue'
 import { dispatchAction } from '@/lib/device-actions.ts'
 import type { Device, DeviceAction } from '@/lib/dashboard-types'
+import {
+	actionPendingKey,
+	DeviceActionPendingKey,
+	type PendingSet,
+} from '@/components/dashboard/deviceActionPending.ts'
 import { manager, instances } from '@/lib/instanceManager'
 
 interface AppLike {
@@ -38,17 +44,28 @@ function appInstance(): AppLike | null {
 	return (inst as unknown as AppLike) ?? null
 }
 
-function onAction(device: Device, action: DeviceAction) {
+// Value-pane components watch this to show a spinner only while their request
+// is actually in flight.
+const pending = reactive(new Set<string>()) as PendingSet
+provide(DeviceActionPendingKey, pending)
+
+async function onAction(device: Device, action: DeviceAction) {
 	const req = dispatchAction(device, action)
 	const app = appInstance()
 	if (!app) {
 		console.warn('[ControlPanelNew] App instance not registered yet')
 		return
 	}
-	void app.apiRequest(req.api, req.args, {
-		infoSnack: false,
-		errorSnack: true,
-	})
+	const key = actionPendingKey(device, action)
+	if (key) pending.add(key)
+	try {
+		await app.apiRequest(req.api, req.args, {
+			infoSnack: false,
+			errorSnack: true,
+		})
+	} finally {
+		if (key) pending.delete(key)
+	}
 }
 
 function onAddAction(kind: 'include' | 'replace-failed' | 'exclude') {

--- a/src/views/ControlPanelNew.vue
+++ b/src/views/ControlPanelNew.vue
@@ -15,15 +15,14 @@
 // full-bleed. Device actions are resolved by `dispatchAction` and sent
 // through `apiRequest()` on the App instance, reached via `instanceManager`.
 
-import { provide, reactive } from 'vue'
+import { provide, shallowRef } from 'vue'
 import ZwAppShell from '@/components/dashboard/layout/ZwAppShell.vue'
 import { dispatchAction } from '@/lib/device-actions.ts'
 import type { Device, DeviceAction } from '@/lib/dashboard-types'
 import {
 	actionPendingKey,
 	DeviceActionPendingKey,
-	type PendingSet,
-} from '@/components/dashboard/deviceActionPending.ts'
+} from '@/lib/deviceActionPending.ts'
 import { manager, instances } from '@/lib/instanceManager'
 
 interface AppLike {
@@ -45,9 +44,16 @@ function appInstance(): AppLike | null {
 }
 
 // Value-pane components watch this to show a spinner only while their request
-// is actually in flight.
-const pending = reactive(new Set<string>()) as PendingSet
+// is actually in flight. Immutable Set, swapped on change (see PendingSet).
+const pending = shallowRef<ReadonlySet<string>>(new Set())
 provide(DeviceActionPendingKey, pending)
+
+function setPending(key: string, on: boolean) {
+	const next = new Set(pending.value)
+	if (on) next.add(key)
+	else next.delete(key)
+	pending.value = next
+}
 
 async function onAction(device: Device, action: DeviceAction) {
 	const req = dispatchAction(device, action)
@@ -57,14 +63,14 @@ async function onAction(device: Device, action: DeviceAction) {
 		return
 	}
 	const key = actionPendingKey(device, action)
-	if (key) pending.add(key)
+	if (key) setPending(key, true)
 	try {
 		await app.apiRequest(req.api, req.args, {
 			infoSnack: false,
 			errorSnack: true,
 		})
 	} finally {
-		if (key) pending.delete(key)
+		if (key) setPending(key, false)
 	}
 }
 


### PR DESCRIPTION
This PR implements the values tab for a node, both for the table view (with the events tab next to it)...
<img width="1446" height="813" alt="image" src="https://github.com/user-attachments/assets/0584868d-f2ce-4c13-bd07-34e0d21f1443" />

...and the card view:
<img width="1436" height="949" alt="image" src="https://github.com/user-attachments/assets/d143f72b-4e6b-4835-9814-a636490b6ad0" />
