### PR TITLE
fix(ui): sort values by propertyKey within command class groups

### DIFF
--- a/src/components/nodes-table/NodeDetails.vue
+++ b/src/components/nodes-table/NodeDetails.vue
@@ -570,6 +570,12 @@ export default {
 					groups.Configuration = []
 				}
 
+				for (const key in groups) {
+					if (groups[key][0]?.commandClass === 99) {
+						groups[key].sort((a, b) => (a.propertyKey ?? 0) - (b.propertyKey ?? 0))
+					}
+				}
+
 				return groups
 			} else {
 				return {}


### PR DESCRIPTION
## Description

Values within each command class group in the expanded node view (`NodeDetails.vue`) are displayed in arbitrary insertion order. For command classes with keyed properties — most notably **User Code (0x63)** — this means lock code slots appear unsorted (e.g. slot 5, slot 1, slot 12…) rather than in numerical order, making it difficult to find and manage specific slots.

## Changes

Sort each command class group's values by `propertyKey` in the `commandGroups` computed property, so values display in consistent ascending order.

**Files changed:** `src/components/nodes-table/NodeDetails.vue` (4 lines added)

## How to test

1. Open a node that has User Code CC (e.g. a Kwikset or Schlage lock)
2. Expand the node and view the "User Code" command class group under the Node tab
3. Verify slots are displayed in ascending order (1, 2, 3, …)