### PR TITLE
feat(ui): implement new Dropdown and NumericInput controls

### DIFF
--- a/src/components/dashboard/atoms/ZwDropdown.vue
+++ b/src/components/dashboard/atoms/ZwDropdown.vue
@@ -138,8 +138,6 @@ const contentId = `zw-dd-${useId()}`
 
 usePopoverFallback({ open, contentId, placement: 'bottom-start', offsetPx: 4 })
 
-// Autocomplete shows a filter when options exceed the plain threshold.
-// Combobox (allowManual) always shows the filter since it doubles as entry.
 const showFilter = computed(
 	() => props.allowManual || props.options.length > OPTIONS_FILTER_THRESHOLD,
 )
@@ -162,11 +160,9 @@ const filteredOptions = computed(() => {
 	)
 })
 
-// Number typed in the filter field — only meaningful in combobox mode.
 const manualNum = computed<number | null>(() => {
 	if (!props.allowManual) return null
 	const q = filter.value.trim()
-	// Accept integers and decimals — allowManualEntry params may have a decimal step.
 	if (!/^-?\d+(\.\d+)?$/.test(q)) return null
 	return Number(q)
 })
@@ -176,12 +172,9 @@ const manualValid = computed(() => {
 	if (n === null) return false
 	if (props.min !== undefined && n < props.min) return false
 	if (props.max !== undefined && n > props.max) return false
-	// Don't offer "set custom" for a value already in the list.
 	return !props.options.some((o) => String(o.value) === String(n))
 })
 
-// Selected value as a string key — options compare against this, so it's
-// coerced once rather than per option per render.
 const selectedKey = computed(() => String(props.modelValue))
 
 const curOpt = computed(() =>
@@ -216,10 +209,7 @@ function onFilterKeyDown(e: KeyboardEvent): void {
 	}
 }
 
-// On open: match panel width to trigger (min 220px) and focus the filter.
-// On close: clear the filter so it doesn't persist across sessions.
-// Registered after usePopoverFallback so its watcher fires first and the
-// element is already positioned when we set width here.
+// Match panel width to trigger on open; clear filter on close.
 watch(
 	() => open.value,
 	(isOpen) => {

--- a/src/components/dashboard/atoms/ZwDropdown.vue
+++ b/src/components/dashboard/atoms/ZwDropdown.vue
@@ -1,0 +1,447 @@
+<template>
+	<Popover.Root v-model="open" :id="contentId">
+		<Popover.Activator
+			as="button"
+			type="button"
+			class="zw-dropdown__trigger zw-focus-ring"
+			:disabled="disabled"
+			:title="triggerLabel"
+		>
+			<span class="zw-dropdown__trigger-text">{{ triggerLabel }}</span>
+			<ChevronDownIcon
+				class="zw-dropdown__chevron"
+				:size="ICON_SIZE.caret"
+			/>
+		</Popover.Activator>
+
+		<Popover.Content as="div" class="zw-dropdown__panel">
+			<div v-if="showFilter" class="zw-dropdown__filter-row">
+				<component
+					:is="allowManual ? EditIcon : SearchIcon"
+					class="zw-dropdown__filter-icon"
+					:size="ICON_SIZE.caret"
+				/>
+				<input
+					ref="filterInputRef"
+					v-model="filter"
+					type="text"
+					class="zw-dropdown__filter-input"
+					:placeholder="filterPlaceholder"
+					@keydown="onFilterKeyDown"
+				/>
+			</div>
+
+			<div class="zw-dropdown__list" role="listbox">
+				<!-- Combobox manual-entry confirm row -->
+				<button
+					v-if="manualValid"
+					type="button"
+					class="zw-dropdown__item zw-dropdown__item--custom"
+					role="option"
+					@click="pick(manualNum!)"
+				>
+					<!-- Spacer preserves alignment with the check column -->
+					<span
+						class="zw-dropdown__check-spacer"
+						aria-hidden="true"
+					/>
+					<span class="zw-dropdown__item-body">
+						Set custom value
+						<span class="zw-dropdown__manual-value">
+							{{ manualNum }}{{ unit ? ` ${unit}` : '' }}
+						</span>
+					</span>
+					<span class="zw-dropdown__enter-hint">Enter ↵</span>
+				</button>
+
+				<button
+					v-for="opt in filteredOptions"
+					:key="String(opt.value)"
+					type="button"
+					class="zw-dropdown__item"
+					:class="{
+						'zw-dropdown__item--selected': isSelected(opt.value),
+					}"
+					role="option"
+					:aria-selected="isSelected(opt.value)"
+					@click="pick(opt.value)"
+				>
+					<CheckIcon
+						class="zw-dropdown__check"
+						:class="{
+							'zw-dropdown__check--invisible': !isSelected(
+								opt.value,
+							),
+						}"
+						:size="ICON_SIZE.dense"
+						aria-hidden="true"
+					/>
+					<span class="zw-dropdown__item-num">[{{ opt.value }}]</span>
+					<span class="zw-dropdown__item-body">{{ opt.label }}</span>
+				</button>
+
+				<div
+					v-if="filteredOptions.length === 0 && !manualValid"
+					class="zw-dropdown__empty"
+				>
+					{{ emptyLabel }}
+				</div>
+			</div>
+		</Popover.Content>
+	</Popover.Root>
+</template>
+
+<script setup lang="ts">
+import { computed, ref, watch, useId } from 'vue'
+import { Popover } from '@vuetify/v0'
+import {
+	CheckIcon,
+	ChevronDownIcon,
+	EditIcon,
+	SearchIcon,
+	ICON_SIZE,
+} from '@/lib/icons'
+import { usePopoverFallback } from '@/lib/popover-fallback.ts'
+
+type OptionValue = number | string | boolean
+
+interface DropdownOption {
+	value: OptionValue
+	label: string
+}
+
+const props = withDefaults(
+	defineProps<{
+		modelValue: OptionValue | null
+		options: DropdownOption[]
+		allowManual?: boolean
+		min?: number
+		max?: number
+		unit?: string
+		disabled?: boolean
+	}>(),
+	{ allowManual: false, disabled: false },
+)
+
+const emit = defineEmits<{ 'update:modelValue': [OptionValue] }>()
+
+const open = ref(false)
+const filter = ref('')
+const filterInputRef = ref<HTMLInputElement | null>(null)
+const contentId = `zw-dd-${useId()}`
+
+usePopoverFallback({ open, contentId, placement: 'bottom-start', offsetPx: 4 })
+
+// Autocomplete shows a filter when options exceed the plain threshold.
+// Combobox (allowManual) always shows the filter since it doubles as entry.
+const showFilter = computed(() => props.allowManual || props.options.length > 6)
+
+const filterPlaceholder = computed(() => {
+	if (!props.allowManual) return 'Filter…'
+	if (props.min !== undefined && props.max !== undefined)
+		return `Enter a value (${props.min}–${props.max})…`
+	return 'Enter a value…'
+})
+
+const filteredOptions = computed(() => {
+	const q = filter.value.trim()
+	if (!q) return props.options
+	const lower = q.toLowerCase()
+	return props.options.filter(
+		(o) =>
+			o.label.toLowerCase().includes(lower) ||
+			String(o.value).includes(q),
+	)
+})
+
+// Integer typed in the filter field — only meaningful in combobox mode.
+const manualNum = computed<number | null>(() => {
+	if (!props.allowManual) return null
+	const q = filter.value.trim()
+	if (!/^-?\d+$/.test(q)) return null
+	return Number(q)
+})
+
+const manualValid = computed(() => {
+	const n = manualNum.value
+	if (n === null) return false
+	if (props.min !== undefined && n < props.min) return false
+	if (props.max !== undefined && n > props.max) return false
+	// Don't offer "set custom" for a value already in the list.
+	return !props.options.some((o) => String(o.value) === String(n))
+})
+
+// Selected value as a string key — options compare against this, so it's
+// coerced once rather than per option per render.
+const selectedKey = computed(() => String(props.modelValue))
+
+const curOpt = computed(() =>
+	props.options.find((o) => String(o.value) === selectedKey.value),
+)
+
+const triggerLabel = computed(() => {
+	if (curOpt.value) return `[${curOpt.value.value}] ${curOpt.value.label}`
+	if (props.modelValue !== null && props.modelValue !== undefined)
+		return `${props.modelValue}${props.unit ? ` ${props.unit}` : ''} · custom`
+	return '—'
+})
+
+const emptyLabel = computed(() =>
+	props.allowManual ? 'No preset matches — enter a number' : 'No matches',
+)
+
+function isSelected(value: OptionValue): boolean {
+	return String(value) === selectedKey.value
+}
+
+function pick(value: OptionValue): void {
+	open.value = false
+	emit('update:modelValue', value)
+}
+
+function onFilterKeyDown(e: KeyboardEvent): void {
+	if (e.key === 'Enter' && manualValid.value && manualNum.value !== null) {
+		pick(manualNum.value)
+	} else if (e.key === 'Escape') {
+		open.value = false
+	}
+}
+
+// On open: match panel width to trigger (min 220px) and focus the filter.
+// On close: clear the filter so it doesn't persist across sessions.
+// Registered after usePopoverFallback so its watcher fires first and the
+// element is already positioned when we set width here.
+watch(
+	() => open.value,
+	(isOpen) => {
+		if (!isOpen) {
+			filter.value = ''
+			return
+		}
+		const c = document.getElementById(contentId)
+		const a = document.querySelector<HTMLElement>(
+			`[popovertarget="${contentId}"]`,
+		)
+		if (a && c) {
+			c.style.setProperty(
+				'min-width',
+				`${Math.max(a.offsetWidth, 220)}px`,
+				'important',
+			)
+		}
+		if (showFilter.value) filterInputRef.value?.focus()
+	},
+	{ flush: 'post' },
+)
+</script>
+
+<style>
+/* Unscoped — V0 Popover primitives set inheritAttrs:false so scoped data-v-*
+   hashes never reach the rendered elements. .zw-dropdown* names are unique. */
+
+.zw-dropdown__trigger {
+	appearance: none;
+	display: inline-flex;
+	align-items: center;
+	gap: 6px;
+	border: 1px solid var(--zw-line);
+	border-radius: var(--zw-radius-sm);
+	padding: 0 6px 0 8px;
+	height: 26px;
+	min-width: 130px;
+	max-width: 260px;
+	background: var(--zw-bg);
+	color: var(--zw-fg);
+	font-family: var(--zw-mono);
+	font-size: 11px;
+	font-weight: 500;
+	font-variant-numeric: tabular-nums;
+	cursor: pointer;
+	transition:
+		border-color 0.12s,
+		background 0.12s;
+}
+
+.zw-dropdown__trigger:hover:not(:disabled) {
+	border-color: var(--zw-line2);
+}
+
+/* V0 sets data-open on Popover.Activator while the popover is open. */
+.zw-dropdown__trigger[data-open] {
+	border-color: var(--zw-accent);
+	background: var(--zw-card);
+}
+
+.zw-dropdown__trigger:disabled {
+	opacity: 0.55;
+	cursor: default;
+	pointer-events: none;
+}
+
+.zw-dropdown__trigger-text {
+	flex: 1;
+	min-width: 0;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+	text-align: left;
+}
+
+.zw-dropdown__chevron {
+	flex-shrink: 0;
+	color: var(--zw-muted);
+	transition: transform 0.12s;
+}
+
+.zw-dropdown__trigger[data-open] .zw-dropdown__chevron {
+	transform: rotate(180deg);
+}
+
+/* See ZwToggleMenu for why position-area override needs !important. */
+.zw-dropdown__panel {
+	position-area: none !important;
+	position-anchor: auto !important;
+	background: var(--zw-card);
+	border: 1px solid var(--zw-line2);
+	border-radius: var(--zw-radius-md);
+	box-shadow: var(--zw-e8);
+	max-height: 300px;
+	overflow: hidden;
+	padding: 0;
+	animation: zw-fade-in 0.12s;
+}
+
+/* display:flex must live here, not on the base rule — otherwise it overrides
+   the UA `[popover]:not(:popover-open) { display:none }` and the panel renders
+   visibly even while closed. */
+.zw-dropdown__panel:popover-open {
+	display: flex;
+	flex-direction: column;
+}
+
+.zw-dropdown__panel::backdrop {
+	display: none;
+}
+
+.zw-dropdown__filter-row {
+	position: relative;
+	padding: 5px 6px;
+	border-bottom: 1px solid var(--zw-line);
+	flex-shrink: 0;
+}
+
+.zw-dropdown__filter-icon {
+	position: absolute;
+	left: 14px;
+	top: 50%;
+	transform: translateY(-50%);
+	color: var(--zw-muted);
+	pointer-events: none;
+}
+
+.zw-dropdown__filter-input {
+	width: 100%;
+	box-sizing: border-box;
+	appearance: none;
+	border: 1px solid var(--zw-line);
+	border-radius: var(--zw-radius-sm);
+	padding: 4px 8px 4px 26px;
+	font-family: var(--zw-mono);
+	font-size: 11px;
+	font-weight: 500;
+	background: var(--zw-bg);
+	color: var(--zw-fg);
+	outline: none;
+	transition: border-color 0.12s;
+}
+
+.zw-dropdown__filter-input:focus {
+	border-color: var(--zw-accent);
+}
+
+.zw-dropdown__list {
+	overflow-y: auto;
+	padding: 3px;
+}
+
+.zw-dropdown__item {
+	appearance: none;
+	border: none;
+	background: transparent;
+	cursor: pointer;
+	text-align: left;
+	color: var(--zw-fg);
+	border-radius: var(--zw-radius-sm);
+	padding: 5px 8px;
+	display: flex;
+	align-items: center;
+	gap: 7px;
+	width: 100%;
+	font-size: 12px;
+	line-height: 1.3;
+	transition: background 0.1s;
+}
+
+.zw-dropdown__item:hover {
+	background: var(--zw-row-hover);
+}
+
+.zw-dropdown__item--selected {
+	background: var(--zw-accent-soft);
+}
+
+.zw-dropdown__item--custom {
+	color: var(--zw-accent);
+}
+
+/* Invisible placeholder keeps the check column width consistent. */
+.zw-dropdown__check-spacer {
+	display: inline-block;
+	width: 13px;
+	flex-shrink: 0;
+}
+
+.zw-dropdown__check {
+	flex-shrink: 0;
+	color: var(--zw-accent);
+}
+
+.zw-dropdown__check--invisible {
+	opacity: 0;
+}
+
+/* [N] prefix in monospace-muted */
+.zw-dropdown__item-num {
+	flex-shrink: 0;
+	font-family: var(--zw-mono);
+	font-size: 11px;
+	font-weight: 500;
+	color: var(--zw-muted);
+	font-variant-numeric: tabular-nums;
+}
+
+.zw-dropdown__item-body {
+	flex: 1;
+	min-width: 0;
+}
+
+/* The value part of the manual entry "Set custom value N unit" */
+.zw-dropdown__manual-value {
+	font-family: var(--zw-mono);
+}
+
+.zw-dropdown__enter-hint {
+	font-family: var(--zw-mono);
+	font-size: 10px;
+	font-weight: 600;
+	color: var(--zw-muted);
+	flex-shrink: 0;
+}
+
+.zw-dropdown__empty {
+	padding: 8px 10px;
+	font-family: var(--zw-mono);
+	font-size: 11px;
+	color: var(--zw-muted);
+}
+</style>

--- a/src/components/dashboard/atoms/ZwDropdown.vue
+++ b/src/components/dashboard/atoms/ZwDropdown.vue
@@ -103,6 +103,11 @@ import {
 } from '@/lib/icons'
 import { usePopoverFallback } from '@/lib/popover-fallback.ts'
 
+// Show the filter input once the list grows beyond this many options.
+const OPTIONS_FILTER_THRESHOLD = 6
+// Panel is never narrower than this, even under a small trigger.
+const MIN_PANEL_WIDTH_PX = 220
+
 type OptionValue = number | string | boolean
 
 interface DropdownOption {
@@ -115,6 +120,7 @@ const props = withDefaults(
 		modelValue: OptionValue | null
 		options: DropdownOption[]
 		allowManual?: boolean
+		// min/max/unit apply only with allowManual (combobox manual entry).
 		min?: number
 		max?: number
 		unit?: string
@@ -134,7 +140,9 @@ usePopoverFallback({ open, contentId, placement: 'bottom-start', offsetPx: 4 })
 
 // Autocomplete shows a filter when options exceed the plain threshold.
 // Combobox (allowManual) always shows the filter since it doubles as entry.
-const showFilter = computed(() => props.allowManual || props.options.length > 6)
+const showFilter = computed(
+	() => props.allowManual || props.options.length > OPTIONS_FILTER_THRESHOLD,
+)
 
 const filterPlaceholder = computed(() => {
 	if (!props.allowManual) return 'Filter…'
@@ -154,11 +162,12 @@ const filteredOptions = computed(() => {
 	)
 })
 
-// Integer typed in the filter field — only meaningful in combobox mode.
+// Number typed in the filter field — only meaningful in combobox mode.
 const manualNum = computed<number | null>(() => {
 	if (!props.allowManual) return null
 	const q = filter.value.trim()
-	if (!/^-?\d+$/.test(q)) return null
+	// Accept integers and decimals — allowManualEntry params may have a decimal step.
+	if (!/^-?\d+(\.\d+)?$/.test(q)) return null
 	return Number(q)
 })
 
@@ -225,7 +234,7 @@ watch(
 		if (a && c) {
 			c.style.setProperty(
 				'min-width',
-				`${Math.max(a.offsetWidth, 220)}px`,
+				`${Math.max(a.offsetWidth, MIN_PANEL_WIDTH_PX)}px`,
 				'important',
 			)
 		}

--- a/src/components/dashboard/atoms/ZwNumericInput.vue
+++ b/src/components/dashboard/atoms/ZwNumericInput.vue
@@ -1,0 +1,232 @@
+<template>
+	<div class="zw-num" :class="{ 'zw-num--disabled': disabled }">
+		<div class="zw-num__field" :class="{ 'zw-num__field--dirty': dirty }">
+			<input
+				type="text"
+				inputmode="numeric"
+				class="zw-num__input"
+				:value="modelValue"
+				:disabled="disabled"
+				@input="onInput"
+				@keydown="onKeyDown"
+			/>
+			<div class="zw-num__stepper" aria-hidden="true">
+				<button
+					type="button"
+					tabindex="-1"
+					class="zw-num__step"
+					:class="{ 'zw-num__step--at-limit': atMax }"
+					:disabled="disabled || atMax"
+					@click="bump(1)"
+				>
+					<ChevronUpIcon :size="ICON_SIZE.chip" />
+				</button>
+				<button
+					type="button"
+					tabindex="-1"
+					class="zw-num__step zw-num__step--down"
+					:class="{ 'zw-num__step--at-limit': atMin }"
+					:disabled="disabled || atMin"
+					@click="bump(-1)"
+				>
+					<ChevronDownIcon :size="ICON_SIZE.chip" />
+				</button>
+			</div>
+		</div>
+		<span v-if="unit" class="zw-num__unit">{{ unit }}</span>
+		<button
+			v-if="dirty"
+			type="button"
+			class="zw-num__apply zw-focus-ring"
+			title="Apply"
+			@click="emit('commit')"
+		>
+			<CheckIcon :size="ICON_SIZE.dense" />
+		</button>
+	</div>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import {
+	CheckIcon,
+	ChevronDownIcon,
+	ChevronUpIcon,
+	ICON_SIZE,
+} from '@/lib/icons'
+
+const props = withDefaults(
+	defineProps<{
+		modelValue: number | string
+		min?: number
+		max?: number
+		step?: number
+		unit?: string
+		disabled?: boolean
+		// Controlled dirty state: parent sets this when the value has changed
+		// from the committed value. Drives the apply button visibility.
+		dirty?: boolean
+	}>(),
+	{ step: 1, disabled: false, dirty: false },
+)
+
+const emit = defineEmits<{ 'update:modelValue': [string]; commit: []; reset: [] }>()
+
+const atMax = computed(
+	() => props.max !== undefined && Number(props.modelValue) >= props.max,
+)
+const atMin = computed(
+	() => props.min !== undefined && Number(props.modelValue) <= props.min,
+)
+
+function clamp(v: number): number {
+	let n = v
+	if (props.min !== undefined && n < props.min) n = props.min
+	if (props.max !== undefined && n > props.max) n = props.max
+	return n
+}
+
+function bump(delta: number): void {
+	const base = Number(props.modelValue)
+	const next = String(clamp((Number.isFinite(base) ? base : 0) + delta * props.step))
+	emit('update:modelValue', next)
+}
+
+function onInput(e: Event): void {
+	emit('update:modelValue', (e.target as HTMLInputElement).value)
+}
+
+function onKeyDown(e: KeyboardEvent): void {
+	if (e.key === 'Enter') {
+		if (props.dirty) emit('commit')
+	} else if (e.key === 'Escape') {
+		if (props.dirty) {
+			e.preventDefault()
+			e.stopPropagation()
+			emit('reset')
+		}
+	} else if (e.key === 'ArrowUp') {
+		e.preventDefault()
+		bump(1)
+	} else if (e.key === 'ArrowDown') {
+		e.preventDefault()
+		bump(-1)
+	}
+}
+</script>
+
+<style scoped>
+.zw-num {
+	display: inline-flex;
+	align-items: center;
+	gap: 6px;
+}
+
+.zw-num--disabled {
+	opacity: 0.55;
+}
+
+.zw-num__field {
+	display: inline-flex;
+	align-items: stretch;
+	height: 26px;
+	border: 1px solid var(--zw-line);
+	border-radius: var(--zw-radius-sm);
+	overflow: hidden;
+	background: var(--zw-bg);
+	transition:
+		border-color 0.12s,
+		background 0.12s;
+}
+
+.zw-num__field--dirty {
+	border-color: var(--zw-accent);
+}
+
+.zw-num__field:focus-within {
+	border-color: var(--zw-accent);
+	background: var(--zw-card);
+}
+
+.zw-num__input {
+	appearance: none;
+	border: none;
+	background: transparent;
+	outline: none;
+	width: 58px;
+	padding: 0 8px;
+	font-family: var(--zw-mono);
+	font-size: 11px;
+	font-weight: 500;
+	color: var(--zw-fg);
+	text-align: right;
+	font-variant-numeric: tabular-nums;
+}
+
+.zw-num__stepper {
+	display: flex;
+	flex-direction: column;
+	width: 20px;
+	flex-shrink: 0;
+	border-left: 1px solid var(--zw-line);
+}
+
+.zw-num__step {
+	appearance: none;
+	border: none;
+	background: transparent;
+	color: var(--zw-muted);
+	cursor: pointer;
+	padding: 0;
+	flex: 1;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	transition:
+		background 0.1s,
+		color 0.1s;
+}
+
+.zw-num__step:hover:not(:disabled) {
+	background: var(--zw-row-hover);
+	color: var(--zw-fg);
+}
+
+.zw-num__step--down {
+	border-top: 1px solid var(--zw-line);
+}
+
+.zw-num__step--at-limit,
+.zw-num__step:disabled {
+	opacity: 0.35;
+	cursor: default;
+}
+
+.zw-num__unit {
+	font-family: var(--zw-mono);
+	font-size: 11px;
+	font-weight: 500;
+	color: var(--zw-muted);
+}
+
+.zw-num__apply {
+	appearance: none;
+	border: none;
+	background: var(--zw-accent);
+	color: rgb(var(--v0-on-primary));
+	width: 26px;
+	height: 26px;
+	border-radius: var(--zw-radius-md);
+	cursor: pointer;
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	flex-shrink: 0;
+	box-shadow: 0 1px 2px rgba(var(--v0-on-surface), 0.2);
+	transition: background 0.12s;
+}
+
+.zw-num__apply:hover {
+	background: var(--zw-accent-dark);
+}
+</style>

--- a/src/components/dashboard/atoms/ZwNumericInput.vue
+++ b/src/components/dashboard/atoms/ZwNumericInput.vue
@@ -63,8 +63,7 @@ const props = withDefaults(
 		step?: number
 		unit?: string
 		disabled?: boolean
-		// Controlled dirty state: parent sets this when the value has changed
-		// from the committed value. Drives the apply button visibility.
+		// When true, shows the apply button.
 		dirty?: boolean
 	}>(),
 	{ step: 1, disabled: false, dirty: false },

--- a/src/components/dashboard/atoms/ZwNumericInput.vue
+++ b/src/components/dashboard/atoms/ZwNumericInput.vue
@@ -57,7 +57,7 @@ import {
 
 const props = withDefaults(
 	defineProps<{
-		modelValue: number | string
+		modelValue: string
 		min?: number
 		max?: number
 		step?: number
@@ -70,7 +70,11 @@ const props = withDefaults(
 	{ step: 1, disabled: false, dirty: false },
 )
 
-const emit = defineEmits<{ 'update:modelValue': [string]; commit: []; reset: [] }>()
+const emit = defineEmits<{
+	'update:modelValue': [string]
+	commit: []
+	reset: []
+}>()
 
 const atMax = computed(
 	() => props.max !== undefined && Number(props.modelValue) >= props.max,
@@ -88,7 +92,9 @@ function clamp(v: number): number {
 
 function bump(delta: number): void {
 	const base = Number(props.modelValue)
-	const next = String(clamp((Number.isFinite(base) ? base : 0) + delta * props.step))
+	const next = String(
+		clamp((Number.isFinite(base) ? base : 0) + delta * props.step),
+	)
 	emit('update:modelValue', next)
 }
 

--- a/src/components/dashboard/components/ZwValueGroup.vue
+++ b/src/components/dashboard/components/ZwValueGroup.vue
@@ -68,7 +68,8 @@ import ZwValueRow from './ZwValueRow.vue'
 import { ChevronDownIcon, ICON_SIZE, RefreshIcon, ResetIcon } from '@/lib/icons'
 import {
 	ccPendingKey,
-	DeviceActionPendingKey,
+	DeviceActionStatusKey,
+	type ActionStatus,
 } from '@/lib/deviceActionPending.ts'
 import type { ValueGroup } from '@/lib/valueGroups.ts'
 import type { ValueID } from '@zwave-js/core'
@@ -86,13 +87,14 @@ const emit = defineEmits<{
 	refreshCc: [number]
 }>()
 
-// Spins only while the CC refresh is actually in flight (see deviceActionPending).
-const pending = inject(
-	DeviceActionPendingKey,
-	shallowRef<ReadonlySet<string>>(new Set()),
+const status = inject(
+	DeviceActionStatusKey,
+	shallowRef<ReadonlyMap<string, ActionStatus>>(new Map()),
 )
-const refreshing = computed(() =>
-	pending.value.has(ccPendingKey(props.nodeId, props.group.ccId)),
+const refreshing = computed(
+	() =>
+		status.value.get(ccPendingKey(props.nodeId, props.group.ccId)) ===
+		'pending',
 )
 
 function onRefresh() {

--- a/src/components/dashboard/components/ZwValueRow.vue
+++ b/src/components/dashboard/components/ZwValueRow.vue
@@ -246,7 +246,15 @@
 </template>
 
 <script setup lang="ts">
-import { computed, inject, ref, shallowRef, useId, watch } from 'vue'
+import {
+	computed,
+	inject,
+	onBeforeUnmount,
+	ref,
+	shallowRef,
+	useId,
+	watch,
+} from 'vue'
 import { Popover } from '@vuetify/v0'
 import ZwToggle from '@/components/dashboard/atoms/ZwToggle.vue'
 import ZwSlider from '@/components/dashboard/atoms/ZwSlider.vue'
@@ -285,6 +293,9 @@ const emit = defineEmits<{
 // editable controls, never a literal null value.)
 const draft = ref<unknown>(null)
 const sendFailed = ref(false)
+// How long the "could not be set" flag stays visible after a failed write.
+const SEND_ERROR_MS = 3000
+let sendErrorTimer: ReturnType<typeof setTimeout> | undefined
 
 // How long the "copied" checkmark shows before reverting to the copy icon.
 const COPY_FEEDBACK_MS = 1200
@@ -299,7 +310,7 @@ const pending = inject(
 	DeviceActionPendingKey,
 	shallowRef<ReadonlySet<string>>(new Set()),
 )
-// Last write outcome, keyed the same as pending; written before pending clears.
+// Last write outcome, keyed the same as pending; set together with pending-clear.
 const results = inject(
 	DeviceActionResultKey,
 	shallowRef<ReadonlyMap<string, boolean>>(new Map()),
@@ -336,18 +347,21 @@ watch(
 	},
 )
 
-// On send completion (pending cleared): the recorded outcome is readable
-// synchronously. On failure, revert the optimistic draft and flag the error.
+// On send completion (pending cleared): the recorded outcome tells success from
+// failure. On failure, revert the optimistic draft and flag the error briefly.
 watch(sending, (isNowSending, wasSending) => {
 	if (!wasSending || isNowSending) return
 	if (results.value.get(setKey.value) === false) {
 		draft.value = null
 		sendFailed.value = true
-		setTimeout(() => {
+		clearTimeout(sendErrorTimer)
+		sendErrorTimer = setTimeout(() => {
 			sendFailed.value = false
-		}, 3000)
+		}, SEND_ERROR_MS)
 	}
 })
+
+onBeforeUnmount(() => clearTimeout(sendErrorTimer))
 
 function coerce(raw: unknown): unknown {
 	if (props.param.kind === 'number' || props.param.kind === 'level') {
@@ -359,8 +373,9 @@ function coerce(raw: unknown): unknown {
 function commit(value: unknown) {
 	menuOpen.value = false
 	sendFailed.value = false
-	// Show the value optimistically; the send-completion watch reverts on failure.
-	draft.value = value
+	// Show the value optimistically (the value-update watch clears it on confirm).
+	// Write-only params never report back, so don't pin — it would stick dirty.
+	draft.value = props.param.readable ? value : null
 	emit('set', props.param.target, value)
 }
 

--- a/src/components/dashboard/components/ZwValueRow.vue
+++ b/src/components/dashboard/components/ZwValueRow.vue
@@ -27,6 +27,13 @@
 						<RefreshIcon :size="ICON_SIZE.chip" class="zw-spin" />
 						Setting…
 					</span>
+					<span
+						v-else-if="sendFailed"
+						class="zw-vrow__status zw-vrow__status--error"
+					>
+						<AlertIcon :size="ICON_SIZE.chip" />
+						Could not be set
+					</span>
 				</template>
 				<template v-else>
 					<span
@@ -120,43 +127,52 @@
 
 			<!-- enum select -->
 			<template v-else-if="param.kind === 'enum'">
-				<select
-					class="zw-vrow__select"
-					:value="String(cur)"
+				<ZwDropdown
+					:model-value="asOptionValue(cur)"
+					:options="param.options ?? []"
 					:disabled="busy"
-					@change="onEnumChange"
-				>
-					<option
-						v-for="o in param.options"
-						:key="o.value"
-						:value="String(o.value)"
-					>
-						[{{ o.value }}] {{ o.label }}
-					</option>
-				</select>
+					@update:model-value="commit"
+				/>
 			</template>
 
-			<!-- number / text input (shared scaffold) -->
-			<template
-				v-else-if="param.kind === 'number' || param.kind === 'text'"
-			>
+			<!-- number: combobox when options exist, else a stepper -->
+			<template v-else-if="param.kind === 'number'">
+				<ZwDropdown
+					v-if="param.options"
+					:model-value="asOptionValue(cur)"
+					:options="param.options"
+					:allow-manual="true"
+					:min="param.min"
+					:max="param.max"
+					:unit="param.unit"
+					:disabled="busy"
+					@update:model-value="commit"
+				/>
+				<ZwNumericInput
+					v-else
+					:model-value="String(cur ?? '')"
+					:min="param.min"
+					:max="param.max"
+					:step="param.step"
+					:unit="param.unit"
+					:disabled="busy"
+					:dirty="dirty"
+					@update:model-value="draft = $event"
+					@commit="send"
+					@reset="draft = null"
+				/>
+			</template>
+
+			<!-- text input -->
+			<template v-else-if="param.kind === 'text'">
 				<input
 					class="zw-vrow__input"
-					:class="{ 'zw-vrow__input--text': param.kind === 'text' }"
-					:type="param.kind === 'number' ? 'number' : 'text'"
+					type="text"
 					:value="cur"
-					:min="param.kind === 'number' ? param.min : undefined"
-					:max="param.kind === 'number' ? param.max : undefined"
-					:step="
-						param.kind === 'number' ? param.step || 1 : undefined
-					"
 					:disabled="busy"
 					@input="onInput"
 					@keydown.enter="send"
 				/>
-				<span v-if="param.unit" class="zw-vrow__unit">{{
-					param.unit
-				}}</span>
 				<button
 					v-if="dirty"
 					type="button"
@@ -201,6 +217,13 @@
 				<RefreshIcon :size="ICON_SIZE.chip" class="zw-spin" />
 				{{ sending ? 'Setting…' : 'Refreshing…' }}
 			</span>
+			<span
+				v-else-if="sendFailed"
+				class="zw-vrow__status zw-vrow__status--error"
+			>
+				<AlertIcon :size="ICON_SIZE.chip" />
+				Could not be set
+			</span>
 		</div>
 
 		<!-- description -->
@@ -227,8 +250,11 @@ import { computed, inject, ref, shallowRef, useId, watch } from 'vue'
 import { Popover } from '@vuetify/v0'
 import ZwToggle from '@/components/dashboard/atoms/ZwToggle.vue'
 import ZwSlider from '@/components/dashboard/atoms/ZwSlider.vue'
+import ZwDropdown from '@/components/dashboard/atoms/ZwDropdown.vue'
+import ZwNumericInput from '@/components/dashboard/atoms/ZwNumericInput.vue'
 import {
 	CheckIcon,
+	AlertIcon,
 	CopyIcon,
 	ICON_SIZE,
 	MoreIcon,
@@ -239,6 +265,7 @@ import { usePopoverFallback } from '@/lib/popover-fallback.ts'
 import type { ValueParam } from '@/lib/valueGroups.ts'
 import {
 	DeviceActionPendingKey,
+	DeviceActionResultKey,
 	pollPendingKey,
 	setPendingKey,
 } from '@/lib/deviceActionPending.ts'
@@ -257,6 +284,7 @@ const emit = defineEmits<{
 // (null is safe as the "no edit" sentinel: drafts only come from user input on
 // editable controls, never a literal null value.)
 const draft = ref<unknown>(null)
+const sendFailed = ref(false)
 
 // How long the "copied" checkmark shows before reverting to the copy icon.
 const COPY_FEEDBACK_MS = 1200
@@ -271,9 +299,13 @@ const pending = inject(
 	DeviceActionPendingKey,
 	shallowRef<ReadonlySet<string>>(new Set()),
 )
-const sending = computed(() =>
-	pending.value.has(setPendingKey(props.nodeId, props.param.target)),
+// Last write outcome, keyed the same as pending; written before pending clears.
+const results = inject(
+	DeviceActionResultKey,
+	shallowRef<ReadonlyMap<string, boolean>>(new Map()),
 )
+const setKey = computed(() => setPendingKey(props.nodeId, props.param.target))
+const sending = computed(() => pending.value.has(setKey.value))
 const refreshing = computed(() =>
 	pending.value.has(pollPendingKey(props.nodeId, props.param.target)),
 )
@@ -296,13 +328,26 @@ const rangeHint = computed(() => {
 	return p.default !== undefined ? `${range} · default ${p.default}` : range
 })
 
-// Once the confirmed value updates, drop the optimistic draft.
+// Confirmed value arrived: drop the optimistic draft so the live value shows.
 watch(
 	() => props.param.value,
 	() => {
 		draft.value = null
 	},
 )
+
+// On send completion (pending cleared): the recorded outcome is readable
+// synchronously. On failure, revert the optimistic draft and flag the error.
+watch(sending, (isNowSending, wasSending) => {
+	if (!wasSending || isNowSending) return
+	if (results.value.get(setKey.value) === false) {
+		draft.value = null
+		sendFailed.value = true
+		setTimeout(() => {
+			sendFailed.value = false
+		}, 3000)
+	}
+})
 
 function coerce(raw: unknown): unknown {
 	if (props.param.kind === 'number' || props.param.kind === 'level') {
@@ -313,11 +358,9 @@ function coerce(raw: unknown): unknown {
 
 function commit(value: unknown) {
 	menuOpen.value = false
-	// Don't optimistically pin the value. On a failed or un-acked write the
-	// device never confirms, so a pinned draft would keep showing the attempted
-	// value while the error toast says it failed. Show the live value instead;
-	// `busy` covers the in-flight window and the watch reflects the real result.
-	draft.value = null
+	sendFailed.value = false
+	// Show the value optimistically; the send-completion watch reverts on failure.
+	draft.value = value
 	emit('set', props.param.target, value)
 }
 
@@ -335,10 +378,15 @@ function onInput(e: Event) {
 	draft.value = (e.target as HTMLInputElement).value
 }
 
-function onEnumChange(e: Event) {
-	const raw = (e.target as HTMLSelectElement).value
-	const opt = props.param.options?.find((o) => String(o.value) === raw)
-	commit(opt ? opt.value : raw)
+// Narrows `cur` to what ZwDropdown accepts; anything else means no selection.
+function asOptionValue(v: unknown): number | string | boolean | null {
+	if (
+		typeof v === 'number' ||
+		typeof v === 'string' ||
+		typeof v === 'boolean'
+	)
+		return v
+	return null
 }
 
 function commitLevel() {
@@ -575,7 +623,6 @@ function copyId() {
 	text-align: right;
 }
 
-.zw-vrow__select,
 .zw-vrow__input {
 	appearance: none;
 	border: 1px solid var(--zw-line);
@@ -585,24 +632,7 @@ function copyId() {
 	background: var(--zw-bg);
 	color: var(--zw-fg);
 	font-family: var(--zw-mono);
-}
-
-.zw-vrow__select {
-	padding-right: 22px;
-	cursor: pointer;
-	max-width: 240px;
-	text-overflow: ellipsis;
-}
-
-.zw-vrow__input {
-	/* Narrow: numbers are short and right-aligned like the readouts. */
-	width: 80px;
-	text-align: right;
-}
-
-.zw-vrow__input--text {
-	/* Wider for free text, but still bounded so a long value can't push the
-	   control line past the cell. */
+	/* Bounded so a long value can't push the control line past the cell. */
 	width: 180px;
 	text-align: left;
 }
@@ -673,6 +703,10 @@ function copyId() {
 	font-family: var(--zw-mono);
 	color: var(--zw-accent);
 	white-space: nowrap;
+}
+
+.zw-vrow__status--error {
+	color: var(--zw-danger);
 }
 
 /* ── meta ── */

--- a/src/components/dashboard/components/ZwValueRow.vue
+++ b/src/components/dashboard/components/ZwValueRow.vue
@@ -272,10 +272,10 @@ import {
 import { usePopoverFallback } from '@/lib/popover-fallback.ts'
 import type { ValueParam } from '@/lib/valueGroups.ts'
 import {
-	DeviceActionPendingKey,
-	DeviceActionResultKey,
+	DeviceActionStatusKey,
 	pollPendingKey,
 	setPendingKey,
+	type ActionStatus,
 } from '@/lib/deviceActionPending.ts'
 import type { ValueID } from '@zwave-js/core'
 
@@ -305,20 +305,18 @@ const menuId = `zw-vrow-${useId()}`
 
 usePopoverFallback({ open: menuOpen, contentId: menuId })
 
-// Busy state from the host's pending set — clears the instant `apiRequest` resolves.
-const pending = inject(
-	DeviceActionPendingKey,
-	shallowRef<ReadonlySet<string>>(new Set()),
-)
-// Last write outcome, keyed the same as pending; set together with pending-clear.
-const results = inject(
-	DeviceActionResultKey,
-	shallowRef<ReadonlyMap<string, boolean>>(new Map()),
+// Per-key action lifecycle: 'pending' while in flight, 'ok'/'fail' briefly on
+// completion, then deleted. Rows only need to distinguish pending from done+fail.
+const status = inject(
+	DeviceActionStatusKey,
+	shallowRef<ReadonlyMap<string, ActionStatus>>(new Map()),
 )
 const setKey = computed(() => setPendingKey(props.nodeId, props.param.target))
-const sending = computed(() => pending.value.has(setKey.value))
-const refreshing = computed(() =>
-	pending.value.has(pollPendingKey(props.nodeId, props.param.target)),
+const sending = computed(() => status.value.get(setKey.value) === 'pending')
+const refreshing = computed(
+	() =>
+		status.value.get(pollPendingKey(props.nodeId, props.param.target)) ===
+		'pending',
 )
 
 const cur = computed(() =>
@@ -347,11 +345,11 @@ watch(
 	},
 )
 
-// On send completion (pending cleared): the recorded outcome tells success from
-// failure. On failure, revert the optimistic draft and flag the error briefly.
+// On send completion (status transitions away from 'pending'): read the outcome
+// before nextTick deletes it. On failure, revert the draft and show an error.
 watch(sending, (isNowSending, wasSending) => {
 	if (!wasSending || isNowSending) return
-	if (results.value.get(setKey.value) === false) {
+	if (status.value.get(setKey.value) === 'fail') {
 		draft.value = null
 		sendFailed.value = true
 		clearTimeout(sendErrorTimer)

--- a/src/components/dashboard/components/ZwValueRow.vue
+++ b/src/components/dashboard/components/ZwValueRow.vue
@@ -288,9 +288,7 @@ const emit = defineEmits<{
 	poll: [ValueID]
 }>()
 
-// Pending edit until applied; null = show the live value. Clears on confirm.
-// (null is safe as the "no edit" sentinel: drafts only come from user input on
-// editable controls, never a literal null value.)
+// Pending edit until applied; null = show the live value.
 const draft = ref<unknown>(null)
 const sendFailed = ref(false)
 // How long the "could not be set" flag stays visible after a failed write.
@@ -305,8 +303,6 @@ const menuId = `zw-vrow-${useId()}`
 
 usePopoverFallback({ open: menuOpen, contentId: menuId })
 
-// Per-key action lifecycle: 'pending' while in flight, 'ok'/'fail' briefly on
-// completion, then deleted. Rows only need to distinguish pending from done+fail.
 const status = inject(
 	DeviceActionStatusKey,
 	shallowRef<ReadonlyMap<string, ActionStatus>>(new Map()),
@@ -330,14 +326,13 @@ const dirty = computed(
 const busy = computed(() => sending.value || refreshing.value)
 const levelValue = computed(() => Number(cur.value) || 0)
 
-// Range hint under an editable number; default segment only when one exists.
 const rangeHint = computed(() => {
 	const p = props.param
 	const range = `min ${p.min} · max ${p.max}`
 	return p.default !== undefined ? `${range} · default ${p.default}` : range
 })
 
-// Confirmed value arrived: drop the optimistic draft so the live value shows.
+// Drop the draft when the confirmed value arrives.
 watch(
 	() => props.param.value,
 	() => {
@@ -345,8 +340,7 @@ watch(
 	},
 )
 
-// On send completion (status transitions away from 'pending'): read the outcome
-// before nextTick deletes it. On failure, revert the draft and show an error.
+// On failure, revert the draft and show an error.
 watch(sending, (isNowSending, wasSending) => {
 	if (!wasSending || isNowSending) return
 	if (status.value.get(setKey.value) === 'fail') {
@@ -371,15 +365,13 @@ function coerce(raw: unknown): unknown {
 function commit(value: unknown) {
 	menuOpen.value = false
 	sendFailed.value = false
-	// Show the value optimistically (the value-update watch clears it on confirm).
-	// Write-only params never report back, so don't pin — it would stick dirty.
+	// Write-only params never get a confirmed value back, so don't pin a draft.
 	draft.value = props.param.readable ? value : null
 	emit('set', props.param.target, value)
 }
 
 function send() {
 	if (!dirty.value) return
-	// An empty number input coerces to 0; don't send a spurious 0 / NaN.
 	if (props.param.kind === 'number') {
 		const n = Number(draft.value)
 		if (draft.value === '' || Number.isNaN(n)) return
@@ -391,7 +383,6 @@ function onInput(e: Event) {
 	draft.value = (e.target as HTMLInputElement).value
 }
 
-// Narrows `cur` to what ZwDropdown accepts; anything else means no selection.
 function asOptionValue(v: unknown): number | string | boolean | null {
 	if (
 		typeof v === 'number' ||
@@ -404,8 +395,7 @@ function asOptionValue(v: unknown): number | string | boolean | null {
 
 function commitLevel() {
 	if (draft.value === null) return
-	// Multilevel Switch tops out at 99 (100/255 mean "restore"); the slider
-	// track is 0–100, so clamp before writing.
+	// Clamp to 0–99 (100 means "restore previous" in Multilevel Switch).
 	const level = Math.min(99, Math.max(0, Number(draft.value)))
 	if (level !== Number(props.param.value)) {
 		commit(level)
@@ -424,8 +414,6 @@ function resetDefault() {
 }
 
 function copyId() {
-	// Clipboard API is absent in insecure contexts (`?.`) and can reject
-	// (permission denied / not focused); swallow both — it's only feedback.
 	void navigator.clipboard?.writeText(props.param.id).catch(() => {})
 	copied.value = true
 	setTimeout(() => {

--- a/src/lib/device-actions.test.ts
+++ b/src/lib/device-actions.test.ts
@@ -5,8 +5,8 @@
 
 import { describe, it, expect } from 'vitest'
 import { CommandClasses } from '@zwave-js/core'
-import { DoorLockMode } from '@zwave-js/cc'
-import { dispatchAction } from './device-actions.ts'
+import { DoorLockMode, SetValueStatus } from '@zwave-js/cc'
+import { dispatchAction, isRequestSuccess } from './device-actions.ts'
 import type { Device } from './dashboard-types.ts'
 
 const device = { nodeId: 8 } as Device
@@ -76,5 +76,34 @@ describe('dispatchAction', () => {
 			api: 'refreshValues',
 			args: [8],
 		})
+	})
+})
+
+describe('isRequestSuccess', () => {
+	it('returns false for an unsuccessful response', () => {
+		expect(isRequestSuccess('pingNode', { success: false })).to.equal(false)
+	})
+
+	it('returns true for a successful non-writeValue response', () => {
+		expect(isRequestSuccess('pingNode', { success: true })).to.equal(true)
+	})
+
+	it('treats a successful writeValue with no result as success', () => {
+		expect(isRequestSuccess('writeValue', { success: true })).to.equal(true)
+	})
+
+	it('honors the SetValueResult status for writeValue', () => {
+		expect(
+			isRequestSuccess('writeValue', {
+				success: true,
+				result: { status: SetValueStatus.Success },
+			}),
+		).to.equal(true)
+		expect(
+			isRequestSuccess('writeValue', {
+				success: true,
+				result: { status: SetValueStatus.Fail },
+			}),
+		).to.equal(false)
 	})
 })

--- a/src/lib/device-actions.ts
+++ b/src/lib/device-actions.ts
@@ -4,7 +4,11 @@
 // Value writes use `writeValue`, not `sendCommand`: only `setValue` updates
 // the value optimistically and verifies it. The `valueId` rides on the action.
 
-import { DoorLockMode } from '@zwave-js/cc'
+import {
+	DoorLockMode,
+	setValueWasUnsupervisedOrSucceeded,
+	type SetValueResult,
+} from '@zwave-js/cc'
 import type { Device, DeviceAction } from './dashboard-types.ts'
 
 type DeviceActionType = DeviceAction['type']
@@ -98,4 +102,22 @@ export function dispatchAction(
 		typeof action
 	>
 	return dispatcher(device, action)
+}
+
+// Shape the UI reads from an `apiRequest` response.
+export interface ApiResponse {
+	success: boolean
+	result?: unknown
+}
+
+export function isRequestSuccess(api: string, response: ApiResponse): boolean {
+	if (!response.success) return false
+	// `writeValue` carries a SetValue status; Working/Success/Unsupervised count
+	// as accepted. Other APIs report only the top-level success flag.
+	if (api === 'writeValue' && response.result) {
+		return setValueWasUnsupervisedOrSucceeded(
+			response.result as SetValueResult,
+		)
+	}
+	return true
 }

--- a/src/lib/device-actions.ts
+++ b/src/lib/device-actions.ts
@@ -104,7 +104,6 @@ export function dispatchAction(
 	return dispatcher(device, action)
 }
 
-// Shape the UI reads from an `apiRequest` response.
 export interface ApiResponse {
 	success: boolean
 	result?: unknown
@@ -112,8 +111,7 @@ export interface ApiResponse {
 
 export function isRequestSuccess(api: string, response: ApiResponse): boolean {
 	if (!response.success) return false
-	// `writeValue` carries a SetValue status; Working/Success/Unsupervised count
-	// as accepted. Other APIs report only the top-level success flag.
+	// `writeValue` carries a SetValue status beyond the top-level success flag.
 	if (api === 'writeValue' && response.result) {
 		return setValueWasUnsupervisedOrSucceeded(
 			response.result as SetValueResult,

--- a/src/lib/deviceActionPending.ts
+++ b/src/lib/deviceActionPending.ts
@@ -6,22 +6,15 @@ import type { InjectionKey, ShallowRef } from 'vue'
 import type { ValueID } from '@zwave-js/core'
 import type { Device, DeviceAction } from './dashboard-types.ts'
 
-// A shallowRef holding an immutable Set, replaced on each change. Members are
-// read via `.value.has(...)`, so a row's check re-runs only when the set is
-// actually swapped — not via Vue's reactive-Set per-key tracking, which
-// invalidates every `.has()` watcher in every mounted row on any mutation.
-export type PendingSet = ShallowRef<ReadonlySet<string>>
+export type ActionStatus = 'pending' | 'ok' | 'fail'
 
-export const DeviceActionPendingKey: InjectionKey<PendingSet> = Symbol(
-	'zwDeviceActionPending',
-)
+// A shallowRef holding an immutable Map, replaced on each change. A row's
+// `.get()` re-runs only when the map is swapped — not per-key, so a single
+// value change doesn't invalidate every mounted row.
+export type ActionStatusMap = ShallowRef<ReadonlyMap<string, ActionStatus>>
 
-// Last completed-request outcome per key (true = succeeded), so a row can tell a
-// successful write from a rejected one. Same key scheme as the pending Set.
-export type ActionResultMap = ShallowRef<ReadonlyMap<string, boolean>>
-
-export const DeviceActionResultKey: InjectionKey<ActionResultMap> = Symbol(
-	'zwDeviceActionResult',
+export const DeviceActionStatusKey: InjectionKey<ActionStatusMap> = Symbol(
+	'zwDeviceActionStatus',
 )
 
 // Stable per-node value identity (`cc-endpoint-property-key`); keys pending

--- a/src/lib/deviceActionPending.ts
+++ b/src/lib/deviceActionPending.ts
@@ -16,6 +16,14 @@ export const DeviceActionPendingKey: InjectionKey<PendingSet> = Symbol(
 	'zwDeviceActionPending',
 )
 
+// Last completed-request outcome per key (true = succeeded), so a row can tell a
+// successful write from a rejected one. Same key scheme as the pending Set.
+export type ActionResultMap = ShallowRef<ReadonlyMap<string, boolean>>
+
+export const DeviceActionResultKey: InjectionKey<ActionResultMap> = Symbol(
+	'zwDeviceActionResult',
+)
+
 // Stable per-node value identity (`cc-endpoint-property-key`); keys pending
 // requests and matches event args back to values. Partial: event args may
 // carry only some of the fields.

--- a/src/lib/deviceActionPending.ts
+++ b/src/lib/deviceActionPending.ts
@@ -8,9 +8,7 @@ import type { Device, DeviceAction } from './dashboard-types.ts'
 
 export type ActionStatus = 'pending' | 'ok' | 'fail'
 
-// A shallowRef holding an immutable Map, replaced on each change. A row's
-// `.get()` re-runs only when the map is swapped — not per-key, so a single
-// value change doesn't invalidate every mounted row.
+// Immutable Map in a shallowRef — replaced on each change.
 export type ActionStatusMap = ShallowRef<ReadonlyMap<string, ActionStatus>>
 
 export const DeviceActionStatusKey: InjectionKey<ActionStatusMap> = Symbol(

--- a/src/lib/popover-fallback.ts
+++ b/src/lib/popover-fallback.ts
@@ -17,12 +17,6 @@
 // rely on the caller-supplied `contentId` (bound via `<Popover.Root :id>`
 // so V0 wires both activator's `popovertarget` and content's `id` to that
 // value), and find the elements at activation time via the DOM.
-//
-// Alignment rule:
-//   - placement: 'bottom-end' (menu's right edge aligned with activator's
-//     right edge, menu extends leftward) — matches typical dropdown UX.
-//   - Middleware `flip` switches to bottom-start (left-aligned) etc. when
-//     the preferred placement would clip.
 
 import { onBeforeUnmount, watch, toValue } from 'vue'
 import type { MaybeRefOrGetter, Ref } from 'vue'
@@ -33,15 +27,28 @@ import {
 	shift,
 	offset,
 } from '@floating-ui/dom'
+import type { Placement } from '@floating-ui/dom'
+
+// Flip fallbacks per primary placement.
+const FALLBACK_PLACEMENTS: Partial<Record<Placement, Placement[]>> = {
+	'bottom-end': ['bottom-start', 'top-end', 'top-start'],
+	'bottom-start': ['top-start', 'bottom-end', 'top-end'],
+}
 
 interface FallbackPositionOptions {
 	open: Ref<boolean>
 	contentId: MaybeRefOrGetter<string>
+	// Default: 'bottom-end'. Pass 'bottom-start' for left-anchored menus.
+	placement?: Placement
+	// Gap between activator and panel in pixels. Default: 6.
+	offsetPx?: number
 }
 
 export function usePopoverFallback({
 	open,
 	contentId,
+	placement = 'bottom-end',
+	offsetPx = 6,
 }: FallbackPositionOptions): void {
 	let cleanup: (() => void) | null = null
 
@@ -66,16 +73,14 @@ export function usePopoverFallback({
 
 		cleanup = autoUpdate(a, c, () => {
 			computePosition(a, c, {
-				placement: 'bottom-end',
+				placement,
 				strategy: 'fixed',
 				middleware: [
-					offset(6),
+					offset(offsetPx),
 					flip({
-						fallbackPlacements: [
-							'bottom-start',
-							'top-end',
-							'top-start',
-						],
+						fallbackPlacements:
+							FALLBACK_PLACEMENTS[placement] ??
+							FALLBACK_PLACEMENTS['bottom-end'],
 					}),
 					shift({ padding: 8 }),
 				],

--- a/src/lib/valueGroups.ts
+++ b/src/lib/valueGroups.ts
@@ -145,14 +145,12 @@ function formatValue(v: ZUIValueId, kind: ValueParamKind): string {
 	}
 }
 
-// Keeps each row's `param` referentially stable while unchanged, so Vue can skip
-// re-rendering rows that didn't change.
+// Referential stability cache — unchanged params reuse the same object.
 const paramCache = new WeakMap<ZUIValueId, ValueParam>()
 
 function projectParam(v: ZUIValueId): ValueParam {
 	const cached = paramCache.get(v)
-	// Compare the value too: the store can mutate `.value` in place (same object),
-	// so the key alone would return a stale param.
+	// The store can mutate `.value` in place, so compare it too.
 	if (cached && Object.is(cached.value, v.value)) return cached
 	const param = buildParam(v)
 	paramCache.set(v, param)

--- a/src/lib/valueGroups.ts
+++ b/src/lib/valueGroups.ts
@@ -145,15 +145,15 @@ function formatValue(v: ZUIValueId, kind: ValueParamKind): string {
 	}
 }
 
-// Caches projected params by their source value object. The store *replaces* a
-// value object on update (splice), so unchanged values keep a stable reference
-// here — and so each row's `param` prop stays referentially stable, letting Vue
-// skip re-rendering every row when a single value changes.
+// Keeps each row's `param` referentially stable while unchanged, so Vue can skip
+// re-rendering rows that didn't change.
 const paramCache = new WeakMap<ZUIValueId, ValueParam>()
 
 function projectParam(v: ZUIValueId): ValueParam {
 	const cached = paramCache.get(v)
-	if (cached) return cached
+	// Compare the value too: the store can mutate `.value` in place (same object),
+	// so the key alone would return a stale param.
+	if (cached && Object.is(cached.value, v.value)) return cached
 	const param = buildParam(v)
 	paramCache.set(v, param)
 	return param

--- a/src/views/ControlPanelNew.vue
+++ b/src/views/ControlPanelNew.vue
@@ -15,7 +15,7 @@
 // full-bleed. Device actions are resolved by `dispatchAction` and sent
 // through `apiRequest()` on the App instance, reached via `instanceManager`.
 
-import { provide, shallowRef } from 'vue'
+import { nextTick, provide, shallowRef } from 'vue'
 import ZwAppShell from '@/components/dashboard/layout/ZwAppShell.vue'
 import {
 	dispatchAction,
@@ -25,8 +25,8 @@ import {
 import type { Device, DeviceAction } from '@/lib/dashboard-types'
 import {
 	actionPendingKey,
-	DeviceActionPendingKey,
-	DeviceActionResultKey,
+	DeviceActionStatusKey,
+	type ActionStatus,
 } from '@/lib/deviceActionPending.ts'
 import { manager, instances } from '@/lib/instanceManager'
 
@@ -48,34 +48,26 @@ function appInstance(): AppLike | null {
 	return (inst as unknown as AppLike) ?? null
 }
 
-// Value-pane components watch this to show a spinner only while their request
-// is actually in flight. Immutable Set, swapped on change (see PendingSet).
-const pending = shallowRef<ReadonlySet<string>>(new Set())
-provide(DeviceActionPendingKey, pending)
+// Per-key action lifecycle: 'pending' while in flight, 'ok'/'fail' on
+// completion, then deleted after one tick (nextTick cleanup).
+const status = shallowRef<ReadonlyMap<string, ActionStatus>>(new Map())
+provide(DeviceActionStatusKey, status)
 
-// Last outcome per key, so a row can tell a rejected write from a successful one.
-const result = shallowRef<ReadonlyMap<string, boolean>>(new Map())
-provide(DeviceActionResultKey, result)
-
-function setPending(key: string, on: boolean) {
-	const next = new Set(pending.value)
-	if (on) next.add(key)
-	else next.delete(key)
-	pending.value = next
+function setStatus(key: string, value: ActionStatus) {
+	const next = new Map(status.value)
+	next.set(key, value)
+	status.value = next
 }
 
-function setResult(key: string, ok: boolean) {
-	const next = new Map(result.value)
-	next.set(key, ok)
-	result.value = next
-}
-
-// Record the outcome and clear pending together. The row's watcher reacts to the
-// pending flip and reads the result, so the two must update in one tick — keep
-// them paired here rather than split across the request.
 function completeAction(key: string, ok: boolean) {
-	setResult(key, ok)
-	setPending(key, false)
+	setStatus(key, ok ? 'ok' : 'fail')
+	// Pre-flush watchers read the outcome before nextTick resolves; safe to
+	// delete afterwards so the map never accumulates stale entries.
+	nextTick(() => {
+		const next = new Map(status.value)
+		next.delete(key)
+		status.value = next
+	})
 }
 
 async function onAction(device: Device, action: DeviceAction) {
@@ -86,7 +78,7 @@ async function onAction(device: Device, action: DeviceAction) {
 		return
 	}
 	const key = actionPendingKey(device, action)
-	if (key) setPending(key, true)
+	if (key) setStatus(key, 'pending')
 	let ok = false
 	try {
 		const response = await app.apiRequest(req.api, req.args, {

--- a/src/views/ControlPanelNew.vue
+++ b/src/views/ControlPanelNew.vue
@@ -17,11 +17,16 @@
 
 import { provide, shallowRef } from 'vue'
 import ZwAppShell from '@/components/dashboard/layout/ZwAppShell.vue'
-import { dispatchAction } from '@/lib/device-actions.ts'
+import {
+	dispatchAction,
+	isRequestSuccess,
+	type ApiResponse,
+} from '@/lib/device-actions.ts'
 import type { Device, DeviceAction } from '@/lib/dashboard-types'
 import {
 	actionPendingKey,
 	DeviceActionPendingKey,
+	DeviceActionResultKey,
 } from '@/lib/deviceActionPending.ts'
 import { manager, instances } from '@/lib/instanceManager'
 
@@ -30,7 +35,7 @@ interface AppLike {
 		api: string,
 		args?: unknown[],
 		opts?: { infoSnack?: boolean; errorSnack?: boolean },
-	) => Promise<unknown>
+	) => Promise<ApiResponse>
 	showSnackbar: (msg: string, level?: string) => void
 	restart: () => Promise<void>
 	showUpdateDialog: () => Promise<void>
@@ -48,11 +53,21 @@ function appInstance(): AppLike | null {
 const pending = shallowRef<ReadonlySet<string>>(new Set())
 provide(DeviceActionPendingKey, pending)
 
+// Last outcome per key, so a row can tell a rejected write from a successful one.
+const result = shallowRef<ReadonlyMap<string, boolean>>(new Map())
+provide(DeviceActionResultKey, result)
+
 function setPending(key: string, on: boolean) {
 	const next = new Set(pending.value)
 	if (on) next.add(key)
 	else next.delete(key)
 	pending.value = next
+}
+
+function setResult(key: string, ok: boolean) {
+	const next = new Map(result.value)
+	next.set(key, ok)
+	result.value = next
 }
 
 async function onAction(device: Device, action: DeviceAction) {
@@ -65,10 +80,13 @@ async function onAction(device: Device, action: DeviceAction) {
 	const key = actionPendingKey(device, action)
 	if (key) setPending(key, true)
 	try {
-		await app.apiRequest(req.api, req.args, {
+		const response = await app.apiRequest(req.api, req.args, {
 			infoSnack: false,
 			errorSnack: true,
 		})
+		// Record the outcome before clearing pending: the row's watch fires on
+		// the pending flip and reads the result, so it must be set first.
+		if (key) setResult(key, isRequestSuccess(req.api, response))
 	} finally {
 		if (key) setPending(key, false)
 	}

--- a/src/views/ControlPanelNew.vue
+++ b/src/views/ControlPanelNew.vue
@@ -48,8 +48,6 @@ function appInstance(): AppLike | null {
 	return (inst as unknown as AppLike) ?? null
 }
 
-// Per-key action lifecycle: 'pending' while in flight, 'ok'/'fail' on
-// completion, then deleted after one tick (nextTick cleanup).
 const status = shallowRef<ReadonlyMap<string, ActionStatus>>(new Map())
 provide(DeviceActionStatusKey, status)
 
@@ -61,8 +59,7 @@ function setStatus(key: string, value: ActionStatus) {
 
 function completeAction(key: string, ok: boolean) {
 	setStatus(key, ok ? 'ok' : 'fail')
-	// Pre-flush watchers read the outcome before nextTick resolves; safe to
-	// delete afterwards so the map never accumulates stale entries.
+	// Delete after one tick so pre-flush watchers can read the outcome.
 	nextTick(() => {
 		const next = new Map(status.value)
 		next.delete(key)

--- a/src/views/ControlPanelNew.vue
+++ b/src/views/ControlPanelNew.vue
@@ -70,6 +70,14 @@ function setResult(key: string, ok: boolean) {
 	result.value = next
 }
 
+// Record the outcome and clear pending together. The row's watcher reacts to the
+// pending flip and reads the result, so the two must update in one tick — keep
+// them paired here rather than split across the request.
+function completeAction(key: string, ok: boolean) {
+	setResult(key, ok)
+	setPending(key, false)
+}
+
 async function onAction(device: Device, action: DeviceAction) {
 	const req = dispatchAction(device, action)
 	const app = appInstance()
@@ -79,16 +87,15 @@ async function onAction(device: Device, action: DeviceAction) {
 	}
 	const key = actionPendingKey(device, action)
 	if (key) setPending(key, true)
+	let ok = false
 	try {
 		const response = await app.apiRequest(req.api, req.args, {
 			infoSnack: false,
 			errorSnack: true,
 		})
-		// Record the outcome before clearing pending: the row's watch fires on
-		// the pending flip and reads the result, so it must be set first.
-		if (key) setResult(key, isRequestSuccess(req.api, response))
+		ok = isRequestSuccess(req.api, response)
 	} finally {
-		if (key) setPending(key, false)
+		if (key) completeAction(key, ok)
 	}
 }
 


### PR DESCRIPTION
This PR implements two specialized controls in the new dashboard design:

## Numeric input
Includes a button to submit after changing, also reacts to up/down arrows, <kbd>ENTER</kbd> and <kbd>ESC</kbd> (resets).

<img width="324" height="114" alt="image" src="https://github.com/user-attachments/assets/f29988d7-e0af-462e-8965-f5746f3b5b16" />

## Dropdown

Closed:
<img width="321" height="79" alt="image" src="https://github.com/user-attachments/assets/06862cfc-8031-474b-86ef-e2657eedb795" />

Open:
<img width="322" height="167" alt="image" src="https://github.com/user-attachments/assets/45a90ac3-f978-43f3-bd92-baf59b58d4a1" />

With a filter for more than 6 entries:
<img width="298" height="375" alt="image" src="https://github.com/user-attachments/assets/a37930ab-caa0-46a4-aa15-1c228c6fad00" />

And a manual input variant:
<img width="268" height="190" alt="image" src="https://github.com/user-attachments/assets/110c8f61-a1f1-4cec-9de2-b8dbfea1207e" />
...which doubles as a filter:
<img width="268" height="190" alt="image" src="https://github.com/user-attachments/assets/85b996c5-026a-4374-b900-2a2ca069a567" />
