### PR TITLE
refactor: cleanup Opus 4.8's word-vomit comments

### DIFF
--- a/src/components/dashboard/atoms/ZwActivityReadout.vue
+++ b/src/components/dashboard/atoms/ZwActivityReadout.vue
@@ -56,8 +56,6 @@ const ACTIVITY_ICON = {
 
 const iconComp = computed(() => ACTIVITY_ICON[props.activity.type])
 
-// Optional progress (a 0–100 integer): when undefined the bar shows an
-// indeterminate sweep with no number.
 const pct = computed(() =>
 	props.activity.progress !== undefined
 		? Math.round(props.activity.progress)
@@ -72,8 +70,6 @@ const title = computed(() =>
 </script>
 
 <style>
-/* Unscoped — V0 primitives set inheritAttrs:false; .zw-tx namespace is
-   unique to this atom. */
 .zw-tx {
 	display: inline-flex;
 	align-items: center;
@@ -104,8 +100,7 @@ const title = computed(() =>
 	overflow: hidden;
 }
 
-/* Indeterminate state hides the fill and animates a sweep across the
-   bar so the user still sees that work is in flight. */
+/* Indeterminate: hide fill, animate a sweep instead. */
 .zw-tx--indeterminate .zw-tx__fill {
 	display: none;
 }

--- a/src/components/dashboard/atoms/ZwBatteryMini.vue
+++ b/src/components/dashboard/atoms/ZwBatteryMini.vue
@@ -13,9 +13,6 @@ import { computed } from 'vue'
 
 const props = defineProps<{ pct?: number | null }>()
 
-// Three-state classifier drives both fill colour and (at 'low') the
-// label tint via CSS attribute selectors below — no per-instance style
-// allocation per battery row.
 const level = computed<'low' | 'mid' | 'ok' | null>(() => {
 	const v = props.pct
 	if (v == null) return null
@@ -26,8 +23,6 @@ const level = computed<'low' | 'mid' | 'ok' | null>(() => {
 </script>
 
 <style scoped>
-/* Type role is Mono Micro — the battery readout is a dense
-   column-style annotation. */
 .zw-bat {
 	display: inline-flex;
 	align-items: center;
@@ -45,8 +40,7 @@ const level = computed<'low' | 'mid' | 'ok' | null>(() => {
 	box-sizing: border-box;
 }
 
-/* Inner cell is 16px wide; leave 1px inset so the fill never touches
-   the border. Clamp to 2px minimum so 1% still shows. */
+/* 1px inset from border; clamp to 2px min so 1% still shows. */
 .zw-bat__fill {
 	position: absolute;
 	top: 1px;

--- a/src/components/dashboard/atoms/ZwButton.vue
+++ b/src/components/dashboard/atoms/ZwButton.vue
@@ -30,12 +30,6 @@ const emit = defineEmits<{ click: [MouseEvent] }>()
 </script>
 
 <style>
-/* Styles are unscoped because Vuetify0 primitives set inheritAttrs:false,
-   so Vue does not forward the parent's scoped data-v-* hash onto the
-   rendered <button>. Class names are BEM-namespaced under .zw-btn.
-   Each variant only sets the four --btn-* custom properties below;
-   the base rule applies them so chrome (radius, transition, focus
-   ring) stays declared once. */
 .zw-btn {
 	appearance: none;
 	cursor: pointer;

--- a/src/components/dashboard/atoms/ZwDropdown.vue
+++ b/src/components/dashboard/atoms/ZwDropdown.vue
@@ -235,9 +235,6 @@ watch(
 </script>
 
 <style>
-/* Unscoped — V0 Popover primitives set inheritAttrs:false so scoped data-v-*
-   hashes never reach the rendered elements. .zw-dropdown* names are unique. */
-
 .zw-dropdown__trigger {
 	appearance: none;
 	display: inline-flex;

--- a/src/components/dashboard/atoms/ZwSegmented.vue
+++ b/src/components/dashboard/atoms/ZwSegmented.vue
@@ -37,18 +37,14 @@ defineProps<{
 
 const emit = defineEmits<{ 'update:modelValue': [string] }>()
 
-// Button.Group with `mandatory: true` + scalar v-model emits the single
-// selected value back as a string. With `mandatory: true` it cannot
-// emit null (no deselect possible), so the optional path is defensive.
+// Button.Group with `mandatory: true` emits a string, but the type is
+// `unknown` — narrow before forwarding.
 function onSelect(value: unknown): void {
 	if (typeof value === 'string') emit('update:modelValue', value)
 }
 </script>
 
 <style>
-/* Styles unscoped — V0 primitives set inheritAttrs:false so Vue does not
-   forward the parent's scoped data-v-* hash. .zw-segmented* class names
-   are unique to this atom. */
 .zw-segmented {
 	display: inline-flex;
 	background: var(--zw-bg);
@@ -57,8 +53,6 @@ function onSelect(value: unknown): void {
 	border: 1px solid var(--zw-line-soft);
 }
 
-/* Type role is Caption; the selected state pops weight to 600 to
-   match the design's segmented control. */
 .zw-segmented__btn {
 	appearance: none;
 	background: transparent;
@@ -82,8 +76,7 @@ function onSelect(value: unknown): void {
 	padding: 3px 7px;
 }
 
-/* `data-selected="true"` is emitted by V0 ButtonRoot when inside a
-   ButtonGroup and selected — replaces the previous .--active class. */
+/* V0 ButtonRoot emits `data-selected="true"` when selected inside a group. */
 .zw-segmented__btn[data-selected='true'] {
 	background: var(--zw-card);
 	color: var(--zw-accent);

--- a/src/components/dashboard/atoms/ZwSlider.vue
+++ b/src/components/dashboard/atoms/ZwSlider.vue
@@ -30,17 +30,14 @@ withDefaults(
 
 const emit = defineEmits<{ 'update:modelValue': [number] }>()
 
-// Slider.Root accepts scalar v-model and emits scalar back, but typescript
-// doesn't infer the scalar case so we narrow here.
+// Slider.Root accepts scalar v-model and emits scalar back, but TypeScript
+// doesn't infer the scalar case — narrow here.
 function onUpdate(value: number | number[]): void {
 	emit('update:modelValue', Array.isArray(value) ? (value[0] ?? 0) : value)
 }
 </script>
 
 <style>
-/* Styles unscoped — V0 primitives set inheritAttrs:false so Vue does not
-   forward the parent's scoped data-v-* hash onto the rendered elements.
-   .zw-slider namespace is unique to this atom. */
 .zw-slider {
 	position: relative;
 	height: 14px;
@@ -64,9 +61,7 @@ function onUpdate(value: number | number[]): void {
 	pointer-events: none;
 }
 
-/* Track captures pointerdown for click-to-jump, so its hit area spans
-   the full 14-px slider row even though the visual line is 6 px — clicks
-   in the padding above/below the line still register. */
+/* Hit area spans the full slider height for click-to-jump. */
 .zw-slider__track {
 	display: block;
 	position: relative;
@@ -98,10 +93,6 @@ function onUpdate(value: number | number[]): void {
 	transition: width 0.05s;
 }
 
-/* Solid accent disc whose size scales with the variant. Drop-shadow at
-   rest carries the "grabbable" affordance; halo grows on hover and
-   dragging. V0 sets inline `left: <pct>%` so we translate(-50%) to
-   center the disc on the value. */
 .zw-slider__thumb {
 	position: absolute;
 	top: 50%;

--- a/src/components/dashboard/atoms/ZwStatusDot.vue
+++ b/src/components/dashboard/atoms/ZwStatusDot.vue
@@ -27,10 +27,7 @@ const defaultLabel = computed(
 	() => props.status.charAt(0).toUpperCase() + props.status.slice(1),
 )
 
-// Bind size through a single custom property so the style block owns
-// both width and height; skip the binding entirely when the caller
-// uses the default so the table's hundred-dot list allocates nothing
-// per row.
+// Skip the style binding at the default size (avoids per-row allocation).
 const sizeStyle = computed(() =>
 	props.size === 8
 		? undefined

--- a/src/components/dashboard/atoms/ZwToggle.vue
+++ b/src/components/dashboard/atoms/ZwToggle.vue
@@ -26,11 +26,6 @@ const emit = defineEmits<{ 'update:modelValue': [boolean] }>()
 </script>
 
 <style>
-/* Styles unscoped — V0 primitives set inheritAttrs:false so Vue does not
-   forward the parent's scoped data-v-* hash onto the rendered <button>.
-   .zw-toggle namespace is unique to this atom. */
-/* 2-px focus offset (vs the utility's 1-px default) so the ring sits
-   clear of the pill track. */
 .zw-toggle {
 	appearance: none;
 	border: none;
@@ -47,9 +42,7 @@ const emit = defineEmits<{ 'update:modelValue': [boolean] }>()
 	opacity: 0.5;
 }
 
-/* SwitchThumb sets `visibility: hidden` inline when unchecked — we
-   override it because the design slides the thumb between two positions
-   rather than fading it in/out. */
+/* Override SwitchThumb's inline visibility:hidden on unchecked state. */
 .zw-toggle__thumb {
 	visibility: visible !important;
 	position: absolute;

--- a/src/components/dashboard/atoms/ZwToggleMenu.vue
+++ b/src/components/dashboard/atoms/ZwToggleMenu.vue
@@ -89,10 +89,6 @@ function onToggle(id: string): void {
 </script>
 
 <style>
-/* Styles unscoped — V0 primitives set inheritAttrs:false so Vue's scoped
-   data-v-* hash does not reach the rendered elements. .zw-tm namespace is
-   unique to this atom. */
-/* Trigger uses the Caption type role. */
 .zw-tm__trigger {
 	appearance: none;
 	background: var(--zw-card);

--- a/src/components/dashboard/atoms/ZwUpdateNotifier.vue
+++ b/src/components/dashboard/atoms/ZwUpdateNotifier.vue
@@ -30,8 +30,6 @@ const emit = defineEmits<{ click: [] }>()
 </script>
 
 <style>
-/* Unscoped — V0 primitives set inheritAttrs:false; .zw-update namespace
-   is unique to this atom. */
 .zw-update {
 	display: inline-flex;
 	align-items: center;
@@ -61,16 +59,12 @@ const emit = defineEmits<{ click: [] }>()
 	line-height: 1.2;
 }
 
-/* Title is an intermediate of Caption (11/400) and Label (12/600):
-   the design calls for 11/600, which is not a tabled type-scale
-   role. Keep the explicit declarations rather than picking a role
-   that would shift the size or drop emphasis. */
+/* Design calls for 11/600, which has no type-scale role. */
 .zw-update__title {
 	font-size: 11px;
 	font-weight: 600;
 }
 
-/* Versions line is Mono Micro. */
 .zw-update__versions {
 	font: var(--zw-text-mono-micro);
 	color: var(--zw-fg-soft);
@@ -92,8 +86,6 @@ const emit = defineEmits<{ click: [] }>()
 	height: 7px;
 	background: var(--zw-accent);
 	border-radius: 50%;
-	/* Ring matches the card background so the dot reads as floating over
-	   the surface in either theme — not a literal white halo. */
 	box-shadow: 0 0 0 1.5px var(--zw-card);
 }
 </style>

--- a/src/components/dashboard/components/ZwAddDeviceSplitButton.vue
+++ b/src/components/dashboard/components/ZwAddDeviceSplitButton.vue
@@ -107,8 +107,6 @@ function onItemClick(id: Action): void {
 </script>
 
 <style>
-/* Unscoped — V0 primitives set inheritAttrs:false; .zw-asb namespace is
-   unique to this component. */
 .zw-asb__group {
 	display: inline-flex;
 	border-radius: 6px;

--- a/src/components/dashboard/components/ZwDeviceRow.vue
+++ b/src/components/dashboard/components/ZwDeviceRow.vue
@@ -133,8 +133,6 @@ const props = defineProps<{
 }>()
 
 const emit = defineEmits<{
-	// Request to show this device's details; the parent decides whether to
-	// expand the row inline or open the drawer.
 	open: [Device]
 	action: [Device, DeviceAction]
 }>()

--- a/src/components/dashboard/components/ZwExpandedRow.vue
+++ b/src/components/dashboard/components/ZwExpandedRow.vue
@@ -12,8 +12,6 @@
 import ZwNodeDetailsBody from './ZwNodeDetailsBody.vue'
 import type { Device, DeviceAction } from '@/lib/dashboard-types'
 
-// `viewport` (the shell width) flows through to NodeDetailsBody, which uses
-// it to pick the two-pane vs stacked layout for the inline expansion.
 defineProps<{ device: Device; viewport: number }>()
 const emit = defineEmits<{ action: [Device, DeviceAction] }>()
 </script>

--- a/src/components/dashboard/components/ZwNodeDetailsBody.vue
+++ b/src/components/dashboard/components/ZwNodeDetailsBody.vue
@@ -172,10 +172,8 @@ import {
 } from '@/lib/dashboard-breakpoints'
 import type { Device, DeviceAction } from '@/lib/dashboard-types'
 
-// `viewport` is the host panel's available width (the shell width passed down
-// by the table, NOT the device viewport). It selects the layout and feeds the
-// rail width. `layout="stacked"` forces the single-column layout regardless of
-// width — the card-view drawer uses it so it always keeps the stacked layout.
+// `viewport` is the host panel's width. `layout="stacked"` forces
+// single-column regardless of width (used by the card-view drawer).
 const props = withDefaults(
 	defineProps<{
 		device: Device
@@ -344,9 +342,6 @@ const advancedCommands = computed<{ label: string; action: DeviceAction }[]>(
 </script>
 
 <style>
-/* Unscoped — V0 Tabs primitives use inheritAttrs:false, so the scoped
-   data-v-* hash never reaches the tab list/items/panels. The .zw-nd
-   namespace is unique to this component. */
 .zw-nd {
 	display: flex;
 	min-width: 0;

--- a/src/components/dashboard/components/ZwNodeEvents.vue
+++ b/src/components/dashboard/components/ZwNodeEvents.vue
@@ -34,8 +34,6 @@ import useBaseStore from '@/stores/base'
 import { relativeTime, useNow } from '@/lib/time'
 import { valueIdKey } from '@/lib/deviceActionPending.ts'
 
-// Live feed of a node's recent events, shared by the Events tab and the rail's
-// "Recent activity". `max` caps entries (the rail passes a smaller cap).
 const props = withDefaults(defineProps<{ device: Device; max?: number }>(), {
 	max: 50,
 })
@@ -49,7 +47,6 @@ interface NodeEventEntry {
 	time?: Date | string | number
 }
 
-// `node.eventsQueue` from the store, so it tracks socket events live.
 const eventsQueue = computed<NodeEventEntry[]>(() => {
 	const node = baseStore.getNode(props.device.nodeId)
 	const q = node?.eventsQueue
@@ -73,14 +70,11 @@ function toMs(t: NodeEventEntry['time']): number | undefined {
 	return Number.isNaN(n) ? undefined : n
 }
 
-// A value-updated/notification event arg, loosely typed — queue args are
-// untyped, so every field may be absent.
 type ValueEventArg = Partial<
 	TranslatedValueID & ValueUpdatedArgs & ValueNotificationArgs
 >
 
-// value-id → metadata label, rebuilt per node-values change. O(1) lookup avoids
-// re-scanning values per event per render; raw event payloads lack the label.
+// value-id → metadata label index (event payloads lack the label).
 const valueLabelIndex = computed(() => {
 	const node = baseStore.getNode(props.device.nodeId) as
 		| { values?: (ValueEventArg & { label?: string })[] }
@@ -95,7 +89,6 @@ const valueLabelIndex = computed(() => {
 })
 
 function eventDetail(ev: NodeEventEntry): string {
-	// Prefer a value's metadata label over its raw property for value events.
 	if (!Array.isArray(ev.args) || ev.args.length === 0) return ''
 	const first = ev.args[0] as unknown
 	if (first && typeof first === 'object') {
@@ -115,14 +108,10 @@ function eventDetail(ev: NodeEventEntry): string {
 	return ev.args.map((a) => formatValue(a)).join(' · ')
 }
 
-// Pre-resolve display strings per data change, so the `now` tick re-runs only
-// the cheap relative-time format, not the per-event label lookup.
 const rows = computed(() =>
 	events.value.map((ev) => {
 		const timeMs = toMs(ev.time)
 		const detail = eventDetail(ev)
-		// Content-derived key so prepending a new event doesn't reshuffle every
-		// row's key (index keys force a full re-patch of the reversed list).
 		return {
 			key: `${timeMs}|${ev.event}|${detail}`,
 			name: ev.event,

--- a/src/components/dashboard/components/ZwValueRow.vue
+++ b/src/components/dashboard/components/ZwValueRow.vue
@@ -423,8 +423,6 @@ function copyId() {
 </script>
 
 <style>
-/* Unscoped — the V0 Popover primitive sets inheritAttrs:false, so the
-   scoped data-v-* hash never reaches the menu. .zw-vrow is unique here. */
 .zw-vrow {
 	padding: 10px 12px;
 	display: flex;

--- a/src/components/dashboard/components/ZwValuesView.vue
+++ b/src/components/dashboard/components/ZwValuesView.vue
@@ -46,7 +46,6 @@ const emit = defineEmits<{ action: [Device, DeviceAction] }>()
 
 const baseStore = useBaseStore()
 
-// Reads live from the store so writes/polls re-render as values land.
 const groups = computed<ValueGroup[]>(() =>
 	buildValueGroups(baseStore.getNode(props.device.nodeId)),
 )

--- a/src/components/dashboard/components/deviceRowGrid.ts
+++ b/src/components/dashboard/components/deviceRowGrid.ts
@@ -1,7 +1,4 @@
-// DeviceRow column packing. TOGGLEABLE_COLS is the single source of truth
-// for the optional columns (ids, order, labels) — consumers import it
-// rather than re-declaring. Viewport decides whether columns show at all;
-// the `columns` array decides which optional ones participate.
+// DeviceRow column definitions and grid-template builder.
 
 import { MOBILE_BREAKPOINT } from '@/lib/dashboard-breakpoints.ts'
 

--- a/src/components/dashboard/components/primary-display/usePrimaryValue.ts
+++ b/src/components/dashboard/components/primary-display/usePrimaryValue.ts
@@ -1,16 +1,5 @@
-// Type-safe access to a device's primary value for the per-type renderers.
-//
-// Each renderer in this folder handles exactly one PrimaryValueType. Rather
-// than assert the shape with a bare `as PrimaryValueX` — which severs the
-// link between the registry key and the subtype, so a mis-wire (e.g. mapping
-// the `state` key to the Toggle renderer) type-checks and only fails at
-// runtime — a renderer narrows with `usePrimaryValue(() => props.device,
-// 'state')` and receives `PrimaryValueState | null`.
-//
-// The discriminant is CHECKED at runtime, so a mis-wire renders nothing
-// (the `v-if="pv"` guard short-circuits) instead of reading fields off the
-// wrong shape. The single internal cast is sound precisely because it sits
-// behind that `pv.type === type` guard — narrowing is verified, not asserted.
+// Narrows device.primaryValue by discriminant at runtime, so a mis-wired
+// renderer renders nothing instead of reading the wrong shape.
 
 import { computed, type ComputedRef } from 'vue'
 import type {

--- a/src/components/dashboard/layout/ZwActivityStrip.vue
+++ b/src/components/dashboard/layout/ZwActivityStrip.vue
@@ -54,8 +54,6 @@ const visibleActivities = computed(() => props.activities.slice(0, MAX_CHIPS))
 </script>
 
 <style>
-/* Unscoped — V0 Button.Root strips Vue's scoped data-v-* hash. .zw-strip* is
-   unique to this component. */
 .zw-strip {
 	display: flex;
 	align-items: stretch;

--- a/src/components/dashboard/layout/ZwAppShell.vue
+++ b/src/components/dashboard/layout/ZwAppShell.vue
@@ -128,8 +128,6 @@ const DEVICE_LIST_NAV: ReadonlySet<string> = new Set<Scope>([
 	'activity',
 ])
 
-// Non-scope nav IDs whose route segment matches the ID itself; selecting
-// one dispatches via vue-router.
 const ROUTABLE_NAV_IDS = new Set([
 	'smart-start',
 	'scenes',
@@ -165,9 +163,6 @@ const emit = defineEmits<{
 }>()
 
 // ── viewport ─────────────────────────────────────────────────
-// A ResizeObserver on the shell root drives the layout breakpoints off the
-// shell's actual rendered width rather than the window width, so it stays
-// correct even when embedded in a fixed-width host.
 
 const shellRef = ref<HTMLElement | null>(null)
 const viewport = ref(typeof window !== 'undefined' ? window.innerWidth : 1280)
@@ -195,18 +190,11 @@ const isMobile = computed(() => viewport.value < 760)
 const isCompact = computed(() => viewport.value >= 760 && viewport.value < 1100)
 
 // ── ui state (AppShell-owned) ────────────────────────────────
-//
-// Load persisted prefs synchronously before first render so saved values
-// don't flash in after the defaults. `query`, `selectedId`,
-// `expandedRowId`, and `mobileSidebarOpen` stay ephemeral.
 const persisted = loadPrefs()
 
 const active = ref<string>(persisted.scope ?? props.initialActive)
 const mobileSidebarOpen = ref(false)
-// Manual override of the width-derived sidebar mode. Intentionally NOT
-// persisted: collapse/expand is a per-session choice that resets to the
-// viewport-appropriate default on reload, so it's absent from DashboardPrefs
-// and from the persistence watcher below.
+// Not persisted: resets to viewport-appropriate default on reload.
 const sidebarState = ref<'collapsed' | 'wide' | null>(null)
 const activityHidden = ref(persisted.activityHidden)
 const query = ref('')
@@ -225,8 +213,6 @@ watch(isMobile, (v) => {
 })
 
 // ── persistence ──────────────────────────────────────────────
-// Snapshot the persistable slice once so the debounced writer and the
-// unmount flush share it.
 function snapshotPrefs(): DashboardPrefs {
 	return {
 		scope: active.value as DashboardPrefs['scope'],
@@ -275,17 +261,12 @@ const store = useDashboardStore()
 const baseStore = useBaseStore()
 const { devices, activities } = storeToRefs(store)
 
-// Reflects the live debug-capture session (base store), so the sidebar
-// toggle stays in sync with captures started elsewhere (e.g. the topbar).
 const capturing = computed(() => baseStore.debugCaptureActive)
 
 // ── scoped + grouped device pool ─────────────────────────────
 
 const isDeviceListNav = computed(() => DEVICE_LIST_NAV.has(active.value))
 
-// Debounce the search input ~100 ms so each keystroke doesn't run the
-// full filter pipeline; the input atom is uncontrolled, so the debounce
-// lives here.
 const debouncedQuery = ref('')
 let queryTimer: ReturnType<typeof setTimeout> | null = null
 watch(query, (v) => {

--- a/src/components/dashboard/layout/ZwDeviceDrawer.vue
+++ b/src/components/dashboard/layout/ZwDeviceDrawer.vue
@@ -96,8 +96,7 @@ function onKeyDown(e: KeyboardEvent) {
 	}
 }
 
-// Trap focus only on the open transition and release it on close; switching
-// from one device to another keeps the single active trap on the same panel.
+// Trap focus on open, release on close.
 watch(
 	() => props.device,
 	async (d, prev) => {

--- a/src/components/dashboard/layout/ZwSidebar.vue
+++ b/src/components/dashboard/layout/ZwSidebar.vue
@@ -59,8 +59,6 @@ import {
 
 export type SidebarMode = 'wide' | 'collapsed' | 'mobile'
 
-// Keys of ROW_ACTION_ICONS — a row action names its glyph, the renderer looks
-// it up. Keeping these in sync removes the need for a lookup fallback.
 export type RowActionIcon = 'play' | 'stop'
 
 export interface RowAction {
@@ -203,8 +201,8 @@ function railBadge(
 	}
 }
 
-// On the collapsed rail, an active row action surfaces as a status dot on
-// the nav icon, toned to match the action.
+// On the collapsed rail, an active row action surfaces as a status dot
+// on the nav icon, toned to match the action.
 function railActionDot(
 	entry: Extract<NavEntry, { kind: 'item' }>,
 ): { show: false } | { show: true; tone: 'danger' | 'accent' } {
@@ -218,15 +216,11 @@ function onSelect(navId: string): void {
 	if (modeIsMobile.value) emit('update:mobileOpen', false)
 }
 
-// Row-action glyphs, keyed by RowAction.icon / .iconActive. Media-style
-// play/stop reads as a control to start/stop a capture (vs. a status dot).
 const ROW_ACTION_ICONS: Record<RowActionIcon, Component> = {
 	play: PlayIcon,
 	stop: StopIcon,
 }
 
-// Body component (inline) so the wide/collapsed/mobile aside shells can
-// share markup without a separate file.
 const SidebarBody = defineComponent({
 	props: {
 		wide: { type: Boolean, required: true },
@@ -450,8 +444,7 @@ function renderEntry(entry: NavEntry, i: number, isWide: boolean) {
 					},
 					h(ROW_ACTION_ICONS[glyph], {
 						size: ICON_SIZE.dense,
-						// Stop reads better as a solid square; the play
-						// triangle stays line-style (its filled tip halos).
+						// Solid fill for stop; line-style for play (looks better).
 						...(glyph === 'stop' ? { fill: 'currentColor' } : {}),
 						'aria-hidden': 'true',
 					}),
@@ -560,7 +553,6 @@ function renderFooterRail() {
 </script>
 
 <style>
-/* Unscoped — class names .zw-sidebar* / .zw-sb* are unique to this component. */
 
 .zw-sidebar {
 	display: flex;

--- a/src/components/dashboard/layout/ZwSidebar.vue
+++ b/src/components/dashboard/layout/ZwSidebar.vue
@@ -553,7 +553,6 @@ function renderFooterRail() {
 </script>
 
 <style>
-
 .zw-sidebar {
 	display: flex;
 	flex-direction: column;

--- a/src/components/dashboard/layout/ZwTableBody.vue
+++ b/src/components/dashboard/layout/ZwTableBody.vue
@@ -200,8 +200,8 @@ type RowItem = { id: string; kind: 'row'; device: Device }
 type FlatItem = GroupHeadItem | RowItem
 type LayoutItem = FlatItem & { top: number; height: number }
 
-// Fixed sizes — must match the row/group-head CSS below. Constants (not
-// measured) avoid a resize-feedback loop.
+// Fixed sizes (must match the row/group-head CSS). Constants instead of
+// measured values to avoid a resize-feedback loop.
 const ROW_HEIGHT = 42
 const GROUP_HEAD_HEIGHT = 36
 const SCROLL_BUFFER = 240
@@ -222,8 +222,6 @@ const emit = defineEmits<{
 	action: [Device, DeviceAction]
 }>()
 
-// A Set so the per-row column check below is O(1); rebuilt when
-// visibleCols changes.
 const visibleColsSet = computed(() => new Set(props.visibleCols))
 
 const columns = computed<ToggleableCol[]>(() => {
@@ -264,8 +262,6 @@ const SORT_KEY_FOR_COL: Record<string, SortKey> = {
 
 const headerCells = computed<HeaderCell[] | null>(() => {
 	if (props.viewport < 600) return null
-	// Lead/trailing cells frame the row; the optional columns and their
-	// labels come straight from TOGGLEABLE_COLS (the single source of truth).
 	const cells: { label: string; key: string }[] = [
 		{ label: '', key: 'status' },
 		{ label: '#', key: 'id' },
@@ -292,8 +288,6 @@ const headerCells = computed<HeaderCell[] | null>(() => {
 	})
 })
 
-// `props.groups` arrives already scoped, grouped and sorted by
-// `buildGroups` (see ZwAppShell); the cards body consumes it the same way.
 const flatItems = computed<FlatItem[]>(() => {
 	const out: FlatItem[] = []
 	for (const [key, items] of props.groups) {
@@ -324,8 +318,6 @@ const expandedDevice = computed<Device | null>(() => {
 })
 
 // ── manual virtualization ─────────────────────────────────────────
-// Render only the rows in or near the viewport. The expanded body lives
-// outside this loop so its state survives scroll and row-height changes.
 
 const bodyRef = ref<HTMLElement | null>(null)
 const expandedHostRef = ref<HTMLElement | null>(null)
@@ -342,9 +334,7 @@ const layout = computed<{ items: LayoutItem[]; total: number }>(() => {
 			item.kind === 'group-head' ? GROUP_HEAD_HEIGHT : ROW_HEIGHT
 		out.push({ ...item, top, height } as LayoutItem)
 		top += height
-		// Reserve space for the expanded body right after its row, as
-		// a layout-only gap so the body never enters the virtualized
-		// loop.
+		// Reserve space for the expanded body.
 		if (
 			item.kind === 'row' &&
 			expanded != null &&
@@ -384,12 +374,8 @@ const expandedBodyTop = computed<number | null>(() => {
 })
 
 // ── sticky group header + expanded summary row ─────────────────────
-// Absolute positioning (the virtualization) defeats native
-// `position: sticky`, so we re-create it: derive each group's vertical
-// span, then render the active group's header — and, while a row is
-// expanded, its summary row just below — as overlays whose `top` is
-// pinned to the scroll viewport. The expanded row is dropped from the
-// normal loop (see template) so the overlay is its sole render.
+// Virtualization uses absolute positioning, which defeats native
+// position:sticky. We re-create it with manually computed top offsets.
 
 interface GroupSpan {
 	key: string
@@ -415,8 +401,8 @@ const groupSpans = computed<GroupSpan[]>(() => {
 	return spans
 })
 
-// The group whose span contains the current scroll offset, with its
-// header `top` clamped so the next group pushes it up at the boundary.
+// The group header pinned at the top of the scroll viewport. Clamped so
+// the next group's header pushes it upward at the boundary.
 const stickyGroup = computed(() => {
 	const st = scrollTop.value
 	for (const g of groupSpans.value) {
@@ -427,8 +413,8 @@ const stickyGroup = computed(() => {
 	return null
 })
 
-// Top for the pinned summary row: just under the group header, clamped
-// to the expanded region so it rides up out of view past the panel.
+// Top offset for the pinned expanded-device summary row. Sits just below
+// the sticky group header and scrolls out when the expanded region ends.
 const stickyRowTop = computed<number | null>(() => {
 	if (expandedBodyTop.value == null) return null
 	const rowTop = expandedBodyTop.value - ROW_HEIGHT
@@ -455,8 +441,7 @@ function onScroll(e: Event) {
 }
 
 // ── scrollbar-width compensation ─────────────────────────────────
-// The body owns its own scrollbar; the column header lives outside
-// it, so its width otherwise drifts when the scrollbar appears.
+// Header lives outside the scrollable body, so compensate for scrollbar width.
 
 const rootRef = ref<HTMLElement | null>(null)
 const scrollbarW = ref(0)
@@ -483,8 +468,7 @@ onMounted(() => {
 	}
 })
 
-// Track the persistent expanded body's height so we reserve the
-// right amount of space in the layout.
+// Track the expanded body's height so the layout reserves the right space.
 watch(expandedHostRef, (el, _old, onCleanup) => {
 	if (expandedObserver) {
 		expandedObserver.disconnect()

--- a/src/components/dashboard/layout/ZwTopbar.vue
+++ b/src/components/dashboard/layout/ZwTopbar.vue
@@ -125,8 +125,6 @@ const showActivityLabel = computed(() => props.viewport >= 760)
 </script>
 
 <style>
-/* Unscoped — V0 primitives strip Vue's scoped data-v-* hash. .zw-topbar* is
-   unique to this layout component. */
 
 .zw-topbar {
 	display: flex;

--- a/src/components/dashboard/layout/ZwTopbar.vue
+++ b/src/components/dashboard/layout/ZwTopbar.vue
@@ -125,7 +125,6 @@ const showActivityLabel = computed(() => props.viewport >= 760)
 </script>
 
 <style>
-
 .zw-topbar {
 	display: flex;
 	align-items: center;

--- a/src/lib/archetypes.ts
+++ b/src/lib/archetypes.ts
@@ -1,7 +1,5 @@
-// Archetype catalogue. Maps a Z-Wave node to an `Archetype` — the device
-// kind that drives its icon, grouping, and primary-value selection.
-// Inference is heuristic (device class → supported CCs → product regex →
-// fallback); order matters, first match wins.
+// Archetype catalogue: maps a Z-Wave node to its device kind, icon,
+// and grouping. First matching rule wins.
 
 import { CommandClasses } from '@zwave-js/core'
 import type { Component } from 'vue'

--- a/src/lib/attention.ts
+++ b/src/lib/attention.ts
@@ -1,11 +1,7 @@
-// "Needs attention" predicate behind the attention scope and its badge
-// count. A device needs attention when any of these holds:
-//   1. status is 'dead'
-//   2. health is 'weak' while awake
-//   3. battery below LOW_BATTERY_THRESHOLD
-//   4. interview incomplete with no in-flight interview activity
-//   5. a firmware update is available
-// Controllers are always excluded.
+// "Needs attention" predicate for the attention scope and badge count.
+// A device needs attention when: dead, weak signal while awake, low battery,
+// incomplete interview (with none in-flight), or firmware update available.
+// Controllers are excluded.
 
 import type { Device } from './dashboard-types.ts'
 
@@ -31,7 +27,7 @@ export function deviceNeedsAttention(d: Device): boolean {
 	return false
 }
 
-/** Short human-readable reason a device needs attention, else `null`. */
+/** Short human-readable reason a device needs attention, or `null`. */
 export function attentionReason(d: Device): string | null {
 	if (!deviceNeedsAttention(d)) return null
 	if (d.status === 'dead') return 'Dead'

--- a/src/lib/dashboard-breakpoints.ts
+++ b/src/lib/dashboard-breakpoints.ts
@@ -1,27 +1,12 @@
-// Dashboard layout breakpoints.
+// Dashboard layout breakpoints (container-width, not window-width).
 
-// The mobile cutoff, in pixels. This is a CONTAINER-width threshold: the
-// dashboard measures its own content area with a ResizeObserver and passes
-// it down as `viewport`, so the device row grid (deviceRowGrid) and the
-// drawer (ZwDeviceDrawer) collapse on available space, not window size.
-//
-// It deliberately does NOT derive from Vuetify's display thresholds
-// (480 / 760 / 1100 / 1380, see plugins/vuetify.js) — those are window-based
-// and none of them is 600 — so a single shared constant is the source of
-// truth across the three JS sites that read `viewport`. The drawer's CSS
-// `@media (max-width: 600px)` stays a literal (a stylesheet can't read a JS
-// constant); keep the two in sync if this ever changes.
+// Keep in sync with the @media (max-width: 600px) rule in ZwDeviceDrawer.
 export const MOBILE_BREAKPOINT = 600
 
-// Container-width threshold (px) at which the table-row expansion switches
-// from the stacked layout to the two-pane layout (left rail + tabbed detail).
-// Below this — and always inside the card-view drawer — the stacked layout is
-// used. Like MOBILE_BREAKPOINT this is measured against the shell's own width
-// (the `viewport` passed down), so it tracks available space, not the window.
+// Below this the detail area uses the stacked layout instead of two-pane.
 export const TWO_PANE_BREAKPOINT = 900
 
-// Two-pane left-rail sizing. At/above RAIL_WIDTH_BREAKPOINT the rail uses the
-// spacious width, below it the compact one (matches the design's two widths).
+// Two-pane left-rail sizing.
 export const RAIL_WIDTH_BREAKPOINT = 1200
 export const RAIL_WIDTH_SPACIOUS = 340
 export const RAIL_WIDTH_COMPACT = 300

--- a/src/lib/dashboard-types.ts
+++ b/src/lib/dashboard-types.ts
@@ -14,9 +14,6 @@ export type PrimaryValueType =
 	| 'state'
 	| 'thermostat'
 
-// The interactive values below carry the writeable `target` (a `ValueID`) the
-// action layer writes to; read-only values (reading, state) omit it.
-
 // On/off device — switch, outlet, or binary light.
 export interface PrimaryValueToggle {
 	type: 'toggle'
@@ -77,8 +74,6 @@ export type PrimaryValue =
 	| PrimaryValueState
 	| PrimaryValueThermostat
 
-// Maps each discriminant to its concrete shape, enabling compile-time
-// narrowing by primary-value type.
 export interface PrimaryValueByType {
 	toggle: PrimaryValueToggle
 	dim: PrimaryValueDim
@@ -126,9 +121,6 @@ export interface Archetype {
 }
 
 // ── Activity ──────────────────────────────────────────────────
-//
-// In-flight long-running operations on a device: OTA updates, route
-// rebuilds, interviews.
 
 export type ActivityType = 'ota' | 'rebuild' | 'interview'
 
@@ -192,9 +184,6 @@ export interface Device {
 }
 
 // ── Action contract ───────────────────────────────────────────
-//
-// Components emit `action(device, { type, … })`; `device-actions.ts`
-// maps each shape to its socket call.
 
 export type DeviceAction =
 	| { type: 'toggle'; on: boolean; valueId: ValueID }

--- a/src/lib/dashboardPrefs.ts
+++ b/src/lib/dashboardPrefs.ts
@@ -1,6 +1,4 @@
-// Persists the dashboard's UI preferences across reloads via the project's
-// `Settings` localStorage helper, under its own `dashboard` key. Exposes
-// `load()`/`save()` plus a debounced `scheduleSave()`.
+// Persists dashboard UI preferences in localStorage.
 
 import { Settings } from '../modules/Settings.js'
 

--- a/src/lib/device-actions.ts
+++ b/src/lib/device-actions.ts
@@ -1,8 +1,4 @@
-// Maps `DeviceAction` shapes to ZwaveClient requests (one dispatcher per
-// action, enforced by the mapped type).
-//
-// Value writes use `writeValue`, not `sendCommand`: only `setValue` updates
-// the value optimistically and verifies it. The `valueId` rides on the action.
+// Maps DeviceAction shapes to ZwaveClient socket requests.
 
 import {
 	DoorLockMode,
@@ -18,8 +14,6 @@ type ActionDispatcher<A extends DeviceAction> = (
 	action: A,
 ) => SocketRequest
 
-// What the dispatcher returns; callers pass it to `apiRequest()`, which
-// keeps this module pure.
 export interface SocketRequest {
 	api: string
 	args: unknown[]
@@ -54,8 +48,6 @@ export const ACTION_DISPATCHERS: {
 		api: 'writeValue',
 		args: [{ nodeId: d.nodeId, ...a.valueId }, a.mode],
 	}),
-	// Generic value-pane interactions. `set-value` writes the value verbatim —
-	// no clamping or coercion; the caller is responsible for a sensible value.
 	'set-value': (d, a) => ({
 		api: 'writeValue',
 		args: [{ nodeId: d.nodeId, ...a.valueId }, a.value],
@@ -68,8 +60,6 @@ export const ACTION_DISPATCHERS: {
 		api: 'refreshCCValues',
 		args: [d.nodeId, a.commandClass],
 	}),
-	// Controller- and node-management actions, mapped to their
-	// bookkeeping APIs.
 	ping: (d) => ({ api: 'pingNode', args: [d.nodeId] }),
 	interview: (d) => ({ api: 'refreshInfo', args: [d.nodeId] }),
 	refresh: (d) => ({ api: 'refreshValues', args: [d.nodeId] }),
@@ -93,7 +83,6 @@ export const ACTION_DISPATCHERS: {
 	exclude: () => ({ api: 'startExclusion', args: [] }),
 }
 
-/** Resolve a `DeviceAction` to its socket request; the caller emits it. */
 export function dispatchAction(
 	device: Device,
 	action: DeviceAction,

--- a/src/lib/deviceActionPending.ts
+++ b/src/lib/deviceActionPending.ts
@@ -1,6 +1,4 @@
-// Reactive Set of in-flight value-pane request keys. The host fills it around
-// `apiRequest` so spinners clear on response (not a timer, and not only when a
-// value changes — a poll often re-reads the same value).
+// Tracks in-flight value-pane requests so spinners clear on response.
 
 import type { InjectionKey, ShallowRef } from 'vue'
 import type { ValueID } from '@zwave-js/core'
@@ -8,21 +6,16 @@ import type { Device, DeviceAction } from './dashboard-types.ts'
 
 export type ActionStatus = 'pending' | 'ok' | 'fail'
 
-// Immutable Map in a shallowRef — replaced on each change.
 export type ActionStatusMap = ShallowRef<ReadonlyMap<string, ActionStatus>>
 
 export const DeviceActionStatusKey: InjectionKey<ActionStatusMap> = Symbol(
 	'zwDeviceActionStatus',
 )
 
-// Stable per-node value identity (`cc-endpoint-property-key`); keys pending
-// requests and matches event args back to values. Partial: event args may
-// carry only some of the fields.
 export function valueIdKey(v: Partial<ValueID>): string {
 	return `${v.commandClass}-${v.endpoint ?? 0}-${String(v.property)}-${v.propertyKey ?? ''}`
 }
 
-// Node-scoped — two nodes can share a ValueID shape.
 export function setPendingKey(nodeId: number, v: ValueID): string {
 	return `${nodeId}:set:${valueIdKey(v)}`
 }
@@ -35,7 +28,6 @@ export function ccPendingKey(nodeId: number, cc: number): string {
 	return `${nodeId}:cc:${cc}`
 }
 
-// Pending key for an action, or null if the Values pane doesn't track it.
 export function actionPendingKey(
 	device: Device,
 	action: DeviceAction,

--- a/src/lib/deviceFilter.ts
+++ b/src/lib/deviceFilter.ts
@@ -85,9 +85,7 @@ export function applySearch(devices: Device[], query: string): Device[] {
 	)
 }
 
-// Group key the controller bucket is filed under; pinned first and rendered
-// as "Controller". Exported so view components match on it rather than
-// re-hardcoding the sentinel.
+// Sentinel group key for the controller bucket (pinned first).
 export const CONTROLLER_KEY = '__controller'
 
 /**

--- a/src/lib/deviceProjection.ts
+++ b/src/lib/deviceProjection.ts
@@ -1,6 +1,4 @@
-// Projects a raw Z-Wave node (`ZUINode`) into the `Device` shape the
-// dashboard renders from. Pure and side-effect-free so callers can
-// memoize per node.
+// Projects a ZUINode into the Device shape the dashboard renders from.
 
 import { CommandClasses, type ValueID } from '@zwave-js/core'
 import { DoorLockMode } from '@zwave-js/cc'
@@ -21,8 +19,7 @@ export interface ProjectOptions {
 	activitiesByNode?: Map<number, Activity[]>
 }
 
-// SecurityClass member names, low → high; `node.security` carries the
-// highest granted class as its enum member name.
+// SecurityClass member names, low → high.
 const SECURITY_KEYS: readonly SecurityKey[] = [
 	'S0_Legacy',
 	'S2_Unauthenticated',
@@ -43,9 +40,6 @@ function findValue(
 	return undefined
 }
 
-// The `ValueID` of a located value. `overrideProperty` swaps to a writeable
-// companion on the same endpoint (e.g. `targetValue` for `currentValue`);
-// otherwise the value's own property and propertyKey are kept.
 function valueId(v: ZUIValueId, overrideProperty?: string): ValueID {
 	const id: ValueID = {
 		commandClass: v.commandClass,
@@ -142,9 +136,7 @@ function projectPrimaryValue(
 	}
 
 	if (archetypeKind === 'outlet' || archetypeKind === 'switch') {
-		// Display state prefers currentValue, falling back to targetValue so a
-		// switch that has only reported its target still reads correctly rather
-		// than forcing OFF. Either one resolves the write target below.
+		// Prefer currentValue, fall back to targetValue.
 		const on =
 			findValue(
 				node,
@@ -287,8 +279,7 @@ function clampLevel(n: number): number {
 }
 
 function meterWatts(node: ZUINode): number | null {
-	// Match electric-power readings on `unit` (`W`/`kW`); propertyName is
-	// localized and unreliable.
+	// Match on unit (propertyName is localized and unreliable).
 	const v = findValue(
 		node,
 		CommandClasses.Meter,
@@ -326,11 +317,6 @@ function labelsFor(kind: string): StateLabels {
 	}
 }
 
-/**
- * Derive `device.activity[]` from node fields: `firmwareUpdate` → OTA,
- * `rebuildRoutesProgress` → rebuild, incomplete `interviewStage` →
- * interview. Entries from `override`, when given, are appended.
- */
 function projectActivities(
 	node: ZUINode,
 	override?: Map<number, Activity[]>,
@@ -358,8 +344,7 @@ function projectActivities(
 
 	const rebuild = node.rebuildRoutesProgress
 	if (rebuild) {
-		// rebuildRoutesProgress is a status enum, not a percentage; treat
-		// any non-terminal state as in-flight.
+		// Status enum, not a percentage — treat any non-terminal state as in-flight.
 		const done =
 			(typeof rebuild === 'string' &&
 				(rebuild === 'done' || rebuild === 'failed')) ||
@@ -373,8 +358,7 @@ function projectActivities(
 		}
 	}
 
-	// Skip interview progress for nodes that can't make any: a Dead or Asleep
-	// node would otherwise show a stalled, misleading indicator.
+	// Dead/Asleep nodes can't progress — skip to avoid stale indicators.
 	if (
 		node.interviewStage &&
 		node.interviewStage !== 'Complete' &&
@@ -394,9 +378,6 @@ function projectActivities(
 	return out
 }
 
-/**
- * Project one ZUINode → UI Device. Pure; safe to memoize.
- */
 export function projectDevice(
 	node: ZUINode,
 	opts: ProjectOptions = {},
@@ -445,7 +426,6 @@ export function projectDevice(
 	}
 }
 
-/** Project an array of nodes; per-node projection is memoizable upstream. */
 export function projectDevices(
 	nodes: ZUINode[],
 	opts: ProjectOptions = {},

--- a/src/lib/icons.ts
+++ b/src/lib/icons.ts
@@ -68,10 +68,7 @@ export {
 	Activity as PulseIcon,
 } from '@lucide/vue'
 
-/**
- * Shared icon-size scale; components reference these names rather than
- * raw pixel values.
- */
+// Shared icon-size scale — use these names instead of raw pixel values.
 export const ICON_SIZE = {
 	pill: 10, // pill leading glyph; popover-menu check / chevron
 	chip: 11, // chips

--- a/src/lib/popover-fallback.ts
+++ b/src/lib/popover-fallback.ts
@@ -1,22 +1,6 @@
 // Floating-UI-backed positioner for V0 Popover content.
-//
-// V0's docs explicitly recommend Floating UI for browsers without CSS
-// Anchor Positioning support — and even in supporting browsers, V0 hard-
-// codes `position-area: bottom` (with no way to override via Root props),
-// which centers the popover under its anchor instead of letting us
-// right-align it to a trigger button.
-//
-// `autoUpdate` keeps the popover in place while the user scrolls, resizes,
-// or interacts with surrounding layout, replacing V0's anchor-positioning
-// inline styles entirely. We disable V0's anchor styles by writing
-// `position-area: none !important` once, then drive `top`/`left` ourselves
-// via `computePosition`.
-//
-// Element lookup: neither `Popover.Activator` nor `Popover.Content` calls
-// `defineExpose`, so Vue template refs on them yield nothing useful. We
-// rely on the caller-supplied `contentId` (bound via `<Popover.Root :id>`
-// so V0 wires both activator's `popovertarget` and content's `id` to that
-// value), and find the elements at activation time via the DOM.
+// V0 hard-codes `position-area: bottom` with no override, so we disable its
+// anchor styles and drive top/left ourselves via computePosition + autoUpdate.
 
 import { onBeforeUnmount, watch, toValue } from 'vue'
 import type { MaybeRefOrGetter, Ref } from 'vue'
@@ -58,12 +42,7 @@ export function usePopoverFallback({
 		const a = document.querySelector<HTMLElement>(`[popovertarget="${id}"]`)
 		if (!a || !c) return
 
-		// Override V0's `position-area: bottom` (which centers the popover
-		// on its anchor) and its `position-anchor` so Floating UI's manual
-		// top/left writes are not overridden by the CSS-anchor cascade.
-		// The position-strategy + right/bottom anchors are also static —
-		// set them once here, leaving only top/left to be rewritten on
-		// each autoUpdate tick.
+		// Override V0's anchor-positioning styles so Floating UI controls placement.
 		c.style.setProperty('position-area', 'none', 'important')
 		c.style.setProperty('position-anchor', 'none', 'important')
 		c.style.setProperty('margin', '0', 'important')
@@ -109,9 +88,7 @@ export function usePopoverFallback({
 			stopTracking()
 			if (isOpen) startTracking()
 		},
-		// Flush after the DOM patch: on open, V0 mounts Popover.Content in
-		// the same tick, so a default 'pre' watcher would query the DOM
-		// before the element exists and startTracking would bail on null.
+		// post: the popover element must exist in the DOM before we position it.
 		{ flush: 'post' },
 	)
 

--- a/src/lib/primaryValue.ts
+++ b/src/lib/primaryValue.ts
@@ -2,12 +2,7 @@
 
 import type { PrimaryValueState } from '@/lib/dashboard-types'
 
-// True when a `state` primary value sits in its alert slot: the second
-// state (index 1) tinted red or amber. This is the single definition of
-// "is this state an alert" — ZwPrimaryState, ZwDeviceCard and
-// ZwCompactPrimary all read it, so the rule can't drift between the row,
-// card and detail surfaces. Mapping an alert to a specific chip tone
-// (red → danger, amber → warn) stays at the call site.
+// Alert state: second slot (index 1) tinted red or amber.
 export function isStateAlert(state: PrimaryValueState): boolean {
 	return (
 		state.stateIdx === 1 &&

--- a/src/lib/time.ts
+++ b/src/lib/time.ts
@@ -1,13 +1,8 @@
-// Relative-time helpers and a shared `useNow()` composable: all consumers
-// tick off one 30-second heartbeat.
+// Relative-time helpers and a shared useNow() composable (30s tick).
 
 import { onScopeDispose, ref } from 'vue'
 import type { Ref } from 'vue'
 
-/**
- * Format a Unix-ms timestamp as a relative-time string (`just now`,
- * `2m ago`, …), or `'never'` if missing. Pure: the caller supplies `now`.
- */
 export function relativeTime(at: number | undefined, now: number): string {
 	if (!at) return 'never'
 	const secs = Math.max(0, Math.floor((now - at) / 1000))
@@ -18,8 +13,7 @@ export function relativeTime(at: number | undefined, now: number): string {
 	return `${Math.floor(secs / 86400)}d ago`
 }
 
-// Singleton `now` ref ticked every 30s. Consumers share one interval; the
-// refcount clears it when the last consumer unmounts.
+// Shared singleton — refcount clears the interval when the last consumer unmounts.
 
 let sharedNow: Ref<number> | null = null
 let intervalId: ReturnType<typeof setInterval> | null = null

--- a/src/lib/valueGroups.ts
+++ b/src/lib/valueGroups.ts
@@ -1,5 +1,4 @@
-// Projects a node's `values` into the grouped, control-ready shape the Values
-// pane renders. Pure — the component memoizes it with a computed.
+// Projects a node's values into the grouped shape the Values pane renders.
 
 import { CommandClasses, type ValueID } from '@zwave-js/core'
 import type {
@@ -11,7 +10,6 @@ import type {
 const CONFIGURATION_CC = CommandClasses.Configuration
 const MULTILEVEL_SWITCH_CC = CommandClasses['Multilevel Switch']
 
-// Which control a value renders (most-specific wins — see `paramKind`).
 export type ValueParamKind =
 	| 'switch'
 	| 'button'
@@ -92,7 +90,6 @@ function hasStates(
 	return Array.isArray(v.states) && v.states.length > 0
 }
 
-// 0–99 dimmer-style value: Multilevel Switch current/target, or any 0–99 number.
 function isLevel(v: ZUIValueId): boolean {
 	if (
 		v.commandClass === MULTILEVEL_SWITCH_CC &&
@@ -100,23 +97,20 @@ function isLevel(v: ZUIValueId): boolean {
 	) {
 		return true
 	}
-	// A 0–99 number with discrete states is an enum (more specific), not a level.
 	return v.type === 'number' && v.min === 0 && v.max === 99 && !hasStates(v)
 }
 
-// Picks the control *shape* (editability is `readonly`, set elsewhere). A value
-// can match several predicates, so order matters — most specific first.
+// Order matters — most specific match first.
 function paramKind(v: ZUIValueId): ValueParamKind {
-	// write-only boolean = a command (e.g. Meter reset), not a toggle
+	// Write-only boolean = a command (e.g. Meter reset).
 	if (v.type === 'boolean' && v.writeable && !v.readable) return 'button'
 	if (v.type === 'boolean') return 'switch'
 	if (v.type === 'color') return 'color'
 	if (isLevel(v)) return 'level'
-	// states → dropdown, unless free entry is allowed (keep arbitrary values reachable)
 	if (hasStates(v) && !(v.writeable && v.allowManualEntry)) return 'enum'
 	if (v.type === 'number') return 'number'
 	if (v.type === 'string' || v.type === 'buffer') return 'text'
-	return 'reading' // duration / any / unsupported → read-only, never written
+	return 'reading'
 }
 
 function formatValue(v: ZUIValueId, kind: ValueParamKind): string {
@@ -145,7 +139,6 @@ function formatValue(v: ZUIValueId, kind: ValueParamKind): string {
 	}
 }
 
-// Referential stability cache — unchanged params reuse the same object.
 const paramCache = new WeakMap<ZUIValueId, ValueParam>()
 
 function projectParam(v: ZUIValueId): ValueParam {
@@ -168,8 +161,6 @@ function buildParam(v: ZUIValueId): ValueParam {
 		kind,
 		value: v.value,
 		display: formatValue(v, kind),
-		// `reading` has no editable control, so it must render read-only even
-		// when the value is technically writeable (avoids an empty control).
 		readonly: kind === 'reading' || !v.writeable,
 		readable: !!v.readable,
 		unit: v.unit,
@@ -187,8 +178,6 @@ function buildParam(v: ZUIValueId): ValueParam {
 	}
 }
 
-// Groups a node's values by command class (first-seen order), each projected to
-// a render-ready `ValueParam`. `[]` for a node without values (e.g. controller).
 export function buildValueGroups(node?: ZUINode | null): ValueGroup[] {
 	if (!node || !Array.isArray(node.values)) return []
 	const byCc = new Map<number, ValueGroup>()

--- a/src/plugins/palette.ts
+++ b/src/plugins/palette.ts
@@ -1,25 +1,6 @@
 // Single source of truth for the dashboard color palette.
-//
-// Imported by:
-// - src/plugins/vuetify0.ts → exposed as --v0-<name> CSS variables that
-//   src/assets/css/tokens.css reads to compose the --zw-* vocabulary
-// - src/plugins/vuetify.js → wired into Vuetify 3's theme system so legacy
-//   pages keep picking up the same palette while they're still on Vuetify 3
-//
-// The two destinations MUST stay in lockstep. Add new colors here, never
-// inline them in either plugin file.
-
-// No `secondary` key: the only secondary tone in the system is the
-// muted FG ramp, already covered by --zw-fg-soft.
-//
-// `info` exists ONLY for backwards compatibility with the legacy
-// dashboard's `<v-alert type="info">` call sites (FirmwareUpdates.vue,
-// NodeDetails.vue, TemplateWizard.vue, Zniffer.vue). Vuetify 3 maps an
-// alert's `type` onto the theme color of the same name, so dropping
-// `info` would break those alerts. The new dashboard implements
-// info-toned surfaces as an accent alias at the atom layer (see
-// .zw-tone-info in tokens.css). REMOVE this key once dashboard-neo
-// lands and the legacy v-alert call sites are gone.
+// Consumed by vuetify0.ts (--v0-* CSS vars) and vuetify.js (Vuetify 3 theme).
+// Add new colors here, never inline them in either plugin file.
 export type Palette = Record<string, string> & {
 	primary: string
 	'primary-darken-1': string
@@ -36,13 +17,11 @@ export type Palette = Record<string, string> & {
 	'background-soft': string
 	'on-surface': string
 	'on-background': string
-	// `on-<accent>` keys exist so atoms can derive contrast text from V0
-	// channel vars (e.g. `rgb(var(--v0-on-primary))`) and stay correct in
-	// dark mode — flipping to a literal `#fff` would defeat that.
 	'on-primary': string
-	// Legacy-only — see header comment. Remove with dashboard-neo.
+	// Legacy: required by v-alert type="info" in FirmwareUpdates, NodeDetails,
+	// TemplateWizard, Zniffer. Remove after dashboard-neo migration.
 	info: string
-	// Kept for backwards compatibility with the legacy app.
+	// Legacy: used by the old dashboard. Remove after dashboard-neo migration.
 	purple: string
 }
 
@@ -67,10 +46,8 @@ export const lightColors: Palette = {
 	purple: '#BA68C8',
 }
 
-// Dark palette is a placeholder — full dark-mode design is a separate pass.
-// Keys MUST all exist or Vuetify 3 throws when a component asks for them, and
-// V0 silently drops them. Alpha-based --zw-* tokens flip automatically because
-// on-surface flips to white here.
+// Placeholder — full dark-mode design is a separate pass.
+// All keys must exist (Vuetify 3 throws on missing theme colors).
 export const darkColors: Palette = {
 	primary: '#1976D2',
 	'primary-darken-1': '#1565C0',

--- a/src/plugins/vuetify0.ts
+++ b/src/plugins/vuetify0.ts
@@ -1,13 +1,5 @@
-// Vuetify0 (@vuetify/v0) theme plugin — emits the dashboard's color palette
-// as --v0-<name> CSS variables on a stylesheet that scopes to
-// [data-theme="<id>"]. The variables are RGB-decomposed channels (rgb: true),
-// so src/assets/css/tokens.css can compose them via rgb()/rgba() — matching
-// the channel form the dashboard's --zw-* tokens already use.
-//
-// V0 is the headless successor to Vuetify 3 ("Vuetify 5 will be built on
-// v0"). New dashboard components target V0 primitives directly; Vuetify 3
-// remains installed only to host legacy routes during the rework, and is
-// removed once every legacy page has migrated.
+// V0 theme plugin: emits palette colors as --v0-<name> CSS variables
+// (RGB-decomposed) under [data-theme="<id>"] for tokens.css to consume.
 
 import { createThemePlugin, V0StyleSheetThemeAdapter } from '@vuetify/v0'
 import type { App } from 'vue'
@@ -24,10 +16,7 @@ const themePlugin = createThemePlugin({
 		prefix: 'v0',
 	}),
 	rgb: true,
-	// `data-theme` goes on <html> so the [data-theme="<id>"] CSS selector
-	// the adapter scopes its --v0-* variables under is visible from :root
-	// downward. tokens.css's --zw-* tokens are declared on :root and read
-	// the --v0-* values directly, so they need them to resolve there.
+	// tokens.css reads --v0-* from :root, so the theme attr must be on <html>.
 	target: 'html',
 })
 

--- a/src/stores/dashboard.ts
+++ b/src/stores/dashboard.ts
@@ -1,5 +1,3 @@
-// Dashboard store: projects Z-Wave node data into `Device` records shared
-// across the dashboard, with derived device/attention/activity counts.
 
 import { computed } from 'vue'
 import { acceptHMRUpdate, defineStore } from 'pinia'
@@ -13,8 +11,7 @@ const useDashboardStore = defineStore('dashboard', () => {
 
 	const devices = computed<Device[]>(() =>
 		projectDevices(
-			// Virtual nodes (broadcast/multicast groups) belong in their own
-			// view, not the device list.
+			// Exclude virtual nodes (broadcast/multicast groups).
 			((base.nodes ?? []) as Parameters<typeof projectDevices>[0]).filter(
 				(n) => !n.virtual,
 			),
@@ -35,7 +32,6 @@ const useDashboardStore = defineStore('dashboard', () => {
 
 	const activityCount = computed(() => activities.value.length)
 
-	// `appInfo.homeHex` is the controller home ID formatted as `0x…` hex.
 	const homeHex = computed(() => base.appInfo?.homeHex || '')
 
 	const appVersion = computed(() => base.appInfo?.appVersion || '')
@@ -53,11 +49,8 @@ const useDashboardStore = defineStore('dashboard', () => {
 	}
 })
 
-// Convenience re-export; the implementation lives in `lib/attention.ts`.
 export { deviceNeedsAttention } from '../lib/attention.ts'
 
-// Without this, editing the store's getters during dev leaves components bound
-// to a stale instance (missing the new getters) until a full reload.
 if (import.meta.hot) {
 	import.meta.hot.accept(acceptHMRUpdate(useDashboardStore, import.meta.hot))
 }

--- a/src/stores/dashboard.ts
+++ b/src/stores/dashboard.ts
@@ -1,4 +1,3 @@
-
 import { computed } from 'vue'
 import { acceptHMRUpdate, defineStore } from 'pinia'
 import useBaseStore from './base.js'


### PR DESCRIPTION
The previous PRs for the dashboard review introduced quite a bit of word salad comment noise. This PR cleans them up.