### PR TITLE
feat(ui): redesign summary tab as three titled cards

### DIFF
--- a/src/components/dashboard/components/ZwNodeDetailsBody.vue
+++ b/src/components/dashboard/components/ZwNodeDetailsBody.vue
@@ -76,8 +76,8 @@
 					value="summary"
 					class="zw-nd__content zw-nd__summary"
 				>
-					<ZwPropTable :rows="manufacturerRows" />
-					<ZwPropTable :rows="firmwareRows" />
+					<ZwPropTable title="Device" :rows="deviceRows" />
+					<ZwPropTable title="Firmware" :rows="fwRows" />
 					<ZwSecurityPanel :device="device" />
 				</Tabs.Panel>
 
@@ -245,18 +245,14 @@ const statusLabel = computed(() => {
 	return s.charAt(0).toUpperCase() + s.slice(1)
 })
 
-const manufacturerRows = computed<[string, string | number][]>(() => [
-	['Manufacturer', props.device.manufacturer ?? '—'],
-	['Product', props.device.product ?? '—'],
-	['Code', props.device.productCode ?? '—'],
-	['Protocol', props.device.protocol ?? '—'],
+const deviceRows = computed<[string, string | number][]>(() => [
+	['Device class', props.device.archetype.label],
+	['Interview', props.device.interviewState],
 ])
 
-const firmwareRows = computed<[string, string | number][]>(() => [
-	['Firmware', props.device.firmware?.node ?? '—'],
+const fwRows = computed<[string, string | number][]>(() => [
+	['Version', props.device.firmware?.node ?? '—'],
 	['SDK', props.device.firmware?.sdk ?? '—'],
-	['Last seen', props.device.lastSeen],
-	['Interview', props.device.interviewState],
 ])
 
 // Placeholder association-group rows.

--- a/src/components/dashboard/components/ZwPropTable.vue
+++ b/src/components/dashboard/components/ZwPropTable.vue
@@ -1,5 +1,6 @@
 <template>
-	<div v-if="rows.length" class="zw-pt">
+	<div v-if="rows.length || title" class="zw-pt">
+		<div v-if="title" class="zw-pt__title">{{ title }}</div>
 		<div
 			v-for="(row, idx) in rows"
 			:key="idx"
@@ -13,7 +14,13 @@
 </template>
 
 <script setup lang="ts">
-defineProps<{ rows: [string, string | number][] }>()
+withDefaults(
+	defineProps<{
+		rows: [string, string | number][]
+		title?: string
+	}>(),
+	{ title: undefined },
+)
 </script>
 
 <style scoped>
@@ -22,6 +29,16 @@ defineProps<{ rows: [string, string | number][] }>()
 	border: 1px solid var(--zw-line);
 	border-radius: 6px;
 	overflow: hidden;
+}
+
+.zw-pt__title {
+	padding: 6px 10px;
+	border-bottom: 1px solid var(--zw-line);
+	font-family: var(--zw-mono);
+	font-size: 10px;
+	color: var(--zw-muted);
+	text-transform: uppercase;
+	letter-spacing: 0.4px;
 }
 
 .zw-pt__row {


### PR DESCRIPTION
Rework the Summary tab from two flat ZwPropTable blocks into three titled cards: Device (device class, endpoints, interview), Firmware (version, SDK), and Security. Remove manufacturer/product/code/ protocol/last-seen which are already shown in the drawer header and row subtitle.

Add optional `title` prop to ZwPropTable for the card header.