### PR TITLE
feat(ui): add values panel overflow menu

### DIFF
--- a/src/components/dashboard/atoms/ZwSearchInput.vue
+++ b/src/components/dashboard/atoms/ZwSearchInput.vue
@@ -35,7 +35,6 @@ function onInput(e: Event) {
 	position: relative;
 	display: inline-flex;
 	width: 100%;
-	max-width: 420px;
 }
 
 .zw-search__icon {

--- a/src/components/dashboard/components/ZwValuesActionsMenu.vue
+++ b/src/components/dashboard/components/ZwValuesActionsMenu.vue
@@ -1,0 +1,144 @@
+<template>
+	<Popover.Root v-model="open" :id="contentId">
+		<Popover.Activator
+			as="button"
+			type="button"
+			class="zw-vam__trigger zw-focus-ring"
+			aria-label="More actions"
+			aria-haspopup="menu"
+		>
+			<MoreIcon :size="ICON_SIZE.std" />
+		</Popover.Activator>
+		<Popover.Content as="div" class="zw-vam__panel" role="menu">
+			<button
+				type="button"
+				class="zw-vam__item"
+				role="menuitem"
+				@click="run('refresh-all')"
+			>
+				<RefreshIcon
+					:size="ICON_SIZE.chip"
+					class="zw-vam__icon zw-vam__icon--accent"
+				/>
+				Refresh all values
+			</button>
+			<div class="zw-vam__sep" />
+			<button
+				type="button"
+				class="zw-vam__item"
+				role="menuitem"
+				@click="run('expand-all')"
+			>
+				<ChevronDownIcon :size="ICON_SIZE.chip" class="zw-vam__icon" />
+				Expand all
+			</button>
+			<button
+				type="button"
+				class="zw-vam__item"
+				role="menuitem"
+				@click="run('collapse-all')"
+			>
+				<ChevronRightIcon :size="ICON_SIZE.chip" class="zw-vam__icon" />
+				Collapse all
+			</button>
+		</Popover.Content>
+	</Popover.Root>
+</template>
+
+<script setup lang="ts">
+import { ref, useId } from 'vue'
+import { Popover } from '@vuetify/v0'
+import {
+	ChevronDownIcon,
+	ChevronRightIcon,
+	ICON_SIZE,
+	MoreIcon,
+	RefreshIcon,
+} from '@/lib/icons'
+import { usePopoverFallback } from '@/lib/popover-fallback.ts'
+
+const emit = defineEmits<{
+	'refresh-all': []
+	'expand-all': []
+	'collapse-all': []
+}>()
+
+const open = ref(false)
+const contentId = `zw-vam-${useId()}`
+
+usePopoverFallback({ open, contentId })
+
+function run(event: 'refresh-all' | 'expand-all' | 'collapse-all') {
+	open.value = false
+	emit(event)
+}
+</script>
+
+<style>
+.zw-vam__trigger {
+	appearance: none;
+	background: transparent;
+	border: 1px solid var(--zw-line);
+	border-radius: 6px;
+	width: 28px;
+	height: 28px;
+	padding: 0;
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	color: var(--zw-muted);
+	cursor: pointer;
+}
+
+.zw-vam__trigger[data-open] {
+	background: var(--zw-chip-bg);
+}
+
+.zw-vam__panel {
+	position-area: none !important;
+	position-anchor: auto !important;
+	min-width: 200px;
+	background: var(--zw-card);
+	border: 1px solid var(--zw-line-soft);
+	border-radius: 6px;
+	box-shadow: var(--zw-e8);
+	overflow: hidden;
+	animation: zw-fade-in 0.12s;
+}
+
+.zw-vam__panel::backdrop {
+	display: none;
+}
+
+.zw-vam__item {
+	display: flex;
+	align-items: center;
+	gap: 9px;
+	width: 100%;
+	background: transparent;
+	border: none;
+	cursor: pointer;
+	padding: 8px 12px;
+	color: var(--zw-fg);
+	font: var(--zw-text-body-s);
+	text-align: left;
+}
+
+.zw-vam__item:hover {
+	background: var(--zw-row-hover);
+}
+
+.zw-vam__icon {
+	color: var(--zw-muted);
+}
+
+.zw-vam__icon--accent {
+	color: var(--zw-accent);
+}
+
+.zw-vam__sep {
+	height: 1px;
+	background: var(--zw-line);
+	margin: 2px 0;
+}
+</style>

--- a/src/components/dashboard/components/ZwValuesView.vue
+++ b/src/components/dashboard/components/ZwValuesView.vue
@@ -1,11 +1,18 @@
 <template>
 	<div class="zw-values">
-		<ZwSearchInput
-			v-model="query"
-			class="zw-values__search"
-			placeholder="Filter values…"
-			aria-label="Filter values"
-		/>
+		<div class="zw-values__toolbar">
+			<ZwSearchInput
+				v-model="query"
+				class="zw-values__search"
+				placeholder="Filter values…"
+				aria-label="Filter values"
+			/>
+			<ZwValuesActionsMenu
+				@refresh-all="onRefreshAll"
+				@expand-all="expandAll"
+				@collapse-all="collapseAll"
+			/>
+		</div>
 
 		<ZwValueGroup
 			v-for="g in filtered"
@@ -31,6 +38,7 @@
 <script setup lang="ts">
 import { computed, ref, watch } from 'vue'
 import ZwSearchInput from '@/components/dashboard/atoms/ZwSearchInput.vue'
+import ZwValuesActionsMenu from './ZwValuesActionsMenu.vue'
 import ZwValueGroup from './ZwValueGroup.vue'
 import useBaseStore from '@/stores/base'
 import {
@@ -105,6 +113,18 @@ function toggle(ccId: number) {
 	open.value = next
 }
 
+function expandAll() {
+	open.value = new Set(groups.value.map((g) => g.ccId))
+}
+
+function collapseAll() {
+	open.value = new Set()
+}
+
+function onRefreshAll() {
+	emit('action', props.device, { type: 'refresh' })
+}
+
 function onSet(valueId: ValueID, value: unknown) {
 	emit('action', props.device, { type: 'set-value', valueId, value })
 }
@@ -123,6 +143,17 @@ function onRefreshCc(commandClass: number) {
 	display: flex;
 	flex-direction: column;
 	gap: 10px;
+}
+
+.zw-values__toolbar {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+}
+
+.zw-values__search {
+	flex: 1;
+	min-width: 0;
 }
 
 .zw-values__empty {

--- a/src/lib/icons.ts
+++ b/src/lib/icons.ts
@@ -74,6 +74,7 @@ export const ICON_SIZE = {
 	chip: 11, // chips
 	caret: 12, // expandable section chevron (sort / group headers)
 	dense: 13, // update notifier; dense action buttons (refresh / trash)
+	std: 15, // standard-size glyphs in menus and standalone buttons
 	inline: 14, // table rows / inline
 	nav: 16, // nav rows
 	topbar: 18, // top bar / icon buttons


### PR DESCRIPTION
Add a ⋮ overflow menu next to the values search field with three actions: Refresh all values, Expand all, and Collapse all. The menu follows the existing Popover pattern from ZwToggleMenu.