### PR TITLE
feat(ui): add action list components and rework Debug tab

### DIFF
--- a/src/components/dashboard/components/ZwActionBtn.vue
+++ b/src/components/dashboard/components/ZwActionBtn.vue
@@ -1,0 +1,201 @@
+<template>
+	<div class="zw-ab" :class="{ 'zw-ab--danger': tone === 'danger' }">
+		<span
+			class="zw-ab__icon"
+			:class="{ 'zw-ab__icon--danger': tone === 'danger' }"
+		>
+			<slot name="icon" />
+		</span>
+		<div class="zw-ab__body">
+			<div class="zw-ab__title">{{ title }}</div>
+			<div v-if="description" class="zw-ab__desc">{{ description }}</div>
+		</div>
+		<div class="zw-ab__actions">
+			<button
+				v-for="(action, i) in actions"
+				:key="i"
+				type="button"
+				class="zw-ab__btn"
+				:class="{
+					'zw-ab__btn--danger': tone === 'danger',
+					'zw-ab__btn--accent': tone === 'accent',
+					'zw-ab__btn--done': states[i] === 'done',
+					'zw-ab__btn--busy': states[i] === 'busy',
+				}"
+				:disabled="states[i] !== 'idle'"
+				@click="run(i)"
+			>
+				<RefreshIcon
+					v-if="states[i] === 'busy'"
+					:size="ICON_SIZE.caret"
+					class="zw-ab__spin"
+				/>
+				<CheckIcon
+					v-else-if="states[i] === 'done'"
+					:size="ICON_SIZE.caret"
+				/>
+				{{
+					states[i] === 'busy'
+						? (action.busyLabel ?? action.label)
+						: states[i] === 'done'
+							? (action.doneLabel ?? action.label)
+							: action.label
+				}}
+			</button>
+		</div>
+	</div>
+</template>
+
+<script setup lang="ts">
+import { reactive } from 'vue'
+import { CheckIcon, ICON_SIZE, RefreshIcon } from '@/lib/icons'
+
+export interface ActionDef {
+	label: string
+	busyLabel?: string
+	doneLabel?: string
+}
+
+const props = withDefaults(
+	defineProps<{
+		title: string
+		description?: string
+		actions: ActionDef[]
+		tone?: 'default' | 'accent' | 'danger'
+	}>(),
+	{ description: undefined, tone: 'default' },
+)
+
+const emit = defineEmits<{ run: [index: number] }>()
+
+type BtnState = 'idle' | 'busy' | 'done'
+const states = reactive<BtnState[]>(props.actions.map(() => 'idle'))
+
+function run(i: number) {
+	if (states[i] !== 'idle') return
+	emit('run', i)
+	if (props.actions[i].busyLabel) {
+		states[i] = 'busy'
+		setTimeout(() => {
+			states[i] = 'done'
+			setTimeout(() => {
+				states[i] = 'idle'
+			}, 1400)
+		}, 1300)
+	} else {
+		states[i] = 'done'
+		setTimeout(() => {
+			states[i] = 'idle'
+		}, 1400)
+	}
+}
+</script>
+
+<style scoped>
+.zw-ab {
+	display: flex;
+	align-items: center;
+	gap: 12px;
+	padding: 11px 12px;
+}
+
+.zw-ab__icon {
+	width: 30px;
+	height: 30px;
+	border-radius: 6px;
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	background: var(--zw-chip-bg);
+	color: var(--zw-accent);
+	flex: 0 0 30px;
+}
+
+.zw-ab__icon--danger {
+	background: rgba(229, 57, 53, 0.1);
+	color: #e53935;
+}
+
+.zw-ab__body {
+	flex: 1;
+	min-width: 0;
+}
+
+.zw-ab__title {
+	font-size: 12px;
+	font-weight: 600;
+	color: var(--zw-fg);
+}
+
+.zw-ab--danger .zw-ab__title {
+	color: #c62828;
+}
+
+.zw-ab__desc {
+	font-size: 11px;
+	color: var(--zw-muted);
+	line-height: 1.4;
+	text-wrap: pretty;
+}
+
+.zw-ab__actions {
+	display: flex;
+	gap: 6px;
+	flex-shrink: 0;
+}
+
+.zw-ab__btn {
+	appearance: none;
+	cursor: pointer;
+	padding: 6px 12px;
+	border-radius: 5px;
+	font: var(--zw-text-caption);
+	font-weight: 600;
+	letter-spacing: 0.3px;
+	min-width: 76px;
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	gap: 5px;
+	border: 1px solid var(--zw-line2);
+	background: var(--zw-card);
+	color: var(--zw-fg);
+	transition:
+		background 0.15s,
+		color 0.15s,
+		border-color 0.15s;
+}
+
+.zw-ab__btn--accent {
+	background: var(--zw-accent);
+	color: #fff;
+	border-color: transparent;
+}
+
+.zw-ab__btn--danger {
+	background: transparent;
+	color: #c62828;
+	border-color: rgba(229, 57, 53, 0.45);
+}
+
+.zw-ab__btn--done {
+	background: rgba(67, 160, 71, 0.12);
+	color: #2e7d32;
+	border-color: transparent;
+}
+
+.zw-ab__btn--busy {
+	opacity: 0.75;
+	cursor: default;
+}
+
+.zw-ab__spin {
+	animation: zw-spin 0.9s linear infinite;
+}
+
+@keyframes zw-spin {
+	to {
+		transform: rotate(360deg);
+	}
+}
+</style>

--- a/src/components/dashboard/components/ZwActionList.vue
+++ b/src/components/dashboard/components/ZwActionList.vue
@@ -1,0 +1,18 @@
+<template>
+	<div class="zw-al">
+		<slot />
+	</div>
+</template>
+
+<style scoped>
+.zw-al {
+	background: var(--zw-card);
+	border: 1px solid var(--zw-line);
+	border-radius: 6px;
+	overflow: hidden;
+}
+
+.zw-al > :deep(:not(:first-child)) {
+	border-top: 1px solid var(--zw-line);
+}
+</style>

--- a/src/components/dashboard/components/ZwNodeDetailsBody.vue
+++ b/src/components/dashboard/components/ZwNodeDetailsBody.vue
@@ -119,7 +119,78 @@
 						<ZwStatsCard title="Communication" :items="commStats" />
 						<ZwStatsCard title="Messages" :items="messageStats" />
 					</div>
-					<ZwPropTable v-else :rows="debugRows" />
+					<ZwActionList v-else>
+						<ZwActionBtn
+							title="Ping"
+							description="Send a no-op command to check the node responds."
+							:actions="[
+								{
+									label: 'Ping',
+									busyLabel: 'Pinging…',
+									doneLabel: 'Sent',
+								},
+							]"
+							tone="accent"
+							@run="emit('action', device, { type: 'ping' })"
+						>
+							<template #icon
+								><PulseIcon :size="ICON_SIZE.std"
+							/></template>
+						</ZwActionBtn>
+						<ZwActionBtn
+							title="Re-interview node"
+							description="Clear all info and run a fresh interview."
+							:actions="[
+								{
+									label: 'Interview',
+									busyLabel: 'Interviewing…',
+									doneLabel: 'Queued',
+								},
+							]"
+							@run="emit('action', device, { type: 'interview' })"
+						>
+							<template #icon
+								><InterviewIcon :size="ICON_SIZE.std"
+							/></template>
+						</ZwActionBtn>
+						<ZwActionBtn
+							title="Rebuild routes"
+							description="Recompute the mesh routes between the controller and this node."
+							:actions="[
+								{
+									label: 'Rebuild',
+									busyLabel: 'Rebuilding…',
+									doneLabel: 'Done',
+								},
+							]"
+							@run="emit('action', device, { type: 'rebuild' })"
+						>
+							<template #icon
+								><NetworkIcon :size="ICON_SIZE.std"
+							/></template>
+						</ZwActionBtn>
+						<ZwActionBtn
+							title="Export node JSON"
+							description="Download this node's definition for backup or sharing."
+							:actions="[
+								{ label: 'UI', doneLabel: 'Saved' },
+								{ label: 'Driver', doneLabel: 'Saved' },
+							]"
+							@run="
+								(i: number) =>
+									emit('action', device, {
+										type:
+											i === 0
+												? 'export-ui'
+												: 'export-json',
+									})
+							"
+						>
+							<template #icon
+								><DownloadIcon :size="ICON_SIZE.std"
+							/></template>
+						</ZwActionBtn>
+					</ZwActionList>
 				</Tabs.Panel>
 
 				<Tabs.Panel
@@ -150,8 +221,17 @@ import ZwPrimaryDisplay from './ZwPrimaryDisplay.vue'
 import ZwPropTable from './ZwPropTable.vue'
 import ZwSecurityPanel from './ZwSecurityPanel.vue'
 import ZwStatsCard, { type StatsItem } from './ZwStatsCard.vue'
+import ZwActionList from './ZwActionList.vue'
+import ZwActionBtn from './ZwActionBtn.vue'
 import ZwNodeEvents from './ZwNodeEvents.vue'
 import ZwValuesView from './ZwValuesView.vue'
+import {
+	DownloadIcon,
+	ICON_SIZE,
+	InterviewIcon,
+	NetworkIcon,
+	PulseIcon,
+} from '@/lib/icons'
 import {
 	RAIL_WIDTH_BREAKPOINT,
 	RAIL_WIDTH_COMPACT,
@@ -282,14 +362,6 @@ const messageStats = computed<StatsItem[]>(() => {
 		{ label: 'Dropped RX', value: s?.messagesDroppedRX ?? 0 },
 	]
 })
-
-const debugRows = computed<[string, string | number][]>(() => [
-	['Endpoint count', '1'],
-	['Routing scheme', '—'],
-	['Tx power', String(props.device.txPower ?? 0) + ' dBm'],
-	['Wakeup interval', props.device.power.type === 'battery' ? '3600s' : '—'],
-	['Generic device class', props.device.archetype.label],
-])
 
 const advancedCommands = computed<{ label: string; action: DeviceAction }[]>(
 	() =>

--- a/src/lib/dashboard-types.ts
+++ b/src/lib/dashboard-types.ts
@@ -202,6 +202,7 @@ export type DeviceAction =
 	| { type: 'rebuild' }
 	| { type: 'remove' }
 	| { type: 'export' }
+	| { type: 'export-ui' }
 	| { type: 'clear' }
 	| { type: 'heal' }
 	| { type: 'backup-nvm' }

--- a/src/views/ControlPanelNew.vue
+++ b/src/views/ControlPanelNew.vue
@@ -29,6 +29,7 @@ import {
 	type ActionStatus,
 } from '@/lib/deviceActionPending.ts'
 import { manager, instances } from '@/lib/instanceManager'
+import useBaseStore from '@/stores/base'
 
 interface AppLike {
 	apiRequest: (
@@ -67,7 +68,24 @@ function completeAction(key: string, ok: boolean) {
 	})
 }
 
+function downloadJson(data: unknown, filename: string) {
+	const json = JSON.stringify(data, null, 2)
+	const blob = new Blob([json], { type: 'text/plain' })
+	const a = document.createElement('a')
+	a.href = URL.createObjectURL(blob)
+	a.download = filename
+	document.body.appendChild(a)
+	a.click()
+	document.body.removeChild(a)
+	URL.revokeObjectURL(a.href)
+}
+
 async function onAction(device: Device, action: DeviceAction) {
+	if (action.type === 'export-ui') {
+		const node = useBaseStore().getNode(device.nodeId)
+		if (node) downloadJson(node, `node_${device.nodeId}.json`)
+		return
+	}
 	const req = dispatchAction(device, action)
 	const app = appInstance()
 	if (!app) {


### PR DESCRIPTION
Introduce ZwActionList and ZwActionBtn — reusable action-row components with idle→busy→done transient states.

Replace the Debug tab's property table (for nodes) with four diagnostic action rows: Ping, Re-interview, Rebuild routes, and Export JSON (with UI/Driver sub-buttons). Controller Debug tab stays unchanged (communication stats).

Add `export-ui` device action type for local node JSON export.

<img width="798" height="306" alt="image" src="https://github.com/user-attachments/assets/8630b566-84b1-473c-b8e5-6ae9fd503557" />
