### PR TITLE
feat(ui): move some bulk actions to Associations tab

### DIFF
--- a/src/components/dashboard/components/ZwAssociationsTab.vue
+++ b/src/components/dashboard/components/ZwAssociationsTab.vue
@@ -1,6 +1,9 @@
 <template>
 	<div class="zw-assoc">
 		<div class="zw-assoc__groups">
+			<div v-if="!groups.length" class="zw-assoc__empty">
+				No association groups available.
+			</div>
 			<div v-for="g in groups" :key="g.name" class="zw-assoc__group">
 				<span class="zw-assoc__name">
 					<LinkIcon
@@ -73,20 +76,10 @@ interface AssocGroup {
 const groups = computed<AssocGroup[]>(() => {
 	const node = baseStore.getNode(props.device.nodeId)
 	const raw = node?.groups ?? []
-	if (!raw.length) {
-		return [
-			{ name: 'Lifeline', members: 'Controller (node 1)', count: '1/5' },
-			{ name: 'NodeID_1', members: '—', count: '0/5' },
-			{ name: 'Endpoint', members: '—', count: '0/5' },
-		]
-	}
 	return raw.map((g: Record<string, unknown>) => ({
-		name: String(g.label ?? g.text ?? `Group ${g.value ?? ''}`),
-		members:
-			Array.isArray(g.multiChannelNodeIds) && g.multiChannelNodeIds.length
-				? g.multiChannelNodeIds.join(', ')
-				: '—',
-		count: `${Array.isArray(g.multiChannelNodeIds) ? g.multiChannelNodeIds.length : 0}/${g.maxNodes ?? '?'}`,
+		name: String(g.title ?? `Group ${g.value ?? '?'}`),
+		members: '—',
+		count: `?/${g.maxNodes ?? '?'}`,
 	}))
 })
 </script>
@@ -133,5 +126,11 @@ const groups = computed<AssocGroup[]>(() => {
 
 .zw-assoc__count {
 	color: var(--zw-muted);
+}
+
+.zw-assoc__empty {
+	font-size: 12px;
+	color: var(--zw-muted);
+	padding: 9px 11px;
 }
 </style>

--- a/src/components/dashboard/components/ZwAssociationsTab.vue
+++ b/src/components/dashboard/components/ZwAssociationsTab.vue
@@ -1,0 +1,137 @@
+<template>
+	<div class="zw-assoc">
+		<div class="zw-assoc__groups">
+			<div v-for="g in groups" :key="g.name" class="zw-assoc__group">
+				<span class="zw-assoc__name">
+					<LinkIcon
+						:size="ICON_SIZE.caret"
+						class="zw-assoc__link-icon"
+					/>
+					{{ g.name }}
+				</span>
+				<span class="zw-assoc__members">{{ g.members }}</span>
+				<span class="zw-assoc__count">{{ g.count }}</span>
+			</div>
+		</div>
+
+		<ZwActionList>
+			<ZwActionBtn
+				title="Clear all associations"
+				description="Remove every target from this node's association groups."
+				:actions="[
+					{
+						label: 'Clear',
+						busyLabel: 'Clearing…',
+						doneLabel: 'Cleared',
+					},
+				]"
+				tone="danger"
+				@run="emit('action', device, { type: 'clear-associations' })"
+			>
+				<template #icon><TrashIcon :size="ICON_SIZE.std" /></template>
+			</ZwActionBtn>
+			<ZwActionBtn
+				title="Remove from all associations"
+				description="Remove this node as a target from every other node's groups."
+				:actions="[
+					{
+						label: 'Remove',
+						busyLabel: 'Removing…',
+						doneLabel: 'Removed',
+					},
+				]"
+				tone="danger"
+				@run="
+					emit('action', device, { type: 'remove-all-associations' })
+				"
+			>
+				<template #icon><LinkIcon :size="ICON_SIZE.std" /></template>
+			</ZwActionBtn>
+		</ZwActionList>
+	</div>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import ZwActionList from './ZwActionList.vue'
+import ZwActionBtn from './ZwActionBtn.vue'
+import { ICON_SIZE, LinkIcon, TrashIcon } from '@/lib/icons'
+import useBaseStore from '@/stores/base'
+import type { Device, DeviceAction } from '@/lib/dashboard-types'
+
+const props = defineProps<{ device: Device }>()
+const emit = defineEmits<{ action: [Device, DeviceAction] }>()
+
+const baseStore = useBaseStore()
+
+interface AssocGroup {
+	name: string
+	members: string
+	count: string
+}
+
+const groups = computed<AssocGroup[]>(() => {
+	const node = baseStore.getNode(props.device.nodeId)
+	const raw = node?.groups ?? []
+	if (!raw.length) {
+		return [
+			{ name: 'Lifeline', members: 'Controller (node 1)', count: '1/5' },
+			{ name: 'NodeID_1', members: '—', count: '0/5' },
+			{ name: 'Endpoint', members: '—', count: '0/5' },
+		]
+	}
+	return raw.map((g: Record<string, unknown>) => ({
+		name: String(g.label ?? g.text ?? `Group ${g.value ?? ''}`),
+		members:
+			Array.isArray(g.multiChannelNodeIds) && g.multiChannelNodeIds.length
+				? g.multiChannelNodeIds.join(', ')
+				: '—',
+		count: `${Array.isArray(g.multiChannelNodeIds) ? g.multiChannelNodeIds.length : 0}/${g.maxNodes ?? '?'}`,
+	}))
+})
+</script>
+
+<style scoped>
+.zw-assoc {
+	display: flex;
+	flex-direction: column;
+	gap: 12px;
+}
+
+.zw-assoc__groups {
+	display: flex;
+	flex-direction: column;
+	gap: 6px;
+}
+
+.zw-assoc__group {
+	display: grid;
+	grid-template-columns: 120px 1fr auto;
+	align-items: center;
+	gap: 8px;
+	padding: 9px 11px;
+	background: var(--zw-card);
+	border: 1px solid var(--zw-line);
+	border-radius: 5px;
+	font-family: var(--zw-mono);
+	font-size: 11px;
+}
+
+.zw-assoc__name {
+	display: inline-flex;
+	align-items: center;
+	gap: 6px;
+}
+
+.zw-assoc__link-icon {
+	color: var(--zw-muted);
+}
+
+.zw-assoc__members {
+	color: var(--zw-muted);
+}
+
+.zw-assoc__count {
+	color: var(--zw-muted);
+}
+</style>

--- a/src/components/dashboard/components/ZwNodeDetailsBody.vue
+++ b/src/components/dashboard/components/ZwNodeDetailsBody.vue
@@ -81,8 +81,8 @@
 					<ZwSecurityPanel :device="device" />
 				</Tabs.Panel>
 
-				<Tabs.Panel value="groups" class="zw-nd__content">
-					<ZwPropTable :rows="groupsStub" />
+				<Tabs.Panel value="associations" class="zw-nd__content">
+					<ZwAssociationsTab :device="device" @action="onAction" />
 				</Tabs.Panel>
 
 				<Tabs.Panel
@@ -223,6 +223,7 @@ import ZwSecurityPanel from './ZwSecurityPanel.vue'
 import ZwStatsCard, { type StatsItem } from './ZwStatsCard.vue'
 import ZwActionList from './ZwActionList.vue'
 import ZwActionBtn from './ZwActionBtn.vue'
+import ZwAssociationsTab from './ZwAssociationsTab.vue'
 import ZwNodeEvents from './ZwNodeEvents.vue'
 import ZwValuesView from './ZwValuesView.vue'
 import {
@@ -259,7 +260,7 @@ function onAction(d: Device, a: DeviceAction) {
 type TabId =
 	| 'values'
 	| 'summary'
-	| 'groups'
+	| 'associations'
 	| 'updates'
 	| 'events'
 	| 'debug'
@@ -268,7 +269,7 @@ type TabId =
 const ALL_TABS: { id: TabId; label: string }[] = [
 	{ id: 'values', label: 'Values' },
 	{ id: 'summary', label: 'Summary' },
-	{ id: 'groups', label: 'Groups' },
+	{ id: 'associations', label: 'Associations' },
 	{ id: 'updates', label: 'Updates' },
 	{ id: 'events', label: 'Events' },
 	{ id: 'debug', label: 'Debug' },
@@ -334,13 +335,6 @@ const fwRows = computed<[string, string | number][]>(() => [
 	['Version', props.device.firmware?.node ?? '—'],
 	['SDK', props.device.firmware?.sdk ?? '—'],
 ])
-
-// Placeholder association-group rows.
-const groupsStub: [string, string][] = [
-	['Lifeline', '1 → Controller'],
-	['NodeID_1', '—'],
-	['Endpoint', '—'],
-]
 
 const commStats = computed<StatsItem[]>(() => {
 	const s = props.device.commStats

--- a/src/lib/dashboard-types.ts
+++ b/src/lib/dashboard-types.ts
@@ -215,3 +215,5 @@ export type DeviceAction =
 	| { type: 'include' }
 	| { type: 'replace-failed' }
 	| { type: 'exclude' }
+	| { type: 'clear-associations' }
+	| { type: 'remove-all-associations' }

--- a/src/lib/device-actions.ts
+++ b/src/lib/device-actions.ts
@@ -81,6 +81,15 @@ export const ACTION_DISPATCHERS: {
 		args: ['replaceFailed'],
 	}),
 	exclude: () => ({ api: 'startExclusion', args: [] }),
+	'export-ui': (d) => ({ api: 'dumpNode', args: [d.nodeId] }),
+	'clear-associations': (d) => ({
+		api: 'removeAllAssociations',
+		args: [d.nodeId],
+	}),
+	'remove-all-associations': (d) => ({
+		api: 'removeNodeFromAllAssociations',
+		args: [d.nodeId],
+	}),
 }
 
 export function dispatchAction(


### PR DESCRIPTION
Rename the "Groups" tab to "Associations" and replace the stub ZwPropTable with ZwAssociationsTab. The new component displays association group rows (name, members, capacity) and provides two bulk actions via ZwActionList: "Clear all associations" and "Remove from all associations".

Note that this does not yet make the associations table/dialog functional again, but it restores the two options that were in the "advanced" node menu:
<img width="789" height="235" alt="image" src="https://github.com/user-attachments/assets/33caaba8-a3d6-4653-8b48-1b4e5bce001c" />
