### PR TITLE
feat(ui): rebuild Updates tab with firmware management surface

### DIFF
--- a/src/assets/css/tokens.css
+++ b/src/assets/css/tokens.css
@@ -32,6 +32,8 @@
 	--zw-bg-soft: rgb(var(--v0-background-soft));
 	--zw-card: rgb(var(--v0-surface));
 
+	--zw-on-accent: rgb(var(--v0-on-primary));
+
 	/* Alpha-based — on-surface is black in light theme, white in dark.
 	   These automatically flip when the user switches themes. */
 	--zw-fg: rgba(var(--v0-on-surface), 0.87);

--- a/src/components/dashboard/atoms/ZwCheckToggle.vue
+++ b/src/components/dashboard/atoms/ZwCheckToggle.vue
@@ -1,0 +1,70 @@
+<template>
+	<button
+		type="button"
+		class="zw-ct"
+		@click="emit('update:modelValue', !modelValue)"
+	>
+		<span class="zw-ct__box" :class="{ 'zw-ct__box--on': modelValue }">
+			<CheckIcon
+				v-if="modelValue"
+				:size="ICON_SIZE.pill"
+				class="zw-ct__check"
+			/>
+		</span>
+		<span class="zw-ct__label">{{ label }}</span>
+	</button>
+</template>
+
+<script setup lang="ts">
+import { CheckIcon, ICON_SIZE } from '@/lib/icons'
+
+defineProps<{
+	modelValue: boolean
+	label: string
+}>()
+
+const emit = defineEmits<{ 'update:modelValue': [boolean] }>()
+</script>
+
+<style scoped>
+.zw-ct {
+	appearance: none;
+	border: none;
+	background: transparent;
+	cursor: pointer;
+	display: inline-flex;
+	align-items: center;
+	gap: 7px;
+	padding: 0;
+	color: var(--zw-fg);
+	font: inherit;
+}
+
+.zw-ct__box {
+	width: 16px;
+	height: 16px;
+	border-radius: 4px;
+	flex: 0 0 16px;
+	border: 1.5px solid rgba(0, 0, 0, 0.3);
+	background: transparent;
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	transition:
+		background 0.12s,
+		border-color 0.12s;
+}
+
+.zw-ct__box--on {
+	background: var(--zw-accent);
+	border-color: var(--zw-accent);
+}
+
+.zw-ct__check {
+	color: #fff;
+}
+
+.zw-ct__label {
+	font-size: 12px;
+}
+</style>

--- a/src/components/dashboard/atoms/ZwCheckToggle.vue
+++ b/src/components/dashboard/atoms/ZwCheckToggle.vue
@@ -2,6 +2,8 @@
 	<button
 		type="button"
 		class="zw-ct"
+		role="switch"
+		:aria-checked="modelValue"
 		@click="emit('update:modelValue', !modelValue)"
 	>
 		<span class="zw-ct__box" :class="{ 'zw-ct__box--on': modelValue }">
@@ -45,7 +47,7 @@ const emit = defineEmits<{ 'update:modelValue': [boolean] }>()
 	height: 16px;
 	border-radius: 4px;
 	flex: 0 0 16px;
-	border: 1.5px solid rgba(0, 0, 0, 0.3);
+	border: 1.5px solid rgba(var(--v0-on-surface), 0.3);
 	background: transparent;
 	display: inline-flex;
 	align-items: center;
@@ -61,7 +63,7 @@ const emit = defineEmits<{ 'update:modelValue': [boolean] }>()
 }
 
 .zw-ct__check {
-	color: #fff;
+	color: var(--zw-on-accent);
 }
 
 .zw-ct__label {

--- a/src/components/dashboard/components/ZwNodeDetailsBody.vue
+++ b/src/components/dashboard/components/ZwNodeDetailsBody.vue
@@ -62,6 +62,14 @@
 						class="zw-nd__tab"
 					>
 						{{ t.label }}
+						<span
+							v-if="
+								t.id === 'updates' &&
+								!device.isController &&
+								device.hasUpdate
+							"
+							class="zw-nd__tab-dot"
+						/>
 					</Tabs.Item>
 				</Tabs.List>
 
@@ -85,22 +93,8 @@
 					<ZwAssociationsTab :device="device" @action="onAction" />
 				</Tabs.Panel>
 
-				<Tabs.Panel
-					value="updates"
-					class="zw-nd__content zw-nd__updates"
-				>
-					<div v-if="device.hasUpdate" class="zw-nd__update-card">
-						<div class="zw-nd__update-current">
-							Current {{ device.firmware?.node ?? '—' }}
-						</div>
-						<div class="zw-nd__update-line">
-							Update available — see the device drawer's footer to
-							apply.
-						</div>
-					</div>
-					<div v-else class="zw-nd__empty">
-						No firmware update available.
-					</div>
+				<Tabs.Panel value="updates" class="zw-nd__content">
+					<ZwUpdatesTab :device="device" @action="onAction" />
 				</Tabs.Panel>
 
 				<!-- Events is omitted from the tab bar in the split layout
@@ -224,6 +218,7 @@ import ZwStatsCard, { type StatsItem } from './ZwStatsCard.vue'
 import ZwActionList from './ZwActionList.vue'
 import ZwActionBtn from './ZwActionBtn.vue'
 import ZwAssociationsTab from './ZwAssociationsTab.vue'
+import ZwUpdatesTab from './ZwUpdatesTab.vue'
 import ZwNodeEvents from './ZwNodeEvents.vue'
 import ZwValuesView from './ZwValuesView.vue'
 import {
@@ -538,6 +533,20 @@ const advancedCommands = computed<{ label: string; action: DeviceAction }[]>(
 	outline-offset: 1px;
 }
 
+.zw-nd__tab-dot {
+	width: 7px;
+	height: 7px;
+	border-radius: 50%;
+	background: var(--zw-accent);
+	box-shadow: 0 0 0 1.5px #fff;
+	flex-shrink: 0;
+}
+
+.zw-nd__tab[data-selected='true'] .zw-nd__tab-dot {
+	background: #fff;
+	box-shadow: none;
+}
+
 /* ── Content ─────────────────────────────────────────────────── */
 .zw-nd__content {
 	padding: 14px 16px 18px;
@@ -576,31 +585,6 @@ const advancedCommands = computed<{ label: string; action: DeviceAction }[]>(
 	color: var(--zw-muted);
 	text-align: center;
 	font-style: italic;
-}
-
-.zw-nd__updates {
-	display: flex;
-	flex-direction: column;
-	gap: 8px;
-}
-
-.zw-nd__update-card {
-	background: var(--zw-card);
-	border: 1px solid var(--zw-line);
-	border-radius: 6px;
-	padding: 12px;
-}
-
-.zw-nd__update-current {
-	font-family: var(--zw-mono);
-	font-size: 11px;
-	color: var(--zw-muted);
-	margin-bottom: 4px;
-}
-
-.zw-nd__update-line {
-	font-size: 13px;
-	color: var(--zw-fg);
 }
 
 .zw-nd__advanced {

--- a/src/components/dashboard/components/ZwNodeDetailsBody.vue
+++ b/src/components/dashboard/components/ZwNodeDetailsBody.vue
@@ -525,7 +525,7 @@ const advancedCommands = computed<{ label: string; action: DeviceAction }[]>(
 /* V0 Tabs.Item emits `data-selected="true"` on the active tab. */
 .zw-nd__tab[data-selected='true'] {
 	background: var(--zw-accent);
-	color: #fff;
+	color: var(--zw-on-accent);
 }
 
 .zw-nd__tab:focus-visible {
@@ -538,12 +538,12 @@ const advancedCommands = computed<{ label: string; action: DeviceAction }[]>(
 	height: 7px;
 	border-radius: 50%;
 	background: var(--zw-accent);
-	box-shadow: 0 0 0 1.5px #fff;
+	box-shadow: 0 0 0 1.5px var(--zw-card);
 	flex-shrink: 0;
 }
 
 .zw-nd__tab[data-selected='true'] .zw-nd__tab-dot {
-	background: #fff;
+	background: var(--zw-on-accent);
 	box-shadow: none;
 }
 

--- a/src/components/dashboard/components/ZwUpdatesTab.vue
+++ b/src/components/dashboard/components/ZwUpdatesTab.vue
@@ -1,0 +1,728 @@
+<template>
+	<div class="zw-fw">
+		<!-- current + check -->
+		<div class="zw-fw__header">
+			<div class="zw-fw__current">
+				<span class="zw-fw__overline">Current firmware</span>
+				<span class="zw-fw__version"
+					>v{{ device.firmware?.node ?? '—' }}</span
+				>
+				<span class="zw-fw__checked"
+					>Last checked {{ lastChecked }}</span
+				>
+			</div>
+			<button
+				type="button"
+				class="zw-fw__check-btn"
+				:disabled="checking"
+				@click="check"
+			>
+				<RefreshIcon
+					:size="ICON_SIZE.dense"
+					:class="{ 'zw-fw__spin': checking }"
+				/>
+				{{ checking ? 'Checking…' : 'Check for updates' }}
+			</button>
+		</div>
+
+		<!-- filters -->
+		<div class="zw-fw__filters">
+			<ZwCheckToggle v-model="includePre" label="Include prereleases" />
+			<ZwCheckToggle v-model="showDown" label="Show downgrades" />
+		</div>
+
+		<!-- flashing banner -->
+		<div v-if="flash" class="zw-fw__flash">
+			<div class="zw-fw__flash-head">
+				<span class="zw-fw__flash-label">
+					<RefreshIcon
+						:size="ICON_SIZE.dense"
+						class="zw-fw__spin zw-fw__flash-icon"
+					/>
+					Flashing <span class="zw-fw__mono">{{ flash.version }}</span
+					>…
+				</span>
+				<span class="zw-fw__mono zw-fw__flash-pct"
+					>{{ flash.pct }}%</span
+				>
+			</div>
+			<div class="zw-fw__progress-track">
+				<div
+					class="zw-fw__progress-fill"
+					:style="{ width: flash.pct + '%' }"
+				/>
+			</div>
+			<div class="zw-fw__flash-foot">
+				<span class="zw-fw__flash-hint"
+					>Keep the device powered until this completes.</span
+				>
+				<button
+					type="button"
+					class="zw-fw__btn zw-fw__btn--danger"
+					@click="abortInstall"
+				>
+					Abort
+				</button>
+			</div>
+		</div>
+
+		<!-- available updates -->
+		<div v-if="!flash" class="zw-fw__list">
+			<span class="zw-fw__overline">
+				{{
+					visible.length
+						? `Available updates (${visible.length})`
+						: 'Available updates'
+				}}
+			</span>
+
+			<div v-if="visible.length === 0" class="zw-fw__empty">
+				<CheckIcon :size="ICON_SIZE.std" class="zw-fw__empty-icon" />
+				<span>
+					<strong>You're on the latest stable firmware.</strong>
+					<template v-if="hiddenCount > 0">
+						{{ ' ' }}{{ hiddenCount }}
+						{{ hiddenCount === 1 ? 'version is' : 'versions are' }}
+						hidden by the filters above.
+					</template>
+				</span>
+			</div>
+
+			<div v-for="c in visible" :key="c.version" class="zw-fw__card">
+				<div class="zw-fw__card-head">
+					<span class="zw-fw__card-version">{{ c.version }}</span>
+					<span class="zw-fw__card-tags">
+						<ZwPill v-if="c.latest" tone="accent" size="sm"
+							>latest</ZwPill
+						>
+						<ZwPill
+							v-if="c.channel === 'prerelease'"
+							tone="asleep"
+							size="sm"
+						>
+							prerelease
+						</ZwPill>
+						<ZwPill v-else tone="neutral" size="sm">stable</ZwPill>
+						<ZwPill v-if="c.downgrade" tone="warn" size="sm"
+							>downgrade</ZwPill
+						>
+					</span>
+					<span class="zw-fw__spacer" />
+					<span
+						v-if="installed === c.version"
+						class="zw-fw__installed"
+					>
+						<CheckIcon :size="ICON_SIZE.dense" /> Installed
+					</span>
+					<button
+						v-else
+						type="button"
+						class="zw-fw__btn"
+						:class="
+							c.downgrade
+								? 'zw-fw__btn--ghost'
+								: 'zw-fw__btn--accent'
+						"
+						@click="startInstall(c.version)"
+					>
+						<DownloadIcon :size="ICON_SIZE.dense" />
+						{{ c.downgrade ? 'Downgrade' : 'Install' }}
+					</button>
+				</div>
+				<div v-if="c.changelog?.length" class="zw-fw__changelog">
+					<div
+						class="zw-fw__changelog-body"
+						:class="{
+							'zw-fw__changelog-body--clamped': !expandedLogs.has(
+								c.version,
+							),
+							'zw-fw__changelog-body--expanded': expandedLogs.has(
+								c.version,
+							),
+						}"
+					>
+						<div
+							v-for="(line, li) in c.changelog"
+							:key="li"
+							class="zw-fw__changelog-line"
+							:class="{
+								'zw-fw__changelog-line--heading':
+									line.startsWith('##'),
+							}"
+						>
+							{{
+								line.startsWith('##')
+									? line.replace(/^##\s*/, '')
+									: `• ${line}`
+							}}
+						</div>
+						<div
+							v-if="
+								!expandedLogs.has(c.version) &&
+								c.changelog.length > 3
+							"
+							class="zw-fw__changelog-fade"
+						/>
+					</div>
+					<button
+						v-if="c.changelog.length > 3"
+						type="button"
+						class="zw-fw__changelog-toggle"
+						@click="toggleLog(c.version)"
+					>
+						<ChevronDownIcon
+							:size="ICON_SIZE.caret"
+							:class="{
+								'zw-fw__chev--open': expandedLogs.has(
+									c.version,
+								),
+							}"
+						/>
+						{{
+							expandedLogs.has(c.version)
+								? 'Show less'
+								: 'Show full changelog'
+						}}
+					</button>
+				</div>
+			</div>
+		</div>
+
+		<!-- upload from file -->
+		<div class="zw-fw__upload-section">
+			<span class="zw-fw__overline">Update from file</span>
+			<input
+				ref="fileInput"
+				type="file"
+				accept=".gbl,.otz,.ota,.hex,.bin,.hec"
+				class="zw-fw__file-input"
+				@change="onFileChange"
+			/>
+			<button
+				v-if="!uploadFile"
+				type="button"
+				class="zw-fw__drop"
+				@click="pickFile"
+			>
+				<UploadIcon :size="ICON_SIZE.topbar" class="zw-fw__drop-icon" />
+				<span class="zw-fw__drop-label">Choose a firmware file</span>
+				<span class="zw-fw__drop-hint"
+					>.gbl · .otz · .ota · .hex · .bin</span
+				>
+			</button>
+			<div v-else class="zw-fw__file-row">
+				<UploadIcon :size="ICON_SIZE.std" class="zw-fw__file-icon" />
+				<span class="zw-fw__file-name">{{ uploadFile }}</span>
+				<button
+					type="button"
+					class="zw-fw__file-remove"
+					title="Remove"
+					@click="uploadFile = null"
+				>
+					<XIcon :size="ICON_SIZE.inline" />
+				</button>
+				<button type="button" class="zw-fw__btn zw-fw__btn--accent">
+					<ZapIcon :size="ICON_SIZE.dense" /> Flash
+				</button>
+			</div>
+		</div>
+	</div>
+</template>
+
+<script setup lang="ts">
+import { ref, computed } from 'vue'
+import ZwPill from '@/components/dashboard/atoms/ZwPill.vue'
+import ZwCheckToggle from '@/components/dashboard/atoms/ZwCheckToggle.vue'
+import {
+	CheckIcon,
+	ChevronDownIcon,
+	DownloadIcon,
+	ICON_SIZE,
+	RefreshIcon,
+	UploadIcon,
+	XIcon,
+	ZapIcon,
+} from '@/lib/icons'
+import type { Device, DeviceAction } from '@/lib/dashboard-types'
+
+interface FwCandidate {
+	version: string
+	channel: 'stable' | 'prerelease'
+	changelog: string[]
+	downgrade: boolean
+	latest?: boolean
+}
+
+const props = defineProps<{ device: Device }>()
+const emit = defineEmits<{ action: [Device, DeviceAction] }>()
+
+const includePre = ref(false)
+const showDown = ref(false)
+const checking = ref(false)
+const lastChecked = ref('—')
+const flash = ref<{ version: string; pct: number } | null>(null)
+const installed = ref<string | null>(null)
+const expandedLogs = ref<Set<string>>(new Set())
+const uploadFile = ref<string | null>(null)
+const fileInput = ref<HTMLInputElement | null>(null)
+let flashTimer: ReturnType<typeof setInterval> | null = null
+
+const candidates = computed<FwCandidate[]>(() => {
+	const updates = props.device.availableFirmwareUpdates
+	if (!updates?.length) return []
+	return updates.map((u, i) => ({
+		version: u.version,
+		channel: u.channel ?? 'stable',
+		changelog: u.changelog ?? [],
+		downgrade: u.downgrade ?? false,
+		latest: i === 0 && !u.downgrade,
+	}))
+})
+
+const visible = computed(() =>
+	candidates.value.filter(
+		(c) =>
+			(includePre.value || c.channel !== 'prerelease') &&
+			(showDown.value || !c.downgrade),
+	),
+)
+
+const hiddenCount = computed(
+	() => candidates.value.length - visible.value.length,
+)
+
+function check() {
+	if (checking.value) return
+	checking.value = true
+	emit('action', props.device, {
+		type: 'check-firmware-updates',
+	} as DeviceAction)
+	setTimeout(() => {
+		checking.value = false
+		lastChecked.value = 'just now'
+	}, 1300)
+}
+
+function startInstall(version: string) {
+	if (flashTimer) clearInterval(flashTimer)
+	installed.value = null
+	flash.value = { version, pct: 0 }
+	flashTimer = setInterval(() => {
+		if (!flash.value) return
+		if (flash.value.pct >= 100) {
+			if (flashTimer) clearInterval(flashTimer)
+			installed.value = flash.value.version
+			flash.value = null
+			return
+		}
+		flash.value = {
+			...flash.value,
+			pct: Math.min(100, flash.value.pct + 7),
+		}
+	}, 300)
+}
+
+function abortInstall() {
+	if (flashTimer) clearInterval(flashTimer)
+	flash.value = null
+}
+
+function toggleLog(version: string) {
+	const next = new Set(expandedLogs.value)
+	if (next.has(version)) next.delete(version)
+	else next.add(version)
+	expandedLogs.value = next
+}
+
+function pickFile() {
+	fileInput.value?.click()
+}
+
+function onFileChange(e: Event) {
+	const input = e.target as HTMLInputElement
+	uploadFile.value = input.files?.[0]?.name ?? null
+}
+</script>
+
+<style scoped>
+.zw-fw {
+	display: flex;
+	flex-direction: column;
+	gap: 10px;
+}
+
+.zw-fw__overline {
+	font-family: var(--zw-mono);
+	font-size: 10.5px;
+	font-weight: 600;
+	color: var(--zw-muted);
+	text-transform: uppercase;
+	letter-spacing: 0.6px;
+}
+
+.zw-fw__mono {
+	font-family: var(--zw-mono);
+}
+
+/* header */
+.zw-fw__header {
+	display: flex;
+	align-items: flex-start;
+	justify-content: space-between;
+	gap: 12px;
+	flex-wrap: wrap;
+}
+
+.zw-fw__current {
+	display: flex;
+	flex-direction: column;
+	gap: 3px;
+}
+
+.zw-fw__version {
+	font-family: var(--zw-mono);
+	font-size: 20px;
+	font-weight: 600;
+}
+
+.zw-fw__checked {
+	font-size: 11px;
+	color: var(--zw-muted);
+}
+
+.zw-fw__check-btn {
+	appearance: none;
+	border: 1px solid var(--zw-line);
+	background: var(--zw-card);
+	color: var(--zw-fg);
+	padding: 7px 14px;
+	border-radius: 6px;
+	cursor: pointer;
+	font: inherit;
+	font-size: 12px;
+	font-weight: 600;
+	display: inline-flex;
+	align-items: center;
+	gap: 6px;
+	white-space: nowrap;
+}
+
+.zw-fw__check-btn:disabled {
+	opacity: 0.7;
+	cursor: default;
+}
+
+/* filters */
+.zw-fw__filters {
+	display: flex;
+	gap: 16px;
+	flex-wrap: wrap;
+}
+
+/* flash banner */
+.zw-fw__flash {
+	background: var(--zw-bg-soft);
+	border-radius: 10px;
+	padding: 12px;
+}
+
+.zw-fw__flash-head {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	margin-bottom: 8px;
+}
+
+.zw-fw__flash-label {
+	display: inline-flex;
+	align-items: center;
+	gap: 6px;
+	font-size: 12px;
+	font-weight: 500;
+}
+
+.zw-fw__flash-icon {
+	color: var(--zw-accent);
+}
+
+.zw-fw__flash-pct {
+	font-size: 12px;
+	color: var(--zw-accent);
+}
+
+.zw-fw__progress-track {
+	height: 6px;
+	border-radius: 3px;
+	background: rgba(0, 0, 0, 0.1);
+	overflow: hidden;
+}
+
+.zw-fw__progress-fill {
+	height: 100%;
+	background: var(--zw-accent);
+	transition: width 0.3s linear;
+}
+
+.zw-fw__flash-foot {
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
+	margin-top: 10px;
+}
+
+.zw-fw__flash-hint {
+	font-size: 11px;
+	color: var(--zw-muted);
+}
+
+/* buttons */
+.zw-fw__btn {
+	appearance: none;
+	border: 1px solid transparent;
+	padding: 7px 14px;
+	border-radius: 6px;
+	cursor: pointer;
+	font: inherit;
+	font-size: 12px;
+	font-weight: 600;
+	display: inline-flex;
+	align-items: center;
+	gap: 6px;
+	white-space: nowrap;
+}
+
+.zw-fw__btn--accent {
+	background: var(--zw-accent);
+	color: #fff;
+	box-shadow: 0 1px 2px rgba(0, 0, 0, 0.18);
+}
+
+.zw-fw__btn--ghost {
+	background: var(--zw-card);
+	color: var(--zw-fg);
+	border-color: var(--zw-line);
+}
+
+.zw-fw__btn--danger {
+	background: transparent;
+	color: #e53935;
+	border-color: #e53935;
+}
+
+/* empty */
+.zw-fw__empty {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	background: var(--zw-bg-soft);
+	border-radius: 10px;
+	padding: 14px 12px;
+	font-size: 12px;
+	color: var(--zw-muted);
+}
+
+.zw-fw__empty-icon {
+	color: var(--zw-ok);
+	flex: 0 0 auto;
+}
+
+/* list */
+.zw-fw__list {
+	display: flex;
+	flex-direction: column;
+	gap: 8px;
+}
+
+/* card */
+.zw-fw__card {
+	border: 1px solid var(--zw-line);
+	border-radius: 10px;
+	background: var(--zw-card);
+	overflow: hidden;
+}
+
+.zw-fw__card-head {
+	display: flex;
+	align-items: center;
+	gap: 10px;
+	padding: 11px 12px;
+	flex-wrap: wrap;
+}
+
+.zw-fw__card-version {
+	font-family: var(--zw-mono);
+	font-size: 14px;
+	font-weight: 600;
+}
+
+.zw-fw__card-tags {
+	display: inline-flex;
+	gap: 4px;
+	flex-wrap: wrap;
+}
+
+.zw-fw__spacer {
+	flex: 1;
+}
+
+.zw-fw__installed {
+	display: inline-flex;
+	align-items: center;
+	gap: 5px;
+	font-size: 11px;
+	font-weight: 600;
+	color: var(--zw-ok);
+}
+
+/* changelog */
+.zw-fw__changelog {
+	padding: 0 12px 11px;
+}
+
+.zw-fw__changelog-body {
+	position: relative;
+	background: var(--zw-bg-soft);
+	border-radius: 8px;
+	padding: 10px;
+}
+
+.zw-fw__changelog-body--clamped {
+	max-height: 58px;
+	overflow: hidden;
+}
+
+.zw-fw__changelog-body--expanded {
+	max-height: 220px;
+	overflow-y: auto;
+}
+
+.zw-fw__changelog-line {
+	font-size: 11.5px;
+	color: var(--zw-muted);
+	line-height: 1.55;
+}
+
+.zw-fw__changelog-line--heading {
+	color: var(--zw-fg);
+	font-weight: 600;
+}
+
+.zw-fw__changelog-fade {
+	position: absolute;
+	left: 0;
+	right: 0;
+	bottom: 0;
+	height: 26px;
+	background: linear-gradient(transparent, var(--zw-bg-soft));
+	pointer-events: none;
+}
+
+.zw-fw__changelog-toggle {
+	appearance: none;
+	border: none;
+	background: transparent;
+	cursor: pointer;
+	font: inherit;
+	color: var(--zw-accent);
+	font-size: 11px;
+	font-weight: 600;
+	padding: 6px 0 0;
+	display: inline-flex;
+	align-items: center;
+	gap: 4px;
+}
+
+.zw-fw__chev--open {
+	transform: rotate(180deg);
+}
+
+/* spin */
+.zw-fw__spin {
+	animation: zw-spin 0.9s linear infinite;
+}
+
+@keyframes zw-spin {
+	to {
+		transform: rotate(360deg);
+	}
+}
+
+/* upload */
+.zw-fw__upload-section {
+	border-top: 1px dashed var(--zw-line);
+	padding-top: 10px;
+	display: flex;
+	flex-direction: column;
+	gap: 8px;
+}
+
+.zw-fw__file-input {
+	display: none;
+}
+
+.zw-fw__drop {
+	width: 100%;
+	appearance: none;
+	cursor: pointer;
+	font: inherit;
+	border: 1.5px dashed var(--zw-line);
+	border-radius: 10px;
+	background: var(--zw-bg-soft);
+	color: var(--zw-muted);
+	padding: 16px 12px;
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	gap: 6px;
+}
+
+.zw-fw__drop-icon {
+	color: var(--zw-accent);
+}
+
+.zw-fw__drop-label {
+	font-size: 12px;
+	color: var(--zw-fg);
+	font-weight: 500;
+}
+
+.zw-fw__drop-hint {
+	font-family: var(--zw-mono);
+	font-size: 10px;
+}
+
+.zw-fw__file-row {
+	display: flex;
+	align-items: center;
+	gap: 10px;
+	border: 1px solid var(--zw-line);
+	border-radius: 10px;
+	background: var(--zw-card);
+	padding: 10px 12px;
+}
+
+.zw-fw__file-icon {
+	color: var(--zw-accent);
+	flex: 0 0 auto;
+}
+
+.zw-fw__file-name {
+	flex: 1;
+	min-width: 0;
+	font-family: var(--zw-mono);
+	font-size: 12px;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+.zw-fw__file-remove {
+	appearance: none;
+	border: none;
+	background: transparent;
+	cursor: pointer;
+	color: var(--zw-muted);
+	padding: 4px;
+	display: inline-flex;
+}
+</style>

--- a/src/components/dashboard/components/ZwUpdatesTab.vue
+++ b/src/components/dashboard/components/ZwUpdatesTab.vue
@@ -194,7 +194,7 @@
 			<input
 				ref="fileInput"
 				type="file"
-				accept=".gbl,.otz,.ota,.hex,.bin,.hec"
+				:accept="FW_EXTENSIONS.join(',')"
 				class="zw-fw__file-input"
 				@change="onFileChange"
 			/>
@@ -206,9 +206,9 @@
 			>
 				<UploadIcon :size="ICON_SIZE.topbar" class="zw-fw__drop-icon" />
 				<span class="zw-fw__drop-label">Choose a firmware file</span>
-				<span class="zw-fw__drop-hint"
-					>.gbl · .otz · .ota · .hex · .bin</span
-				>
+				<span class="zw-fw__drop-hint">{{
+					FW_EXTENSIONS.join(' · ')
+				}}</span>
 			</button>
 			<div v-else class="zw-fw__file-row">
 				<UploadIcon :size="ICON_SIZE.std" class="zw-fw__file-icon" />
@@ -252,6 +252,8 @@ interface FwCandidate {
 	downgrade: boolean
 	latest?: boolean
 }
+
+const FW_EXTENSIONS = ['.gbl', '.otz', '.ota', '.hex', '.bin', '.hec'] as const
 
 const props = defineProps<{ device: Device }>()
 const emit = defineEmits<{ action: [Device, DeviceAction] }>()
@@ -453,7 +455,7 @@ function onFileChange(e: Event) {
 .zw-fw__progress-track {
 	height: 6px;
 	border-radius: 3px;
-	background: rgba(0, 0, 0, 0.1);
+	background: rgba(var(--v0-on-surface), 0.1);
 	overflow: hidden;
 }
 
@@ -493,8 +495,8 @@ function onFileChange(e: Event) {
 
 .zw-fw__btn--accent {
 	background: var(--zw-accent);
-	color: #fff;
-	box-shadow: 0 1px 2px rgba(0, 0, 0, 0.18);
+	color: var(--zw-on-accent);
+	box-shadow: 0 1px 2px rgba(var(--v0-on-surface), 0.18);
 }
 
 .zw-fw__btn--ghost {
@@ -505,8 +507,8 @@ function onFileChange(e: Event) {
 
 .zw-fw__btn--danger {
 	background: transparent;
-	color: #e53935;
-	border-color: #e53935;
+	color: var(--zw-danger);
+	border-color: var(--zw-danger);
 }
 
 /* empty */

--- a/src/components/dashboard/components/ZwUpdatesTab.vue
+++ b/src/components/dashboard/components/ZwUpdatesTab.vue
@@ -31,43 +31,8 @@
 			<ZwCheckToggle v-model="showDown" label="Show downgrades" />
 		</div>
 
-		<!-- flashing banner -->
-		<div v-if="flash" class="zw-fw__flash">
-			<div class="zw-fw__flash-head">
-				<span class="zw-fw__flash-label">
-					<RefreshIcon
-						:size="ICON_SIZE.dense"
-						class="zw-fw__spin zw-fw__flash-icon"
-					/>
-					Flashing <span class="zw-fw__mono">{{ flash.version }}</span
-					>…
-				</span>
-				<span class="zw-fw__mono zw-fw__flash-pct"
-					>{{ flash.pct }}%</span
-				>
-			</div>
-			<div class="zw-fw__progress-track">
-				<div
-					class="zw-fw__progress-fill"
-					:style="{ width: flash.pct + '%' }"
-				/>
-			</div>
-			<div class="zw-fw__flash-foot">
-				<span class="zw-fw__flash-hint"
-					>Keep the device powered until this completes.</span
-				>
-				<button
-					type="button"
-					class="zw-fw__btn zw-fw__btn--danger"
-					@click="abortInstall"
-				>
-					Abort
-				</button>
-			</div>
-		</div>
-
 		<!-- available updates -->
-		<div v-if="!flash" class="zw-fw__list">
+		<div class="zw-fw__list">
 			<span class="zw-fw__overline">
 				{{
 					visible.length
@@ -108,14 +73,7 @@
 						>
 					</span>
 					<span class="zw-fw__spacer" />
-					<span
-						v-if="installed === c.version"
-						class="zw-fw__installed"
-					>
-						<CheckIcon :size="ICON_SIZE.dense" /> Installed
-					</span>
 					<button
-						v-else
 						type="button"
 						class="zw-fw__btn"
 						:class="
@@ -123,13 +81,13 @@
 								? 'zw-fw__btn--ghost'
 								: 'zw-fw__btn--accent'
 						"
-						@click="startInstall(c.version)"
+						@click="installOTA(c)"
 					>
 						<DownloadIcon :size="ICON_SIZE.dense" />
 						{{ c.downgrade ? 'Downgrade' : 'Install' }}
 					</button>
 				</div>
-				<div v-if="c.changelog?.length" class="zw-fw__changelog">
+				<div v-if="c.changelogLines.length" class="zw-fw__changelog">
 					<div
 						class="zw-fw__changelog-body"
 						:class="{
@@ -142,7 +100,7 @@
 						}"
 					>
 						<div
-							v-for="(line, li) in c.changelog"
+							v-for="(line, li) in c.changelogLines"
 							:key="li"
 							class="zw-fw__changelog-line"
 							:class="{
@@ -159,13 +117,13 @@
 						<div
 							v-if="
 								!expandedLogs.has(c.version) &&
-								c.changelog.length > 3
+								c.changelogLines.length > 3
 							"
 							class="zw-fw__changelog-fade"
 						/>
 					</div>
 					<button
-						v-if="c.changelog.length > 3"
+						v-if="c.changelogLines.length > 3"
 						type="button"
 						class="zw-fw__changelog-toggle"
 						@click="toggleLog(c.version)"
@@ -221,7 +179,11 @@
 				>
 					<XIcon :size="ICON_SIZE.inline" />
 				</button>
-				<button type="button" class="zw-fw__btn zw-fw__btn--accent">
+				<button
+					type="button"
+					class="zw-fw__btn zw-fw__btn--accent"
+					@click="flashFile"
+				>
 					<ZapIcon :size="ICON_SIZE.dense" /> Flash
 				</button>
 			</div>
@@ -231,6 +193,8 @@
 
 <script setup lang="ts">
 import { ref, computed } from 'vue'
+import { padVersion } from '@zwave-js/shared'
+import { compare } from 'semver'
 import ZwPill from '@/components/dashboard/atoms/ZwPill.vue'
 import ZwCheckToggle from '@/components/dashboard/atoms/ZwCheckToggle.vue'
 import {
@@ -243,14 +207,19 @@ import {
 	XIcon,
 	ZapIcon,
 } from '@/lib/icons'
-import type { Device, DeviceAction } from '@/lib/dashboard-types'
+import type {
+	Device,
+	DeviceAction,
+	FirmwareUpdateInfo,
+} from '@/lib/dashboard-types'
 
 interface FwCandidate {
 	version: string
 	channel: 'stable' | 'prerelease'
-	changelog: string[]
+	changelogLines: string[]
 	downgrade: boolean
-	latest?: boolean
+	latest: boolean
+	raw: FirmwareUpdateInfo
 }
 
 const FW_EXTENSIONS = ['.gbl', '.otz', '.ota', '.hex', '.bin', '.hec'] as const
@@ -262,22 +231,51 @@ const includePre = ref(false)
 const showDown = ref(false)
 const checking = ref(false)
 const lastChecked = ref('—')
-const flash = ref<{ version: string; pct: number } | null>(null)
-const installed = ref<string | null>(null)
 const expandedLogs = ref<Set<string>>(new Set())
 const uploadFile = ref<string | null>(null)
 const fileInput = ref<HTMLInputElement | null>(null)
-let flashTimer: ReturnType<typeof setInterval> | null = null
+
+function isLatest(u: FirmwareUpdateInfo, all: FirmwareUpdateInfo[]): boolean {
+	if (u.downgrade) return false
+	const upgrades = all.filter((c) => !c.downgrade)
+	if (upgrades.length === 0) return false
+	let best = upgrades[0]
+	for (let i = 1; i < upgrades.length; i++) {
+		try {
+			if (
+				compare(
+					padVersion(upgrades[i].version),
+					padVersion(best.version),
+				) > 0
+			) {
+				best = upgrades[i]
+			}
+		} catch {
+			// invalid semver — keep current best
+		}
+	}
+	return u.version === best.version
+}
 
 const candidates = computed<FwCandidate[]>(() => {
 	const updates = props.device.availableFirmwareUpdates
 	if (!updates?.length) return []
-	return updates.map((u, i) => ({
+	const sorted = [...updates].sort((a, b) => {
+		try {
+			return compare(padVersion(b.version), padVersion(a.version))
+		} catch {
+			return 0
+		}
+	})
+	return sorted.map((u) => ({
 		version: u.version,
 		channel: u.channel ?? 'stable',
-		changelog: u.changelog ?? [],
+		changelogLines: u.changelog
+			? u.changelog.split('\n').filter((l) => l.trim())
+			: [],
 		downgrade: u.downgrade ?? false,
-		latest: i === 0 && !u.downgrade,
+		latest: isLatest(u, sorted),
+		raw: u,
 	}))
 })
 
@@ -296,37 +294,15 @@ const hiddenCount = computed(
 function check() {
 	if (checking.value) return
 	checking.value = true
-	emit('action', props.device, {
-		type: 'check-firmware-updates',
-	} as DeviceAction)
+	emit('action', props.device, { type: 'check-firmware-updates' })
 	setTimeout(() => {
 		checking.value = false
 		lastChecked.value = 'just now'
 	}, 1300)
 }
 
-function startInstall(version: string) {
-	if (flashTimer) clearInterval(flashTimer)
-	installed.value = null
-	flash.value = { version, pct: 0 }
-	flashTimer = setInterval(() => {
-		if (!flash.value) return
-		if (flash.value.pct >= 100) {
-			if (flashTimer) clearInterval(flashTimer)
-			installed.value = flash.value.version
-			flash.value = null
-			return
-		}
-		flash.value = {
-			...flash.value,
-			pct: Math.min(100, flash.value.pct + 7),
-		}
-	}, 300)
-}
-
-function abortInstall() {
-	if (flashTimer) clearInterval(flashTimer)
-	flash.value = null
+function installOTA(c: FwCandidate) {
+	emit('action', props.device, { type: 'firmware-install', update: c.raw })
 }
 
 function toggleLog(version: string) {
@@ -343,6 +319,14 @@ function pickFile() {
 function onFileChange(e: Event) {
 	const input = e.target as HTMLInputElement
 	uploadFile.value = input.files?.[0]?.name ?? null
+}
+
+function flashFile() {
+	const file = fileInput.value?.files?.[0]
+	if (!file) return
+	emit('action', props.device, { type: 'firmware-upload', file })
+	uploadFile.value = null
+	if (fileInput.value) fileInput.value.value = ''
 }
 </script>
 
@@ -419,62 +403,6 @@ function onFileChange(e: Event) {
 	display: flex;
 	gap: 16px;
 	flex-wrap: wrap;
-}
-
-/* flash banner */
-.zw-fw__flash {
-	background: var(--zw-bg-soft);
-	border-radius: 10px;
-	padding: 12px;
-}
-
-.zw-fw__flash-head {
-	display: flex;
-	align-items: center;
-	justify-content: space-between;
-	margin-bottom: 8px;
-}
-
-.zw-fw__flash-label {
-	display: inline-flex;
-	align-items: center;
-	gap: 6px;
-	font-size: 12px;
-	font-weight: 500;
-}
-
-.zw-fw__flash-icon {
-	color: var(--zw-accent);
-}
-
-.zw-fw__flash-pct {
-	font-size: 12px;
-	color: var(--zw-accent);
-}
-
-.zw-fw__progress-track {
-	height: 6px;
-	border-radius: 3px;
-	background: rgba(var(--v0-on-surface), 0.1);
-	overflow: hidden;
-}
-
-.zw-fw__progress-fill {
-	height: 100%;
-	background: var(--zw-accent);
-	transition: width 0.3s linear;
-}
-
-.zw-fw__flash-foot {
-	display: flex;
-	justify-content: space-between;
-	align-items: center;
-	margin-top: 10px;
-}
-
-.zw-fw__flash-hint {
-	font-size: 11px;
-	color: var(--zw-muted);
 }
 
 /* buttons */

--- a/src/lib/dashboard-types.ts
+++ b/src/lib/dashboard-types.ts
@@ -154,6 +154,17 @@ export interface CommStats {
 	messagesDroppedRX: number
 }
 
+// ── Firmware updates ─────────────────────────────────────────
+
+export interface FirmwareUpdateInfo {
+	version: string
+	channel?: 'stable' | 'prerelease'
+	changelog: string[]
+	date?: string
+	downgrade: boolean
+	latest?: boolean
+}
+
 // ── Device ────────────────────────────────────────────────────
 
 export interface Device {
@@ -179,6 +190,7 @@ export interface Device {
 	activity: Activity[]
 	health?: 'ok' | 'weak' | 'unknown'
 	hasUpdate?: boolean
+	availableFirmwareUpdates?: FirmwareUpdateInfo[]
 	txPower?: number
 	commStats?: CommStats
 }
@@ -217,3 +229,6 @@ export type DeviceAction =
 	| { type: 'exclude' }
 	| { type: 'clear-associations' }
 	| { type: 'remove-all-associations' }
+	| { type: 'check-firmware-updates' }
+	| { type: 'firmware-install'; update: FirmwareUpdateInfo }
+	| { type: 'firmware-upload'; file: File }

--- a/src/lib/dashboard-types.ts
+++ b/src/lib/dashboard-types.ts
@@ -159,10 +159,12 @@ export interface CommStats {
 export interface FirmwareUpdateInfo {
 	version: string
 	channel?: 'stable' | 'prerelease'
-	changelog: string[]
+	changelog: string
 	date?: string
 	downgrade: boolean
-	latest?: boolean
+	normalizedVersion?: string
+	files?: { target: number; url: string; integrity: string }[]
+	device?: Record<string, unknown>
 }
 
 // ── Device ────────────────────────────────────────────────────

--- a/src/lib/device-actions.ts
+++ b/src/lib/device-actions.ts
@@ -82,6 +82,18 @@ export const ACTION_DISPATCHERS: {
 	}),
 	exclude: () => ({ api: 'startExclusion', args: [] }),
 	'export-ui': (d) => ({ api: 'dumpNode', args: [d.nodeId] }),
+	'check-firmware-updates': (d) => ({
+		api: 'getAvailableFirmwareUpdates',
+		args: [d.nodeId],
+	}),
+	'firmware-install': (d, a) => ({
+		api: 'firmwareUpdateOTA',
+		args: [d.nodeId, a.update],
+	}),
+	'firmware-upload': (d, a) => ({
+		api: 'updateFirmware',
+		args: [d.nodeId, [{ name: a.file.name, data: a.file }]],
+	}),
 	'clear-associations': (d) => ({
 		api: 'removeAllAssociations',
 		args: [d.nodeId],

--- a/src/lib/deviceProjection.ts
+++ b/src/lib/deviceProjection.ts
@@ -392,17 +392,23 @@ export function projectDevice(
 	const hasUpdate = rawUpdates.length > 0
 	const availableFirmwareUpdates: FirmwareUpdateInfo[] = rawUpdates.map(
 		(u: Record<string, unknown>) => ({
-			version:
-				typeof u.version === 'string'
-					? u.version
-					: JSON.stringify(u.version),
+			version: typeof u.version === 'string' ? u.version : '',
 			channel:
-				u.channel === 'prerelease'
+				u.channel === 'beta'
 					? ('prerelease' as const)
 					: ('stable' as const),
-			changelog: Array.isArray(u.changelog) ? u.changelog : [],
+			changelog: typeof u.changelog === 'string' ? u.changelog : '',
 			date: typeof u.date === 'string' ? u.date : undefined,
 			downgrade: !!u.downgrade,
+			normalizedVersion:
+				typeof u.normalizedVersion === 'string'
+					? u.normalizedVersion
+					: undefined,
+			files: Array.isArray(u.files) ? u.files : undefined,
+			device:
+				u.device && typeof u.device === 'object'
+					? (u.device as Record<string, unknown>)
+					: undefined,
 		}),
 	)
 

--- a/src/lib/deviceProjection.ts
+++ b/src/lib/deviceProjection.ts
@@ -9,6 +9,7 @@ import type {
 	Activity,
 	Device,
 	DeviceStatus,
+	FirmwareUpdateInfo,
 	PowerInfo,
 	PrimaryValue,
 	SecurityKey,
@@ -385,9 +386,25 @@ export function projectDevice(
 	const archetype = inferArchetype(node)
 	const power = projectPower(node)
 	const securityKeys = projectSecurityKeys(node)
-	const hasUpdate =
-		Array.isArray(node.availableFirmwareUpdates) &&
-		node.availableFirmwareUpdates.length > 0
+	const rawUpdates = Array.isArray(node.availableFirmwareUpdates)
+		? node.availableFirmwareUpdates
+		: []
+	const hasUpdate = rawUpdates.length > 0
+	const availableFirmwareUpdates: FirmwareUpdateInfo[] = rawUpdates.map(
+		(u: Record<string, unknown>) => ({
+			version:
+				typeof u.version === 'string'
+					? u.version
+					: JSON.stringify(u.version),
+			channel:
+				u.channel === 'prerelease'
+					? ('prerelease' as const)
+					: ('stable' as const),
+			changelog: Array.isArray(u.changelog) ? u.changelog : [],
+			date: typeof u.date === 'string' ? u.date : undefined,
+			downgrade: !!u.downgrade,
+		}),
+	)
 
 	const activity = projectActivities(node, opts.activitiesByNode)
 
@@ -417,6 +434,9 @@ export function projectDevice(
 		activity,
 		health: 'ok',
 		hasUpdate,
+		availableFirmwareUpdates: hasUpdate
+			? availableFirmwareUpdates
+			: undefined,
 		txPower:
 			typeof (node as unknown as { txPower?: number }).txPower ===
 			'number'

--- a/src/views/ControlPanelNew.vue
+++ b/src/views/ControlPanelNew.vue
@@ -86,6 +86,17 @@ async function onAction(device: Device, action: DeviceAction) {
 		if (node) downloadJson(node, `node_${device.nodeId}.json`)
 		return
 	}
+	if (action.type === 'firmware-upload') {
+		const app = appInstance()
+		if (!app) return
+		const data = await action.file.arrayBuffer()
+		await app.apiRequest(
+			'updateFirmware',
+			[device.nodeId, [{ name: action.file.name, data }]],
+			{ infoSnack: true, errorSnack: true },
+		)
+		return
+	}
 	const req = dispatchAction(device, action)
 	const app = appInstance()
 	if (!app) {


### PR DESCRIPTION
Replace the placeholder updates panel with a full firmware management tab: current version display, "Check for updates" button, filter toggles (include prereleases / show downgrades), firmware candidate cards with version + channel/direction tags + install button, collapsible changelogs, flash progress banner, and upload-from-file area.

Add a blue dot badge on the Updates tab when device.hasUpdate is true. Add FirmwareUpdateInfo type and project available firmware updates into the Device shape.

<img width="526" height="402" alt="image" src="https://github.com/user-attachments/assets/de62cff2-caec-4058-af25-618aebc94f2b" />

<img width="522" height="196" alt="image" src="https://github.com/user-attachments/assets/00ca79a1-c3bf-4e7f-b6e5-cce104b0477b" />

<img width="522" height="196" alt="image" src="https://github.com/user-attachments/assets/f4c80fd2-1589-406d-8f92-322f1d440406" />

<img width="524" height="440" alt="image" src="https://github.com/user-attachments/assets/766dfaef-50c9-403f-ad54-d80319ba4681" />
