### PR TITLE
feat(ui): hide bulk association actions for the controller

### DIFF
--- a/src/components/dashboard/components/ZwAssociationsTab.vue
+++ b/src/components/dashboard/components/ZwAssociationsTab.vue
@@ -17,7 +17,7 @@
 			</div>
 		</div>
 
-		<ZwActionList>
+		<ZwActionList v-if="!device.isController">
 			<ZwActionBtn
 				title="Clear all associations"
 				description="Remove every target from this node's association groups."


### PR DESCRIPTION
The controller has no meaningful Clear-all / Remove-from-all association actions. Hide the action list when viewing the controller node.