### PR TITLE
feat(ui): add controller RF options to overview tab

### DIFF
--- a/src/components/dashboard/components/ZwControllerOptionRow.vue
+++ b/src/components/dashboard/components/ZwControllerOptionRow.vue
@@ -1,0 +1,262 @@
+<template>
+	<div class="zw-optrow" :class="{ 'zw-optrow--dirty': dirty }">
+		<!-- label line -->
+		<div class="zw-optrow__head">
+			<span class="zw-optrow__label">{{ option.label }}</span>
+
+			<Popover.Root v-model="menuOpen" :id="menuId">
+				<Popover.Activator
+					as="button"
+					class="zw-optrow__menu-btn zw-focus-ring"
+					title="More"
+				>
+					<MoreIcon :size="ICON_SIZE.inline" />
+				</Popover.Activator>
+				<Popover.Content as="div" class="zw-optrow__menu" role="menu">
+					<button
+						type="button"
+						class="zw-optrow__menu-item"
+						@click="refresh"
+					>
+						<RefreshIcon :size="ICON_SIZE.dense" /> Refresh value
+					</button>
+				</Popover.Content>
+			</Popover.Root>
+		</div>
+
+		<!-- control line -->
+		<div
+			class="zw-optrow__control"
+			:class="{ 'zw-optrow__control--busy': busy }"
+		>
+			<!-- read-only display -->
+			<template v-if="option.kind === 'readonly'">
+				<span class="zw-optrow__display">{{ option.display }}</span>
+			</template>
+
+			<!-- enum select -->
+			<template v-else-if="option.kind === 'enum'">
+				<ZwDropdown
+					:model-value="asOptionValue(cur)"
+					:options="option.options ?? []"
+					:disabled="busy"
+					@update:model-value="commit"
+				/>
+			</template>
+
+			<!-- number -->
+			<template v-else-if="option.kind === 'number'">
+				<ZwNumericInput
+					:model-value="String(cur ?? '')"
+					:min="option.min"
+					:max="option.max"
+					:step="option.step"
+					:unit="option.unit"
+					:disabled="busy"
+					:dirty="dirty"
+					@update:model-value="draft = $event"
+					@commit="send"
+					@reset="draft = null"
+				/>
+			</template>
+
+			<span v-if="busy" class="zw-optrow__status">
+				<RefreshIcon :size="ICON_SIZE.chip" class="zw-spin" />
+				{{ sending ? 'Setting…' : 'Refreshing…' }}
+			</span>
+		</div>
+
+		<!-- description -->
+		<div v-if="option.description" class="zw-optrow__desc">
+			{{ option.description }}
+		</div>
+	</div>
+</template>
+
+<script setup lang="ts">
+import { computed, ref, useId } from 'vue'
+import { Popover } from '@vuetify/v0'
+import ZwDropdown from '@/components/dashboard/atoms/ZwDropdown.vue'
+import ZwNumericInput from '@/components/dashboard/atoms/ZwNumericInput.vue'
+import { ICON_SIZE, MoreIcon, RefreshIcon } from '@/lib/icons'
+import { usePopoverFallback } from '@/lib/popover-fallback.ts'
+import type { ControllerOption } from '@/lib/controllerOptions.ts'
+
+const props = defineProps<{
+	option: ControllerOption
+}>()
+const emit = defineEmits<{
+	change: [key: string, value: unknown]
+	refresh: [key: string]
+}>()
+
+const draft = ref<unknown>(null)
+const sending = ref(false)
+const refreshing = ref(false)
+const menuOpen = ref(false)
+const menuId = `zw-optrow-${useId()}`
+
+usePopoverFallback({ open: menuOpen, contentId: menuId })
+
+const cur = computed(() =>
+	draft.value !== null ? draft.value : props.option.value,
+)
+const dirty = computed(
+	() =>
+		draft.value !== null &&
+		String(draft.value) !== String(props.option.value),
+)
+const busy = computed(() => sending.value || refreshing.value)
+
+function commit(value: unknown) {
+	menuOpen.value = false
+	draft.value = null
+	emit('change', props.option.key, value)
+}
+
+function send() {
+	if (!dirty.value) return
+	const v = props.option.kind === 'number' ? Number(draft.value) : draft.value
+	commit(v)
+}
+
+function refresh() {
+	menuOpen.value = false
+	emit('refresh', props.option.key)
+}
+
+function asOptionValue(v: unknown): number | string | boolean | null {
+	if (
+		typeof v === 'number' ||
+		typeof v === 'string' ||
+		typeof v === 'boolean'
+	)
+		return v
+	return null
+}
+</script>
+
+<style>
+.zw-optrow {
+	padding: 10px 12px;
+	display: flex;
+	flex-direction: column;
+	gap: 6px;
+	flex: 1;
+	min-width: 0;
+	background: transparent;
+	transition: background 0.15s;
+}
+
+.zw-optrow--dirty {
+	background: rgba(var(--v0-primary), 0.05);
+}
+
+/* ── label line ── */
+.zw-optrow__head {
+	display: flex;
+	align-items: flex-start;
+	gap: 8px;
+}
+
+.zw-optrow__label {
+	font-size: 12px;
+	font-weight: 500;
+	color: var(--zw-fg);
+	min-width: 0;
+	flex: 1;
+	line-height: 17px;
+	overflow-wrap: anywhere;
+}
+
+.zw-optrow__menu-btn {
+	appearance: none;
+	border: none;
+	background: transparent;
+	color: var(--zw-muted);
+	cursor: pointer;
+	padding: 3px;
+	border-radius: 4px;
+	display: inline-flex;
+	align-items: center;
+	flex-shrink: 0;
+}
+
+.zw-optrow__menu-btn[data-open] {
+	background: var(--zw-chip-bg);
+}
+
+.zw-optrow__menu {
+	position-area: none !important;
+	position-anchor: auto !important;
+	min-width: 180px;
+	background: var(--zw-card);
+	border: 1px solid var(--zw-line2);
+	border-radius: 6px;
+	box-shadow: var(--zw-e8);
+	padding: 0;
+	overflow: hidden;
+	animation: zw-fade-in 0.12s;
+}
+
+.zw-optrow__menu::backdrop {
+	display: none;
+}
+
+.zw-optrow__menu-item {
+	width: 100%;
+	appearance: none;
+	border: none;
+	background: transparent;
+	cursor: pointer;
+	text-align: left;
+	color: var(--zw-fg);
+	padding: 8px 10px;
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	font: var(--zw-text-body-s);
+}
+
+.zw-optrow__menu-item:hover {
+	background: var(--zw-row-hover);
+}
+
+/* ── control line ── */
+.zw-optrow__control {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	min-width: 0;
+	transition: opacity 0.15s;
+}
+
+.zw-optrow__control--busy {
+	opacity: 0.55;
+}
+
+.zw-optrow__display {
+	font-family: var(--zw-mono);
+	font-size: 14px;
+	font-weight: 600;
+	font-variant-numeric: tabular-nums;
+	overflow-wrap: anywhere;
+}
+
+.zw-optrow__status {
+	display: inline-flex;
+	align-items: center;
+	gap: 4px;
+	font-size: 10px;
+	font-family: var(--zw-mono);
+	color: var(--zw-accent);
+	white-space: nowrap;
+}
+
+/* ── meta ── */
+.zw-optrow__desc {
+	font-size: 11px;
+	color: var(--zw-muted);
+	line-height: 1.45;
+}
+</style>

--- a/src/components/dashboard/components/ZwControllerOptionsPanel.vue
+++ b/src/components/dashboard/components/ZwControllerOptionsPanel.vue
@@ -1,0 +1,80 @@
+<template>
+	<div class="zw-ctrl-opts">
+		<span class="zw-ctrl-opts__title">Controller Options</span>
+		<div v-if="options.length" class="zw-ctrl-opts__body">
+			<ZwControllerOptionRow
+				v-for="(opt, i) in options"
+				:key="opt.key"
+				:option="opt"
+				:class="{ 'zw-ctrl-opts__row--last': i === options.length - 1 }"
+				@change="onChange"
+				@refresh="onRefresh"
+			/>
+		</div>
+	</div>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import ZwControllerOptionRow from './ZwControllerOptionRow.vue'
+import useBaseStore from '@/stores/base'
+import { buildControllerOptions } from '@/lib/controllerOptions.ts'
+import type { Device, DeviceAction } from '@/lib/dashboard-types'
+
+const props = defineProps<{ device: Device }>()
+const emit = defineEmits<{ action: [Device, DeviceAction] }>()
+
+const baseStore = useBaseStore()
+
+const options = computed(() =>
+	buildControllerOptions(baseStore.getNode(props.device.nodeId)),
+)
+
+function onChange(key: string, value: unknown) {
+	if (key === 'rfRegion') {
+		emit('action', props.device, {
+			type: 'set-rf-region',
+			region: Number(value),
+		})
+	} else if (key === 'measured0dBm') {
+		const node = baseStore.getNode(props.device.nodeId)
+		emit('action', props.device, {
+			type: 'set-powerlevel',
+			powerlevel: node?.powerlevel ?? 0,
+			measured0dBm: Number(value),
+		})
+	}
+}
+
+function onRefresh(_key: string) {
+	emit('action', props.device, { type: 'refresh' })
+}
+</script>
+
+<style>
+.zw-ctrl-opts {
+	display: flex;
+	flex-direction: column;
+	gap: 8px;
+}
+
+.zw-ctrl-opts__title {
+	font-family: var(--zw-mono);
+	font-size: 10px;
+	font-weight: 600;
+	color: var(--zw-muted);
+	text-transform: uppercase;
+	letter-spacing: 0.6px;
+}
+
+.zw-ctrl-opts__body {
+	background: var(--zw-card);
+	border: 1px solid var(--zw-line);
+	border-radius: 6px;
+	overflow: hidden;
+}
+
+.zw-ctrl-opts__body > .zw-optrow:not(.zw-ctrl-opts__row--last) {
+	border-bottom: 1px solid var(--zw-line);
+}
+</style>

--- a/src/components/dashboard/components/ZwControllerOptionsPanel.vue
+++ b/src/components/dashboard/components/ZwControllerOptionsPanel.vue
@@ -26,9 +26,14 @@ const emit = defineEmits<{ action: [Device, DeviceAction] }>()
 
 const baseStore = useBaseStore()
 
-const options = computed(() =>
-	buildControllerOptions(baseStore.getNode(props.device.nodeId)),
-)
+const options = computed(() => {
+	const zwave = (
+		baseStore as unknown as { zwave: { rf: { autoPowerlevels: boolean } } }
+	).zwave
+	return buildControllerOptions(baseStore.getNode(props.device.nodeId), {
+		autoPowerlevels: zwave?.rf?.autoPowerlevels ?? true,
+	})
+})
 
 function onChange(key: string, value: unknown) {
 	if (key === 'rfRegion') {
@@ -36,18 +41,36 @@ function onChange(key: string, value: unknown) {
 			type: 'set-rf-region',
 			region: Number(value),
 		})
-	} else if (key === 'measured0dBm') {
+	} else if (key === 'powerlevel' || key === 'measured0dBm') {
 		const node = baseStore.getNode(props.device.nodeId)
 		emit('action', props.device, {
 			type: 'set-powerlevel',
-			powerlevel: node?.powerlevel ?? 0,
-			measured0dBm: Number(value),
+			powerlevel:
+				key === 'powerlevel' ? Number(value) : (node?.powerlevel ?? 0),
+			measured0dBm:
+				key === 'measured0dBm'
+					? Number(value)
+					: (node?.measured0dBm ?? 0),
+		})
+	} else if (key === 'maxLRPowerlevel') {
+		emit('action', props.device, {
+			type: 'set-max-lr-powerlevel',
+			maxLRPowerlevel: Number(value),
 		})
 	}
 }
 
-function onRefresh(_key: string) {
-	emit('action', props.device, { type: 'refresh' })
+function onRefresh(key: string) {
+	const propMap: Record<string, string> = {
+		rfRegion: 'RFRegion',
+		powerlevel: 'powerlevel',
+		measured0dBm: 'powerlevel',
+		maxLRPowerlevel: 'maxLongRangePowerlevel',
+	}
+	emit('action', props.device, {
+		type: 'refresh-controller-prop',
+		prop: propMap[key] ?? key,
+	})
 }
 </script>
 

--- a/src/components/dashboard/components/ZwNodeDetailsBody.vue
+++ b/src/components/dashboard/components/ZwNodeDetailsBody.vue
@@ -86,6 +86,11 @@
 					<ZwPropTable title="Device" :rows="deviceRows" />
 					<ZwPropTable title="Firmware" :rows="fwRows" />
 					<ZwSecurityPanel :device="device" />
+					<ZwControllerOptionsPanel
+						v-if="device.isController"
+						:device="device"
+						@action="onAction"
+					/>
 				</Tabs.Panel>
 
 				<Tabs.Panel value="associations" class="zw-nd__content">
@@ -204,6 +209,7 @@ import ZwAssociationsTab from './ZwAssociationsTab.vue'
 import ZwUpdatesTab from './ZwUpdatesTab.vue'
 import ZwNodeEvents from './ZwNodeEvents.vue'
 import ZwValuesView from './ZwValuesView.vue'
+import ZwControllerOptionsPanel from './ZwControllerOptionsPanel.vue'
 import {
 	DownloadIcon,
 	ICON_SIZE,

--- a/src/lib/controllerOptions.test.ts
+++ b/src/lib/controllerOptions.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect } from 'vitest'
+import { buildControllerOptions } from './controllerOptions.ts'
+import type { ZUINode } from '../../api/lib/ZwaveClient'
+import { RFRegion } from 'zwave-js'
+
+function node(overrides: Partial<ZUINode> = {}): ZUINode {
+	return {
+		id: 1,
+		isControllerNode: true,
+		ready: true,
+		available: true,
+		failed: false,
+		inited: true,
+		eventsQueue: [],
+		RFRegion: RFRegion['USA (Long Range)'],
+		rfRegions: [
+			{ title: 'Europe', value: RFRegion.Europe },
+			{ title: 'USA', value: RFRegion.USA },
+			{ title: 'USA (Long Range)', value: RFRegion['USA (Long Range)'] },
+			{
+				title: 'Unknown',
+				value: RFRegion.Unknown,
+				disabled: true,
+			} as { title: string; value: number; disabled: boolean },
+		],
+		powerlevel: -1,
+		measured0dBm: 0.3,
+		supportsLongRange: true,
+		maxLongRangePowerlevel: 14,
+		...overrides,
+	} as unknown as ZUINode
+}
+
+describe('buildControllerOptions', () => {
+	it('returns empty array for null node', () => {
+		expect(buildControllerOptions(null)).toEqual([])
+		expect(buildControllerOptions(undefined)).toEqual([])
+	})
+
+	it('produces all four options for a Long Range controller', () => {
+		const opts = buildControllerOptions(node())
+		expect(opts).toHaveLength(4)
+		expect(opts.map((o) => o.key)).toEqual([
+			'rfRegion',
+			'powerlevel',
+			'measured0dBm',
+			'maxLRPowerlevel',
+		])
+	})
+
+	it('omits maxLRPowerlevel when supportsLongRange is false', () => {
+		const opts = buildControllerOptions(node({ supportsLongRange: false }))
+		expect(opts.map((o) => o.key)).not.toContain('maxLRPowerlevel')
+	})
+
+	describe('RF Region', () => {
+		it('filters out disabled regions', () => {
+			const opts = buildControllerOptions(node())
+			const rf = opts.find((o) => o.key === 'rfRegion')
+			const values = rf.options.map((o) => o.value)
+			expect(values).not.toContain(RFRegion.Unknown)
+		})
+
+		it('renders as readonly when RFRegion is undefined', () => {
+			const opts = buildControllerOptions(node({ RFRegion: undefined }))
+			const rf = opts.find((o) => o.key === 'rfRegion')
+			expect(rf.kind).toBe('readonly')
+			expect(rf.display).toBe('—')
+			expect(rf.options).toBeUndefined()
+		})
+	})
+
+	describe('power levels with auto-powerlevel enabled', () => {
+		it('makes powerlevel readonly for USA region', () => {
+			const opts = buildControllerOptions(node(), {
+				autoPowerlevels: true,
+			})
+			const pl = opts.find((o) => o.key === 'powerlevel')
+			expect(pl.kind).toBe('readonly')
+			expect(pl.description).toContain('Automatic mode')
+		})
+
+		it('makes maxLRPowerlevel readonly for USA region', () => {
+			const opts = buildControllerOptions(node(), {
+				autoPowerlevels: true,
+			})
+			const lr = opts.find((o) => o.key === 'maxLRPowerlevel')
+			expect(lr.kind).toBe('readonly')
+		})
+	})
+
+	describe('power levels with auto-powerlevel disabled', () => {
+		it('makes powerlevel editable', () => {
+			const opts = buildControllerOptions(node(), {
+				autoPowerlevels: false,
+			})
+			const pl = opts.find((o) => o.key === 'powerlevel')
+			expect(pl.kind).toBe('number')
+			expect(pl.description).toBeUndefined()
+		})
+
+		it('makes maxLRPowerlevel an enum with two options', () => {
+			const opts = buildControllerOptions(node(), {
+				autoPowerlevels: false,
+			})
+			const lr = opts.find((o) => o.key === 'maxLRPowerlevel')
+			expect(lr.kind).toBe('enum')
+			expect(lr.options).toHaveLength(2)
+			expect(lr.options.map((o) => o.value)).toEqual([14, 20])
+		})
+	})
+
+	describe('power levels for non-auto-eligible regions', () => {
+		it('makes powerlevel editable even with autoPowerlevels=true', () => {
+			const opts = buildControllerOptions(
+				node({ RFRegion: RFRegion.India }),
+				{ autoPowerlevels: true },
+			)
+			const pl = opts.find((o) => o.key === 'powerlevel')
+			expect(pl.kind).toBe('number')
+		})
+	})
+
+	it('uses step 0.1 for measured0dBm', () => {
+		const opts = buildControllerOptions(node())
+		const m = opts.find((o) => o.key === 'measured0dBm')
+		expect(m.step).toBe(0.1)
+	})
+})

--- a/src/lib/controllerOptions.ts
+++ b/src/lib/controllerOptions.ts
@@ -1,17 +1,8 @@
 // Projects the controller node's RF-related properties into the shape
 // the controller options panel renders.
 
-import { RFRegion } from '@zwave-js/core'
 import type { ZUINode } from '../../api/lib/ZwaveClient.ts'
-
-function regionSupportsAutoPowerlevel(region: number | undefined): boolean {
-	return (
-		region === RFRegion.Europe ||
-		region === RFRegion['Europe (Long Range)'] ||
-		region === RFRegion.USA ||
-		region === RFRegion['USA (Long Range)']
-	)
-}
+import { regionSupportsAutoPowerlevel } from '@server/lib/shared'
 
 export type ControllerOptionKind = 'enum' | 'number' | 'readonly'
 
@@ -47,7 +38,9 @@ export function buildControllerOptions(
 	const opts: ControllerOption[] = []
 
 	const isAutoEnabled =
-		ctx.autoPowerlevels && regionSupportsAutoPowerlevel(node.RFRegion)
+		ctx.autoPowerlevels &&
+		node.RFRegion !== undefined &&
+		regionSupportsAutoPowerlevel(node.RFRegion)
 
 	// RF Region — enum dropdown built from the controller's reported regions.
 	// Filter out disabled entries (Unknown, Default (EU)) matching the old UI.

--- a/src/lib/controllerOptions.ts
+++ b/src/lib/controllerOptions.ts
@@ -2,6 +2,7 @@
 // the controller options panel renders.
 
 import type { ZUINode } from '../../api/lib/ZwaveClient.ts'
+import { regionSupportsAutoPowerlevel } from '@server/lib/shared'
 
 export type ControllerOptionKind = 'enum' | 'number' | 'readonly'
 
@@ -24,43 +25,63 @@ export interface ControllerOption {
 	options?: ControllerOptionChoice[]
 }
 
+export interface BuildControllerOptionsContext {
+	autoPowerlevels: boolean
+}
+
 export function buildControllerOptions(
 	node: ZUINode | null | undefined,
+	ctx: BuildControllerOptionsContext = { autoPowerlevels: true },
 ): ControllerOption[] {
 	if (!node) return []
 
 	const opts: ControllerOption[] = []
 
+	const isAutoEnabled =
+		ctx.autoPowerlevels &&
+		regionSupportsAutoPowerlevel(node.RFRegion as number)
+
 	// RF Region — enum dropdown built from the controller's reported regions.
-	const regionOptions: ControllerOptionChoice[] = (node.rfRegions ?? []).map(
-		(r) => ({ value: r.value, label: r.title }),
-	)
-	const regionValue = node.RFRegion ?? 0
-	const regionLabel =
-		regionOptions.find((o) => o.value === regionValue)?.label ??
-		String(regionValue)
+	// Filter out disabled entries (Unknown, Default (EU)) matching the old UI.
+	const regionOptions: ControllerOptionChoice[] = (node.rfRegions ?? [])
+		.filter((r) => !(r as { disabled?: boolean }).disabled)
+		.map((r) => ({ value: r.value, label: r.title }))
+	const supported = node.RFRegion !== undefined
+	const regionValue = node.RFRegion
+	const regionLabel = supported
+		? (regionOptions.find((o) => o.value === regionValue)?.label ??
+			String(regionValue))
+		: undefined
 	opts.push({
 		key: 'rfRegion',
 		label: 'RF Region',
-		description: 'Radio-frequency region the controller transmits in.',
-		kind: 'enum',
+		description: supported
+			? 'Radio-frequency region the controller transmits in.'
+			: 'Not supported by your controller.',
+		kind: supported ? 'enum' : 'readonly',
 		value: regionValue,
-		display: `[${regionValue}] ${regionLabel}`,
-		options: regionOptions,
+		display: supported ? `[${regionValue}] ${regionLabel}` : '—',
+		options: supported ? regionOptions : undefined,
 	})
 
-	// Normal Power Level — read-only when auto-driven.
+	// Normal Power Level — editable unless auto-powerlevel is active.
 	const powerlevel = node.powerlevel ?? 0
 	opts.push({
 		key: 'powerlevel',
 		label: 'Normal Power Level',
-		description: 'Automatic mode enabled in settings.',
-		kind: 'readonly',
+		description: isAutoEnabled
+			? 'Automatic mode enabled in settings.'
+			: undefined,
+		kind: isAutoEnabled ? 'readonly' : 'number',
 		value: powerlevel,
 		display: `${powerlevel} dBm`,
+		unit: 'dBm',
+		min: -10,
+		max: 20,
+		step: 0.1,
 	})
 
-	// Measured output power at 0 dBm — editable calibration offset.
+	// Measured output power at 0 dBm — always editable.
 	const measured = node.measured0dBm ?? 0
 	opts.push({
 		key: 'measured0dBm',
@@ -73,19 +94,29 @@ export function buildControllerOptions(
 		unit: 'dBm',
 		min: -10,
 		max: 10,
-		step: 1,
+		step: 0.1,
 	})
 
-	// Max LR Power Level — read-only, only relevant for Long Range sticks.
+	// Max LR Power Level — editable (enum) unless auto-powerlevel is active.
 	if (node.supportsLongRange) {
-		const maxLR = node.maxLongRangePowerlevel ?? 0
+		const maxLR = node.maxLongRangePowerlevel ?? 14
+		const lrOptions: ControllerOptionChoice[] = [
+			{ value: 14, label: '+14 dBm' },
+			{ value: 20, label: '+20 dBm' },
+		]
+		const lrLabel =
+			lrOptions.find((o) => o.value === maxLR)?.label ??
+			`${maxLR > 0 ? '+' : ''}${maxLR} dBm`
 		opts.push({
 			key: 'maxLRPowerlevel',
 			label: 'Maximum LR Power Level',
-			description: 'Automatic mode enabled in settings.',
-			kind: 'readonly',
+			description: isAutoEnabled
+				? 'Automatic mode enabled in settings.'
+				: undefined,
+			kind: isAutoEnabled ? 'readonly' : 'enum',
 			value: maxLR,
-			display: `${maxLR > 0 ? '+' : ''}${maxLR} dBm`,
+			display: lrLabel,
+			options: isAutoEnabled ? undefined : lrOptions,
 		})
 	}
 

--- a/src/lib/controllerOptions.ts
+++ b/src/lib/controllerOptions.ts
@@ -2,7 +2,7 @@
 // the controller options panel renders.
 
 import type { ZUINode } from '../../api/lib/ZwaveClient.ts'
-import { regionSupportsAutoPowerlevel } from '@server/lib/shared'
+import { regionSupportsAutoPowerlevel } from '../../api/lib/shared.ts'
 
 export type ControllerOptionKind = 'enum' | 'number' | 'readonly'
 

--- a/src/lib/controllerOptions.ts
+++ b/src/lib/controllerOptions.ts
@@ -1,0 +1,93 @@
+// Projects the controller node's RF-related properties into the shape
+// the controller options panel renders.
+
+import type { ZUINode } from '../../api/lib/ZwaveClient.ts'
+
+export type ControllerOptionKind = 'enum' | 'number' | 'readonly'
+
+export interface ControllerOptionChoice {
+	value: number | string
+	label: string
+}
+
+export interface ControllerOption {
+	key: string
+	label: string
+	description?: string
+	kind: ControllerOptionKind
+	value: unknown
+	display: string
+	unit?: string
+	min?: number
+	max?: number
+	step?: number
+	options?: ControllerOptionChoice[]
+}
+
+export function buildControllerOptions(
+	node: ZUINode | null | undefined,
+): ControllerOption[] {
+	if (!node) return []
+
+	const opts: ControllerOption[] = []
+
+	// RF Region — enum dropdown built from the controller's reported regions.
+	const regionOptions: ControllerOptionChoice[] = (node.rfRegions ?? []).map(
+		(r) => ({ value: r.value, label: r.title }),
+	)
+	const regionValue = node.RFRegion ?? 0
+	const regionLabel =
+		regionOptions.find((o) => o.value === regionValue)?.label ??
+		String(regionValue)
+	opts.push({
+		key: 'rfRegion',
+		label: 'RF Region',
+		description: 'Radio-frequency region the controller transmits in.',
+		kind: 'enum',
+		value: regionValue,
+		display: `[${regionValue}] ${regionLabel}`,
+		options: regionOptions,
+	})
+
+	// Normal Power Level — read-only when auto-driven.
+	const powerlevel = node.powerlevel ?? 0
+	opts.push({
+		key: 'powerlevel',
+		label: 'Normal Power Level',
+		description: 'Automatic mode enabled in settings.',
+		kind: 'readonly',
+		value: powerlevel,
+		display: `${powerlevel} dBm`,
+	})
+
+	// Measured output power at 0 dBm — editable calibration offset.
+	const measured = node.measured0dBm ?? 0
+	opts.push({
+		key: 'measured0dBm',
+		label: 'Measured output power at 0 dBm',
+		description:
+			"Calibration offset for the antenna's measured output at 0 dBm.",
+		kind: 'number',
+		value: measured,
+		display: `${measured} dBm`,
+		unit: 'dBm',
+		min: -10,
+		max: 10,
+		step: 1,
+	})
+
+	// Max LR Power Level — read-only, only relevant for Long Range sticks.
+	if (node.supportsLongRange) {
+		const maxLR = node.maxLongRangePowerlevel ?? 0
+		opts.push({
+			key: 'maxLRPowerlevel',
+			label: 'Maximum LR Power Level',
+			description: 'Automatic mode enabled in settings.',
+			kind: 'readonly',
+			value: maxLR,
+			display: `${maxLR > 0 ? '+' : ''}${maxLR} dBm`,
+		})
+	}
+
+	return opts
+}

--- a/src/lib/controllerOptions.ts
+++ b/src/lib/controllerOptions.ts
@@ -1,8 +1,17 @@
 // Projects the controller node's RF-related properties into the shape
 // the controller options panel renders.
 
+import { RFRegion } from '@zwave-js/core'
 import type { ZUINode } from '../../api/lib/ZwaveClient.ts'
-import { regionSupportsAutoPowerlevel } from '../../api/lib/shared.ts'
+
+function regionSupportsAutoPowerlevel(region: number | undefined): boolean {
+	return (
+		region === RFRegion.Europe ||
+		region === RFRegion['Europe (Long Range)'] ||
+		region === RFRegion.USA ||
+		region === RFRegion['USA (Long Range)']
+	)
+}
 
 export type ControllerOptionKind = 'enum' | 'number' | 'readonly'
 
@@ -38,8 +47,7 @@ export function buildControllerOptions(
 	const opts: ControllerOption[] = []
 
 	const isAutoEnabled =
-		ctx.autoPowerlevels &&
-		regionSupportsAutoPowerlevel(node.RFRegion as number)
+		ctx.autoPowerlevels && regionSupportsAutoPowerlevel(node.RFRegion)
 
 	// RF Region — enum dropdown built from the controller's reported regions.
 	// Filter out disabled entries (Unknown, Default (EU)) matching the old UI.

--- a/src/lib/dashboard-types.ts
+++ b/src/lib/dashboard-types.ts
@@ -236,6 +236,8 @@ export type DeviceAction =
 	| { type: 'firmware-upload'; file: File }
 	| { type: 'set-rf-region'; region: number }
 	| { type: 'set-powerlevel'; powerlevel: number; measured0dBm: number }
+	| { type: 'set-max-lr-powerlevel'; maxLRPowerlevel: number }
+	| { type: 'refresh-controller-prop'; prop: string }
 	| { type: 'shutdown' }
 	| { type: 'soft-reset' }
 	| { type: 'factory-reset' }

--- a/src/lib/dashboard-types.ts
+++ b/src/lib/dashboard-types.ts
@@ -234,3 +234,8 @@ export type DeviceAction =
 	| { type: 'check-firmware-updates' }
 	| { type: 'firmware-install'; update: FirmwareUpdateInfo }
 	| { type: 'firmware-upload'; file: File }
+	| { type: 'set-rf-region'; region: number }
+	| { type: 'set-powerlevel'; powerlevel: number; measured0dBm: number }
+	| { type: 'shutdown' }
+	| { type: 'soft-reset' }
+	| { type: 'factory-reset' }

--- a/src/lib/device-actions.ts
+++ b/src/lib/device-actions.ts
@@ -102,6 +102,14 @@ export const ACTION_DISPATCHERS: {
 		api: 'removeNodeFromAllAssociations',
 		args: [d.nodeId],
 	}),
+	'set-rf-region': (_d, a) => ({ api: 'setRFRegion', args: [a.region] }),
+	'set-powerlevel': (_d, a) => ({
+		api: 'setPowerlevel',
+		args: [a.powerlevel, a.measured0dBm],
+	}),
+	shutdown: () => ({ api: 'shutdownZwaveAPI', args: [] }),
+	'soft-reset': () => ({ api: 'softReset', args: [] }),
+	'factory-reset': () => ({ api: 'hardReset', args: [] }),
 }
 
 export function dispatchAction(

--- a/src/lib/device-actions.ts
+++ b/src/lib/device-actions.ts
@@ -107,6 +107,14 @@ export const ACTION_DISPATCHERS: {
 		api: 'setPowerlevel',
 		args: [a.powerlevel, a.measured0dBm],
 	}),
+	'set-max-lr-powerlevel': (_d, a) => ({
+		api: 'setMaxLongRangePowerlevel',
+		args: [a.maxLRPowerlevel],
+	}),
+	'refresh-controller-prop': (_d, a) => ({
+		api: 'updateControllerNodeProps',
+		args: [null, [a.prop]],
+	}),
 	shutdown: () => ({ api: 'shutdownZwaveAPI', args: [] }),
 	'soft-reset': () => ({ api: 'softReset', args: [] }),
 	'factory-reset': () => ({ api: 'hardReset', args: [] }),

--- a/src/lib/icons.ts
+++ b/src/lib/icons.ts
@@ -26,6 +26,7 @@ export {
 	DoorClosed as ContactIcon,
 	Download as DownloadIcon,
 	Droplet as LeakIcon,
+	HardDrive as DatabaseIcon,
 	Filter as FilterIcon,
 	House as LocationsIcon,
 	LayoutGrid as GridIcon,

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -18,7 +18,7 @@ export default defineConfig({
 			},
 			{
 				find: /^@server\/(.+)/,
-				replacement: `${path.resolve(__dirname, 'server')}/$1`,
+				replacement: `${path.resolve(__dirname, 'api')}/$1`,
 			},
 		],
 	},


### PR DESCRIPTION
Don't mind the layout - this will be optimized in the next PR.

<img width="797" height="578" alt="image" src="https://github.com/user-attachments/assets/97712ed6-2abc-406d-a926-2652db5b3f68" />
