### PR TITLE
feat(ui): rebuild controller Overview and Debug tabs

### DIFF
--- a/src/components/dashboard/components/ZwActionBtn.vue
+++ b/src/components/dashboard/components/ZwActionBtn.vue
@@ -47,7 +47,7 @@
 </template>
 
 <script setup lang="ts">
-import { reactive } from 'vue'
+import { computed, reactive } from 'vue'
 import { CheckIcon, ICON_SIZE, RefreshIcon } from '@/lib/icons'
 
 export interface ActionDef {
@@ -56,36 +56,45 @@ export interface ActionDef {
 	doneLabel?: string
 }
 
+export type BtnState = 'idle' | 'busy' | 'done'
+
 const props = withDefaults(
 	defineProps<{
 		title: string
 		description?: string
 		actions: ActionDef[]
 		tone?: 'default' | 'accent' | 'danger'
+		/** When provided, overrides internal state for each action index. */
+		actionStates?: BtnState[]
 	}>(),
-	{ description: undefined, tone: 'default' },
+	{ description: undefined, tone: 'default', actionStates: undefined },
 )
 
 const emit = defineEmits<{ run: [index: number] }>()
 
-type BtnState = 'idle' | 'busy' | 'done'
-const states = reactive<BtnState[]>(props.actions.map(() => 'idle'))
+const internalStates = reactive<BtnState[]>(props.actions.map(() => 'idle'))
+
+const states = computed(() =>
+	props.actions.map((_, i) => props.actionStates?.[i] ?? internalStates[i]),
+)
 
 function run(i: number) {
-	if (states[i] !== 'idle') return
+	if (states.value[i] !== 'idle') return
 	emit('run', i)
+	// When the parent controls this button's state, skip internal timers.
+	if (props.actionStates) return
 	if (props.actions[i].busyLabel) {
-		states[i] = 'busy'
+		internalStates[i] = 'busy'
 		setTimeout(() => {
-			states[i] = 'done'
+			internalStates[i] = 'done'
 			setTimeout(() => {
-				states[i] = 'idle'
+				internalStates[i] = 'idle'
 			}, 1400)
 		}, 1300)
 	} else {
-		states[i] = 'done'
+		internalStates[i] = 'done'
 		setTimeout(() => {
-			states[i] = 'idle'
+			internalStates[i] = 'idle'
 		}, 1400)
 	}
 }

--- a/src/components/dashboard/components/ZwActionBtn.vue
+++ b/src/components/dashboard/components/ZwActionBtn.vue
@@ -22,7 +22,7 @@
 					'zw-ab__btn--done': states[i] === 'done',
 					'zw-ab__btn--busy': states[i] === 'busy',
 				}"
-				:disabled="states[i] !== 'idle'"
+				:disabled="disabled || states[i] !== 'idle'"
 				@click="run(i)"
 			>
 				<RefreshIcon
@@ -66,8 +66,15 @@ const props = withDefaults(
 		tone?: 'default' | 'accent' | 'danger'
 		/** When provided, overrides internal state for each action index. */
 		actionStates?: BtnState[]
+		/** Disables all buttons regardless of state. */
+		disabled?: boolean
 	}>(),
-	{ description: undefined, tone: 'default', actionStates: undefined },
+	{
+		description: undefined,
+		tone: 'default',
+		actionStates: undefined,
+		disabled: false,
+	},
 )
 
 const emit = defineEmits<{ run: [index: number] }>()
@@ -191,6 +198,11 @@ function run(i: number) {
 	background: rgba(67, 160, 71, 0.12);
 	color: #2e7d32;
 	border-color: transparent;
+}
+
+.zw-ab__btn:disabled:not(.zw-ab__btn--busy):not(.zw-ab__btn--done) {
+	opacity: 0.45;
+	cursor: default;
 }
 
 .zw-ab__btn--busy {

--- a/src/components/dashboard/components/ZwActionBtn.vue
+++ b/src/components/dashboard/components/ZwActionBtn.vue
@@ -54,6 +54,8 @@ export interface ActionDef {
 	label: string
 	busyLabel?: string
 	doneLabel?: string
+	/** When set, overrides internal timer-driven state for this action. */
+	state?: BtnState
 }
 
 export type BtnState = 'idle' | 'busy' | 'done'
@@ -64,15 +66,12 @@ const props = withDefaults(
 		description?: string
 		actions: ActionDef[]
 		tone?: 'default' | 'accent' | 'danger'
-		/** When provided, overrides internal state for each action index. */
-		actionStates?: BtnState[]
 		/** Disables all buttons regardless of state. */
 		disabled?: boolean
 	}>(),
 	{
 		description: undefined,
 		tone: 'default',
-		actionStates: undefined,
 		disabled: false,
 	},
 )
@@ -82,14 +81,13 @@ const emit = defineEmits<{ run: [index: number] }>()
 const internalStates = reactive<BtnState[]>(props.actions.map(() => 'idle'))
 
 const states = computed(() =>
-	props.actions.map((_, i) => props.actionStates?.[i] ?? internalStates[i]),
+	props.actions.map((a, i) => a.state ?? internalStates[i]),
 )
 
 function run(i: number) {
 	if (states.value[i] !== 'idle') return
 	emit('run', i)
-	// When the parent controls this button's state, skip internal timers.
-	if (props.actionStates) return
+	if (props.actions[i].state !== undefined) return
 	if (props.actions[i].busyLabel) {
 		internalStates[i] = 'busy'
 		setTimeout(() => {

--- a/src/components/dashboard/components/ZwControllerOptionRow.vue
+++ b/src/components/dashboard/components/ZwControllerOptionRow.vue
@@ -74,7 +74,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, ref, useId } from 'vue'
+import { computed, ref, useId, watch } from 'vue'
 import { Popover } from '@vuetify/v0'
 import ZwDropdown from '@/components/dashboard/atoms/ZwDropdown.vue'
 import ZwNumericInput from '@/components/dashboard/atoms/ZwNumericInput.vue'
@@ -82,17 +82,20 @@ import { ICON_SIZE, MoreIcon, RefreshIcon } from '@/lib/icons'
 import { usePopoverFallback } from '@/lib/popover-fallback.ts'
 import type { ControllerOption } from '@/lib/controllerOptions.ts'
 
-const props = defineProps<{
-	option: ControllerOption
-}>()
+const props = withDefaults(
+	defineProps<{
+		option: ControllerOption
+		sending?: boolean
+		refreshing?: boolean
+	}>(),
+	{ sending: false, refreshing: false },
+)
 const emit = defineEmits<{
 	change: [key: string, value: unknown]
 	refresh: [key: string]
 }>()
 
 const draft = ref<unknown>(null)
-const sending = ref(false)
-const refreshing = ref(false)
 const menuOpen = ref(false)
 const menuId = `zw-optrow-${useId()}`
 
@@ -106,7 +109,14 @@ const dirty = computed(
 		draft.value !== null &&
 		String(draft.value) !== String(props.option.value),
 )
-const busy = computed(() => sending.value || refreshing.value)
+const busy = computed(() => props.sending || props.refreshing)
+
+watch(
+	() => props.option.value,
+	() => {
+		draft.value = null
+	},
+)
 
 function commit(value: unknown) {
 	menuOpen.value = false

--- a/src/components/dashboard/components/ZwControllerOptionsPanel.vue
+++ b/src/components/dashboard/components/ZwControllerOptionsPanel.vue
@@ -6,6 +6,8 @@
 				v-for="(opt, i) in options"
 				:key="opt.key"
 				:option="opt"
+				:sending="isSending(opt.key)"
+				:refreshing="isRefreshing(opt.key)"
 				:class="{ 'zw-ctrl-opts__row--last': i === options.length - 1 }"
 				@change="onChange"
 				@refresh="onRefresh"
@@ -15,16 +17,26 @@
 </template>
 
 <script setup lang="ts">
-import { computed } from 'vue'
+import { computed, inject, shallowRef } from 'vue'
 import ZwControllerOptionRow from './ZwControllerOptionRow.vue'
 import useBaseStore from '@/stores/base'
 import { buildControllerOptions } from '@/lib/controllerOptions.ts'
+import {
+	controllerPropKey,
+	DeviceActionStatusKey,
+	type ActionStatus,
+} from '@/lib/deviceActionPending.ts'
 import type { Device, DeviceAction } from '@/lib/dashboard-types'
 
 const props = defineProps<{ device: Device }>()
 const emit = defineEmits<{ action: [Device, DeviceAction] }>()
 
 const baseStore = useBaseStore()
+
+const status = inject(
+	DeviceActionStatusKey,
+	shallowRef<ReadonlyMap<string, ActionStatus>>(new Map()),
+)
 
 const options = computed(() => {
 	const zwave = (
@@ -34,6 +46,38 @@ const options = computed(() => {
 		autoPowerlevels: zwave?.rf?.autoPowerlevels ?? true,
 	})
 })
+
+const SET_KEY_MAP: Record<string, string> = {
+	rfRegion: 'rfRegion',
+	powerlevel: 'powerlevel',
+	measured0dBm: 'powerlevel',
+	maxLRPowerlevel: 'maxLRPowerlevel',
+}
+
+const REFRESH_KEY_MAP: Record<string, string> = {
+	rfRegion: 'RFRegion',
+	powerlevel: 'powerlevel',
+	measured0dBm: 'powerlevel',
+	maxLRPowerlevel: 'maxLongRangePowerlevel',
+}
+
+function isSending(key: string): boolean {
+	const prop = SET_KEY_MAP[key] ?? key
+	return (
+		status.value.get(
+			controllerPropKey(props.device.nodeId, 'set', prop),
+		) === 'pending'
+	)
+}
+
+function isRefreshing(key: string): boolean {
+	const prop = REFRESH_KEY_MAP[key] ?? key
+	return (
+		status.value.get(
+			controllerPropKey(props.device.nodeId, 'refresh', prop),
+		) === 'pending'
+	)
+}
 
 function onChange(key: string, value: unknown) {
 	if (key === 'rfRegion') {
@@ -61,15 +105,9 @@ function onChange(key: string, value: unknown) {
 }
 
 function onRefresh(key: string) {
-	const propMap: Record<string, string> = {
-		rfRegion: 'RFRegion',
-		powerlevel: 'powerlevel',
-		measured0dBm: 'powerlevel',
-		maxLRPowerlevel: 'maxLongRangePowerlevel',
-	}
 	emit('action', props.device, {
 		type: 'refresh-controller-prop',
-		prop: propMap[key] ?? key,
+		prop: REFRESH_KEY_MAP[key] ?? key,
 	})
 }
 </script>

--- a/src/components/dashboard/components/ZwNodeDetailsBody.vue
+++ b/src/components/dashboard/components/ZwNodeDetailsBody.vue
@@ -94,13 +94,11 @@
 							<ZwStatsCard
 								title="Communication"
 								hint="Serial link errors"
-								layout="ledger"
 								:items="commStats"
 							/>
 							<ZwStatsCard
 								title="Messages"
 								hint="Frames since driver start"
-								layout="ledger"
 								:items="messageStats"
 							/>
 						</div>

--- a/src/components/dashboard/components/ZwNodeDetailsBody.vue
+++ b/src/components/dashboard/components/ZwNodeDetailsBody.vue
@@ -81,16 +81,39 @@
 
 				<Tabs.Panel
 					value="summary"
-					class="zw-nd__content zw-nd__summary"
+					class="zw-nd__content"
+					:class="
+						device.isController
+							? 'zw-nd__overview'
+							: 'zw-nd__summary'
+					"
 				>
-					<ZwPropTable title="Device" :rows="deviceRows" />
-					<ZwPropTable title="Firmware" :rows="fwRows" />
-					<ZwSecurityPanel :device="device" />
-					<ZwControllerOptionsPanel
-						v-if="device.isController"
-						:device="device"
-						@action="onAction"
-					/>
+					<template v-if="device.isController">
+						<span class="zw-nd__section-label">Statistics</span>
+						<div class="zw-nd__stats">
+							<ZwStatsCard
+								title="Communication"
+								hint="Serial link errors"
+								:items="commStats"
+							/>
+							<ZwStatsCard
+								title="Messages"
+								hint="Frames since driver start"
+								:items="messageStats"
+							/>
+						</div>
+						<ZwControllerOptionsPanel
+							:device="device"
+							@action="onAction"
+						/>
+						<span class="zw-nd__section-label">Firmware</span>
+						<ZwPropTable :rows="fwRows" />
+					</template>
+					<template v-else>
+						<ZwPropTable title="Device" :rows="deviceRows" />
+						<ZwPropTable title="Firmware" :rows="fwRows" />
+						<ZwSecurityPanel :device="device" />
+					</template>
 				</Tabs.Panel>
 
 				<Tabs.Panel value="associations" class="zw-nd__content">
@@ -112,11 +135,125 @@
 					<ZwNodeEvents :device="device" />
 				</Tabs.Panel>
 
-				<Tabs.Panel value="debug" class="zw-nd__content">
-					<div v-if="device.isController" class="zw-nd__stats">
-						<ZwStatsCard title="Communication" :items="commStats" />
-						<ZwStatsCard title="Messages" :items="messageStats" />
-					</div>
+				<Tabs.Panel
+					value="debug"
+					class="zw-nd__content"
+					:class="{ 'zw-nd__debug': device.isController }"
+				>
+					<template v-if="device.isController">
+						<ZwActionList>
+							<ZwActionBtn
+								title="Export controller JSON"
+								description="Download the controller's definition for backup or diagnostics."
+								:actions="[
+									{ label: 'UI', doneLabel: 'Saved' },
+									{ label: 'Driver', doneLabel: 'Saved' },
+								]"
+								@run="
+									(i: number) =>
+										emit('action', device, {
+											type:
+												i === 0
+													? 'export-ui'
+													: 'export-json',
+										})
+								"
+							>
+								<template #icon
+									><DownloadIcon :size="ICON_SIZE.std"
+								/></template>
+							</ZwActionBtn>
+							<ZwActionBtn
+								title="NVM Backup / Restore"
+								description="Back up or restore the controller's non-volatile memory."
+								:actions="[
+									{
+										label: 'Backup',
+										busyLabel: 'Backing up…',
+										doneLabel: 'Done',
+									},
+									{
+										label: 'Restore',
+										busyLabel: 'Restoring…',
+										doneLabel: 'Done',
+									},
+								]"
+								@run="
+									(i: number) =>
+										emit('action', device, {
+											type:
+												i === 0
+													? 'backup-nvm'
+													: 'restore-nvm',
+										})
+								"
+							>
+								<template #icon
+									><DatabaseIcon :size="ICON_SIZE.std"
+								/></template>
+							</ZwActionBtn>
+						</ZwActionList>
+						<ZwActionList>
+							<ZwActionBtn
+								title="Shutdown"
+								description="Safely shut down the Z-Wave API so the stick can be unplugged."
+								:actions="[
+									{
+										label: 'Shutdown',
+										busyLabel: 'Shutting down…',
+									},
+								]"
+								tone="accent"
+								@run="
+									emit('action', device, { type: 'shutdown' })
+								"
+							>
+								<template #icon
+									><PowerIcon :size="ICON_SIZE.std"
+								/></template>
+							</ZwActionBtn>
+							<ZwActionBtn
+								title="Soft reset"
+								description="Restart the controller. The network is preserved."
+								:actions="[
+									{
+										label: 'Soft reset',
+										busyLabel: 'Resetting…',
+										doneLabel: 'Done',
+									},
+								]"
+								@run="
+									emit('action', device, {
+										type: 'soft-reset',
+									})
+								"
+							>
+								<template #icon
+									><RefreshIcon :size="ICON_SIZE.std"
+								/></template>
+							</ZwActionBtn>
+							<ZwActionBtn
+								title="Factory reset"
+								description="Reset the controller to factory defaults. Every paired device will be removed."
+								:actions="[
+									{
+										label: 'Reset',
+										busyLabel: 'Resetting…',
+									},
+								]"
+								tone="danger"
+								@run="
+									emit('action', device, {
+										type: 'factory-reset',
+									})
+								"
+							>
+								<template #icon
+									><AlertIcon :size="ICON_SIZE.std"
+								/></template>
+							</ZwActionBtn>
+						</ZwActionList>
+					</template>
 					<ZwActionList v-else>
 						<ZwActionBtn
 							title="Ping"
@@ -211,11 +348,15 @@ import ZwNodeEvents from './ZwNodeEvents.vue'
 import ZwValuesView from './ZwValuesView.vue'
 import ZwControllerOptionsPanel from './ZwControllerOptionsPanel.vue'
 import {
+	AlertIcon,
+	DatabaseIcon,
 	DownloadIcon,
 	ICON_SIZE,
 	InterviewIcon,
 	NetworkIcon,
+	PowerIcon,
 	PulseIcon,
+	RefreshIcon,
 } from '@/lib/icons'
 import {
 	RAIL_WIDTH_BREAKPOINT,
@@ -357,9 +498,9 @@ const commStats = computed<StatsItem[]>(() => {
 	return [
 		{ label: 'CAN', value: s?.can ?? 0 },
 		{ label: 'NAK', value: s?.nak ?? 0 },
-		{ label: 'Timeout ACK', value: s?.timeoutACK ?? 0 },
-		{ label: 'Timeout Response', value: s?.timeoutResponse ?? 0 },
-		{ label: 'Timeout Callback', value: s?.timeoutCallback ?? 0 },
+		{ label: 'ACK Timeout', value: s?.timeoutACK ?? 0 },
+		{ label: 'Response Timeout', value: s?.timeoutResponse ?? 0 },
+		{ label: 'Callback Timeout', value: s?.timeoutCallback ?? 0 },
 	]
 })
 
@@ -570,6 +711,30 @@ const messageStats = computed<StatsItem[]>(() => {
 	.zw-nd__summary {
 		grid-template-columns: 1fr 1fr 1fr;
 	}
+}
+
+/* Controller overview — single-column stack, not the responsive grid
+   the node summary uses. */
+.zw-nd__overview {
+	display: flex;
+	flex-direction: column;
+	gap: 16px;
+}
+
+.zw-nd__section-label {
+	font-family: var(--zw-mono);
+	font-size: 10px;
+	font-weight: 600;
+	color: var(--zw-muted);
+	text-transform: uppercase;
+	letter-spacing: 0.6px;
+}
+
+/* Controller debug tab — two action-list cards stacked. */
+.zw-nd__debug {
+	display: flex;
+	flex-direction: column;
+	gap: 12px;
 }
 
 .zw-nd__empty {

--- a/src/components/dashboard/components/ZwNodeDetailsBody.vue
+++ b/src/components/dashboard/components/ZwNodeDetailsBody.vue
@@ -172,14 +172,15 @@
 										label: 'Backup',
 										busyLabel: 'Backing up…',
 										doneLabel: 'Done',
+										state: btnState('backup-nvm'),
 									},
 									{
 										label: 'Restore',
 										busyLabel: 'Restoring…',
 										doneLabel: 'Done',
+										state: btnState('restore-nvm'),
 									},
 								]"
-								:action-states="nvmStates"
 								:disabled="anyControllerActionBusy"
 								@run="
 									(i: number) =>
@@ -204,9 +205,9 @@
 									{
 										label: 'Shutdown',
 										busyLabel: 'Shutting down…',
+										state: btnState('shutdown'),
 									},
 								]"
-								:action-states="shutdownState"
 								:disabled="anyControllerActionBusy"
 								tone="accent"
 								@run="
@@ -225,9 +226,9 @@
 										label: 'Soft reset',
 										busyLabel: 'Resetting…',
 										doneLabel: 'Done',
+										state: btnState('soft-reset'),
 									},
 								]"
-								:action-states="softResetState"
 								:disabled="anyControllerActionBusy"
 								@run="
 									emit('action', device, {
@@ -246,9 +247,9 @@
 									{
 										label: 'Reset',
 										busyLabel: 'Resetting…',
+										state: btnState('factory-reset'),
 									},
 								]"
-								:action-states="factoryResetState"
 								:disabled="anyControllerActionBusy"
 								tone="danger"
 								@run="
@@ -377,7 +378,6 @@ import useBaseStore from '@/stores/base'
 import { buildValueGroups } from '@/lib/valueGroups.ts'
 import type { Device, DeviceAction } from '@/lib/dashboard-types'
 import {
-	actionPendingKey,
 	DeviceActionStatusKey,
 	type ActionStatus,
 } from '@/lib/deviceActionPending.ts'
@@ -402,32 +402,31 @@ const status = inject(
 	shallowRef<ReadonlyMap<string, ActionStatus>>(new Map()),
 )
 
-function btnState(actionType: DeviceAction['type']): BtnState {
-	const key = actionPendingKey(props.device, {
-		type: actionType,
-	} as DeviceAction)
-	if (!key) return 'idle'
+type ControllerDebugAction =
+	| 'backup-nvm'
+	| 'restore-nvm'
+	| 'shutdown'
+	| 'soft-reset'
+	| 'factory-reset'
+
+function btnState(actionType: ControllerDebugAction): BtnState {
+	const key = `${props.device.nodeId}:${actionType}`
 	const s = status.value.get(key)
 	if (s === 'pending') return 'busy'
 	if (s === 'ok') return 'done'
 	return 'idle'
 }
 
-const nvmStates = computed<BtnState[]>(() => [
-	btnState('backup-nvm'),
-	btnState('restore-nvm'),
-])
-
-const shutdownState = computed<BtnState[]>(() => [btnState('shutdown')])
-const softResetState = computed<BtnState[]>(() => [btnState('soft-reset')])
-const factoryResetState = computed<BtnState[]>(() => [
-	btnState('factory-reset'),
-])
+const CONTROLLER_DEBUG_ACTIONS: ControllerDebugAction[] = [
+	'backup-nvm',
+	'restore-nvm',
+	'shutdown',
+	'soft-reset',
+	'factory-reset',
+]
 
 const anyControllerActionBusy = computed(() =>
-	[nvmStates, shutdownState, softResetState, factoryResetState].some((s) =>
-		s.value.some((v) => v !== 'idle'),
-	),
+	CONTROLLER_DEBUG_ACTIONS.some((type) => btnState(type) !== 'idle'),
 )
 
 function onAction(d: Device, a: DeviceAction) {

--- a/src/components/dashboard/components/ZwNodeDetailsBody.vue
+++ b/src/components/dashboard/components/ZwNodeDetailsBody.vue
@@ -178,6 +178,7 @@
 										doneLabel: 'Done',
 									},
 								]"
+								:action-states="nvmStates"
 								@run="
 									(i: number) =>
 										emit('action', device, {
@@ -203,6 +204,7 @@
 										busyLabel: 'Shutting down…',
 									},
 								]"
+								:action-states="shutdownState"
 								tone="accent"
 								@run="
 									emit('action', device, { type: 'shutdown' })
@@ -222,6 +224,7 @@
 										doneLabel: 'Done',
 									},
 								]"
+								:action-states="softResetState"
 								@run="
 									emit('action', device, {
 										type: 'soft-reset',
@@ -241,6 +244,7 @@
 										busyLabel: 'Resetting…',
 									},
 								]"
+								:action-states="factoryResetState"
 								tone="danger"
 								@run="
 									emit('action', device, {
@@ -333,7 +337,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed, watch } from 'vue'
+import { ref, computed, inject, shallowRef, watch } from 'vue'
 import { Tabs } from '@vuetify/v0'
 import ZwStatusDot from '@/components/dashboard/atoms/ZwStatusDot.vue'
 import ZwPrimaryDisplay from './ZwPrimaryDisplay.vue'
@@ -367,6 +371,12 @@ import {
 import useBaseStore from '@/stores/base'
 import { buildValueGroups } from '@/lib/valueGroups.ts'
 import type { Device, DeviceAction } from '@/lib/dashboard-types'
+import {
+	actionPendingKey,
+	DeviceActionStatusKey,
+	type ActionStatus,
+} from '@/lib/deviceActionPending.ts'
+import type { BtnState } from './ZwActionBtn.vue'
 
 // `viewport` is the host panel's width. `layout="stacked"` forces
 // single-column regardless of width (used by the card-view drawer).
@@ -381,6 +391,33 @@ const props = withDefaults(
 const emit = defineEmits<{ action: [Device, DeviceAction] }>()
 
 const baseStore = useBaseStore()
+
+const status = inject(
+	DeviceActionStatusKey,
+	shallowRef<ReadonlyMap<string, ActionStatus>>(new Map()),
+)
+
+function btnState(actionType: DeviceAction['type']): BtnState {
+	const key = actionPendingKey(props.device, {
+		type: actionType,
+	} as DeviceAction)
+	if (!key) return 'idle'
+	const s = status.value.get(key)
+	if (s === 'pending') return 'busy'
+	if (s === 'ok') return 'done'
+	return 'idle'
+}
+
+const nvmStates = computed<BtnState[]>(() => [
+	btnState('backup-nvm'),
+	btnState('restore-nvm'),
+])
+
+const shutdownState = computed<BtnState[]>(() => [btnState('shutdown')])
+const softResetState = computed<BtnState[]>(() => [btnState('soft-reset')])
+const factoryResetState = computed<BtnState[]>(() => [
+	btnState('factory-reset'),
+])
 
 function onAction(d: Device, a: DeviceAction) {
 	emit('action', d, a)

--- a/src/components/dashboard/components/ZwNodeDetailsBody.vue
+++ b/src/components/dashboard/components/ZwNodeDetailsBody.vue
@@ -149,6 +149,7 @@
 									{ label: 'UI', doneLabel: 'Saved' },
 									{ label: 'Driver', doneLabel: 'Saved' },
 								]"
+								:disabled="anyControllerActionBusy"
 								@run="
 									(i: number) =>
 										emit('action', device, {
@@ -179,6 +180,7 @@
 									},
 								]"
 								:action-states="nvmStates"
+								:disabled="anyControllerActionBusy"
 								@run="
 									(i: number) =>
 										emit('action', device, {
@@ -205,6 +207,7 @@
 									},
 								]"
 								:action-states="shutdownState"
+								:disabled="anyControllerActionBusy"
 								tone="accent"
 								@run="
 									emit('action', device, { type: 'shutdown' })
@@ -225,6 +228,7 @@
 									},
 								]"
 								:action-states="softResetState"
+								:disabled="anyControllerActionBusy"
 								@run="
 									emit('action', device, {
 										type: 'soft-reset',
@@ -245,6 +249,7 @@
 									},
 								]"
 								:action-states="factoryResetState"
+								:disabled="anyControllerActionBusy"
 								tone="danger"
 								@run="
 									emit('action', device, {
@@ -418,6 +423,12 @@ const softResetState = computed<BtnState[]>(() => [btnState('soft-reset')])
 const factoryResetState = computed<BtnState[]>(() => [
 	btnState('factory-reset'),
 ])
+
+const anyControllerActionBusy = computed(() =>
+	[nvmStates, shutdownState, softResetState, factoryResetState].some((s) =>
+		s.value.some((v) => v !== 'idle'),
+	),
+)
 
 function onAction(d: Device, a: DeviceAction) {
 	emit('action', d, a)

--- a/src/components/dashboard/components/ZwNodeDetailsBody.vue
+++ b/src/components/dashboard/components/ZwNodeDetailsBody.vue
@@ -94,11 +94,13 @@
 							<ZwStatsCard
 								title="Communication"
 								hint="Serial link errors"
+								layout="ledger"
 								:items="commStats"
 							/>
 							<ZwStatsCard
 								title="Messages"
 								hint="Frames since driver start"
+								layout="ledger"
 								:items="messageStats"
 							/>
 						</div>

--- a/src/components/dashboard/components/ZwStatsCard.vue
+++ b/src/components/dashboard/components/ZwStatsCard.vue
@@ -76,6 +76,7 @@ function formatValue(item: StatsItem) {
 	font-family: var(--zw-mono);
 	font-size: 10px;
 	color: var(--zw-muted);
+	min-width: 0;
 	overflow: hidden;
 	text-overflow: ellipsis;
 	white-space: nowrap;

--- a/src/components/dashboard/components/ZwStatsCard.vue
+++ b/src/components/dashboard/components/ZwStatsCard.vue
@@ -1,6 +1,9 @@
 <template>
 	<section class="zw-sc">
-		<div class="zw-sc__title">{{ title }}</div>
+		<div class="zw-sc__header">
+			<span class="zw-sc__title">{{ title }}</span>
+			<span v-if="hint" class="zw-sc__hint">{{ hint }}</span>
+		</div>
 		<div
 			class="zw-sc__body"
 			:style="{
@@ -29,6 +32,7 @@ export type StatsItem = {
 withDefaults(
 	defineProps<{
 		title: string
+		hint?: string
 		items: StatsItem[]
 		minCellWidth?: number
 	}>(),
@@ -56,13 +60,30 @@ function formatValue(item: StatsItem) {
 	padding-bottom: 8px;
 }
 
+.zw-sc__header {
+	display: flex;
+	align-items: baseline;
+	justify-content: space-between;
+	gap: 8px;
+	padding: 8px 12px;
+	border-bottom: 1px solid var(--zw-line);
+}
+
 .zw-sc__title {
-	padding: 6px 10px;
 	font-family: var(--zw-mono);
 	font-size: 10px;
 	color: var(--zw-muted);
 	text-transform: uppercase;
 	letter-spacing: 0.6px;
+}
+
+.zw-sc__hint {
+	font-family: var(--zw-mono);
+	font-size: 10px;
+	color: var(--zw-muted);
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
 }
 
 .zw-sc__body {

--- a/src/components/dashboard/components/ZwStatsCard.vue
+++ b/src/components/dashboard/components/ZwStatsCard.vue
@@ -1,10 +1,27 @@
 <template>
-	<section class="zw-sc">
+	<section class="zw-sc" :class="{ 'zw-sc--ledger': layout === 'ledger' }">
 		<div class="zw-sc__header">
 			<span class="zw-sc__title">{{ title }}</span>
 			<span v-if="hint" class="zw-sc__hint">{{ hint }}</span>
 		</div>
+		<div v-if="layout === 'ledger'" class="zw-sc__ledger">
+			<div
+				v-for="(item, i) in items"
+				:key="item.label"
+				class="zw-sc__row"
+				:class="{ 'zw-sc__row--first': i === 0 }"
+			>
+				<span class="zw-sc__row-label">{{ item.label }}</span>
+				<span
+					class="zw-sc__row-value"
+					:class="{ 'zw-sc__row-value--muted': isMuted(item) }"
+				>
+					{{ formatValue(item) }}
+				</span>
+			</div>
+		</div>
 		<div
+			v-else
 			class="zw-sc__body"
 			:style="{
 				gridTemplateColumns: `repeat(auto-fit, minmax(${minCellWidth}px, 1fr))`,
@@ -34,9 +51,10 @@ withDefaults(
 		title: string
 		hint?: string
 		items: StatsItem[]
+		layout?: 'grid' | 'ledger'
 		minCellWidth?: number
 	}>(),
-	{ minCellWidth: 96 },
+	{ layout: 'grid', minCellWidth: 96 },
 )
 
 function isMuted(item: StatsItem) {
@@ -57,6 +75,9 @@ function formatValue(item: StatsItem) {
 	border: 1px solid var(--zw-line);
 	border-radius: 6px;
 	overflow: hidden;
+}
+
+.zw-sc:not(.zw-sc--ledger) {
 	padding-bottom: 8px;
 }
 
@@ -86,6 +107,7 @@ function formatValue(item: StatsItem) {
 	white-space: nowrap;
 }
 
+/* ── Grid layout (default) ── */
 .zw-sc__body {
 	display: grid;
 	gap: 1px;
@@ -117,6 +139,43 @@ function formatValue(item: StatsItem) {
 }
 
 .zw-sc__value--muted {
+	color: var(--zw-muted);
+}
+
+/* ── Ledger layout ── */
+.zw-sc__ledger {
+	display: flex;
+	flex-direction: column;
+}
+
+.zw-sc__row {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: 12px;
+	padding: 7px 12px;
+	border-top: 1px solid var(--zw-line);
+}
+
+.zw-sc__row--first {
+	border-top: none;
+}
+
+.zw-sc__row-label {
+	font-family: var(--zw-mono);
+	font-size: 11px;
+	color: var(--zw-muted);
+}
+
+.zw-sc__row-value {
+	font-family: var(--zw-mono);
+	font-size: 14px;
+	font-weight: 500;
+	color: var(--zw-fg);
+	font-variant-numeric: tabular-nums;
+}
+
+.zw-sc__row-value--muted {
 	color: var(--zw-muted);
 }
 </style>

--- a/src/components/dashboard/components/ZwStatsCard.vue
+++ b/src/components/dashboard/components/ZwStatsCard.vue
@@ -1,40 +1,23 @@
 <template>
-	<section class="zw-sc" :class="{ 'zw-sc--ledger': layout === 'ledger' }">
+	<section class="zw-sc">
 		<div class="zw-sc__header">
 			<span class="zw-sc__title">{{ title }}</span>
 			<span v-if="hint" class="zw-sc__hint">{{ hint }}</span>
 		</div>
-		<div v-if="layout === 'ledger'" class="zw-sc__ledger">
+		<div class="zw-sc__body">
 			<div
 				v-for="(item, i) in items"
 				:key="item.label"
 				class="zw-sc__row"
 				:class="{ 'zw-sc__row--first': i === 0 }"
 			>
-				<span class="zw-sc__row-label">{{ item.label }}</span>
+				<span class="zw-sc__label">{{ item.label }}</span>
 				<span
-					class="zw-sc__row-value"
-					:class="{ 'zw-sc__row-value--muted': isMuted(item) }"
-				>
-					{{ formatValue(item) }}
-				</span>
-			</div>
-		</div>
-		<div
-			v-else
-			class="zw-sc__body"
-			:style="{
-				gridTemplateColumns: `repeat(auto-fit, minmax(${minCellWidth}px, 1fr))`,
-			}"
-		>
-			<div v-for="item in items" :key="item.label" class="zw-sc__cell">
-				<div class="zw-sc__label">{{ item.label }}</div>
-				<div
 					class="zw-sc__value"
 					:class="{ 'zw-sc__value--muted': isMuted(item) }"
 				>
 					{{ formatValue(item) }}
-				</div>
+				</span>
 			</div>
 		</div>
 	</section>
@@ -46,16 +29,11 @@ export type StatsItem = {
 	value: number | string
 }
 
-withDefaults(
-	defineProps<{
-		title: string
-		hint?: string
-		items: StatsItem[]
-		layout?: 'grid' | 'ledger'
-		minCellWidth?: number
-	}>(),
-	{ layout: 'grid', minCellWidth: 96 },
-)
+defineProps<{
+	title: string
+	hint?: string
+	items: StatsItem[]
+}>()
 
 function isMuted(item: StatsItem) {
 	return typeof item.value === 'number' && item.value === 0
@@ -75,10 +53,6 @@ function formatValue(item: StatsItem) {
 	border: 1px solid var(--zw-line);
 	border-radius: 6px;
 	overflow: hidden;
-}
-
-.zw-sc:not(.zw-sc--ledger) {
-	padding-bottom: 8px;
 }
 
 .zw-sc__header {
@@ -107,43 +81,7 @@ function formatValue(item: StatsItem) {
 	white-space: nowrap;
 }
 
-/* ── Grid layout (default) ── */
 .zw-sc__body {
-	display: grid;
-	gap: 1px;
-	background: var(--zw-line);
-}
-
-.zw-sc__cell {
-	display: flex;
-	flex-direction: column;
-	gap: 3px;
-	padding: 8px 10px;
-	background: var(--zw-card);
-}
-
-.zw-sc__label {
-	font-family: var(--zw-mono);
-	font-size: 10px;
-	color: var(--zw-muted);
-	text-transform: uppercase;
-	letter-spacing: 0.4px;
-}
-
-.zw-sc__value {
-	font-family: var(--zw-mono);
-	font-size: 15px;
-	font-weight: 500;
-	color: var(--zw-fg);
-	font-variant-numeric: tabular-nums;
-}
-
-.zw-sc__value--muted {
-	color: var(--zw-muted);
-}
-
-/* ── Ledger layout ── */
-.zw-sc__ledger {
 	display: flex;
 	flex-direction: column;
 }
@@ -161,13 +99,13 @@ function formatValue(item: StatsItem) {
 	border-top: none;
 }
 
-.zw-sc__row-label {
+.zw-sc__label {
 	font-family: var(--zw-mono);
 	font-size: 11px;
 	color: var(--zw-muted);
 }
 
-.zw-sc__row-value {
+.zw-sc__value {
 	font-family: var(--zw-mono);
 	font-size: 14px;
 	font-weight: 500;
@@ -175,7 +113,7 @@ function formatValue(item: StatsItem) {
 	font-variant-numeric: tabular-nums;
 }
 
-.zw-sc__row-value--muted {
+.zw-sc__value--muted {
 	color: var(--zw-muted);
 }
 </style>

--- a/src/lib/deviceActionPending.ts
+++ b/src/lib/deviceActionPending.ts
@@ -55,6 +55,16 @@ export function actionPendingKey(
 			return controllerPropKey(device.nodeId, 'set', 'maxLRPowerlevel')
 		case 'refresh-controller-prop':
 			return controllerPropKey(device.nodeId, 'refresh', action.prop)
+		case 'backup-nvm':
+			return `${device.nodeId}:backup-nvm`
+		case 'restore-nvm':
+			return `${device.nodeId}:restore-nvm`
+		case 'factory-reset':
+			return `${device.nodeId}:factory-reset`
+		case 'soft-reset':
+			return `${device.nodeId}:soft-reset`
+		case 'shutdown':
+			return `${device.nodeId}:shutdown`
 		default:
 			return null
 	}

--- a/src/lib/deviceActionPending.ts
+++ b/src/lib/deviceActionPending.ts
@@ -28,6 +28,14 @@ export function ccPendingKey(nodeId: number, cc: number): string {
 	return `${nodeId}:cc:${cc}`
 }
 
+export function controllerPropKey(
+	nodeId: number,
+	op: string,
+	prop: string,
+): string {
+	return `${nodeId}:${op}:ctrl:${prop}`
+}
+
 export function actionPendingKey(
 	device: Device,
 	action: DeviceAction,
@@ -39,6 +47,14 @@ export function actionPendingKey(
 			return pollPendingKey(device.nodeId, action.valueId)
 		case 'refresh-cc':
 			return ccPendingKey(device.nodeId, action.commandClass)
+		case 'set-rf-region':
+			return controllerPropKey(device.nodeId, 'set', 'rfRegion')
+		case 'set-powerlevel':
+			return controllerPropKey(device.nodeId, 'set', 'powerlevel')
+		case 'set-max-lr-powerlevel':
+			return controllerPropKey(device.nodeId, 'set', 'maxLRPowerlevel')
+		case 'refresh-controller-prop':
+			return controllerPropKey(device.nodeId, 'refresh', action.prop)
 		default:
 			return null
 	}

--- a/src/lib/deviceProjection.ts
+++ b/src/lib/deviceProjection.ts
@@ -2,6 +2,7 @@
 
 import { CommandClasses, type ValueID } from '@zwave-js/core'
 import { DoorLockMode } from '@zwave-js/cc'
+import type { ControllerStatistics } from 'zwave-js'
 import type { ZUINode, ZUIValueId } from '../../api/lib/ZwaveClient.ts'
 import { inferArchetype } from './archetypes.ts'
 import { relativeTime } from './time.ts'
@@ -381,19 +382,7 @@ function projectActivities(
 
 function projectCommStats(node: ZUINode): CommStats | undefined {
 	if (!node.isControllerNode) return undefined
-	const s = node.statistics as
-		| {
-				CAN?: number
-				NAK?: number
-				timeoutACK?: number
-				timeoutResponse?: number
-				timeoutCallback?: number
-				messagesTX?: number
-				messagesRX?: number
-				messagesDroppedTX?: number
-				messagesDroppedRX?: number
-		  }
-		| undefined
+	const s = node.statistics as ControllerStatistics | undefined
 	if (!s) return undefined
 	return {
 		can: s.CAN ?? 0,

--- a/src/lib/deviceProjection.ts
+++ b/src/lib/deviceProjection.ts
@@ -7,6 +7,7 @@ import { inferArchetype } from './archetypes.ts'
 import { relativeTime } from './time.ts'
 import type {
 	Activity,
+	CommStats,
 	Device,
 	DeviceStatus,
 	FirmwareUpdateInfo,
@@ -378,6 +379,35 @@ function projectActivities(
 	return out
 }
 
+function projectCommStats(node: ZUINode): CommStats | undefined {
+	if (!node.isControllerNode) return undefined
+	const s = node.statistics as
+		| {
+				CAN?: number
+				NAK?: number
+				timeoutACK?: number
+				timeoutResponse?: number
+				timeoutCallback?: number
+				messagesTX?: number
+				messagesRX?: number
+				messagesDroppedTX?: number
+				messagesDroppedRX?: number
+		  }
+		| undefined
+	if (!s) return undefined
+	return {
+		can: s.CAN ?? 0,
+		nak: s.NAK ?? 0,
+		timeoutACK: s.timeoutACK ?? 0,
+		timeoutResponse: s.timeoutResponse ?? 0,
+		timeoutCallback: s.timeoutCallback ?? 0,
+		messagesTX: s.messagesTX ?? 0,
+		messagesRX: s.messagesRX ?? 0,
+		messagesDroppedTX: s.messagesDroppedTX ?? 0,
+		messagesDroppedRX: s.messagesDroppedRX ?? 0,
+	}
+}
+
 export function projectDevice(
 	node: ZUINode,
 	opts: ProjectOptions = {},
@@ -448,6 +478,7 @@ export function projectDevice(
 			'number'
 				? (node as unknown as { txPower: number }).txPower
 				: undefined,
+		commStats: projectCommStats(node),
 	}
 }
 

--- a/src/views/ControlPanelNew.vue
+++ b/src/views/ControlPanelNew.vue
@@ -64,19 +64,29 @@ function setStatus(key: string, value: ActionStatus) {
 	status.value = next
 }
 
-function completeAction(key: string, ok: boolean) {
+const DONE_VISIBLE_MS = 1400
+
+function completeAction(key: string, ok: boolean, delayMs = 0) {
 	setStatus(key, ok ? 'ok' : 'fail')
-	// Delete after one tick so pre-flush watchers can read the outcome.
-	nextTick(() => {
+	const clear = () => {
 		const next = new Map(status.value)
 		next.delete(key)
 		status.value = next
-	})
+	}
+	if (delayMs > 0) {
+		setTimeout(clear, delayMs)
+	} else {
+		// Delete after one tick so pre-flush watchers can read the outcome.
+		nextTick(clear)
+	}
 }
 
-function downloadJson(data: unknown, filename: string) {
-	const json = JSON.stringify(data, null, 2)
-	const blob = new Blob([json], { type: 'text/plain' })
+function downloadFile(
+	data: string | ArrayBuffer | Uint8Array,
+	filename: string,
+	type = 'text/plain',
+) {
+	const blob = new Blob([data], { type })
 	const a = document.createElement('a')
 	a.href = URL.createObjectURL(blob)
 	a.download = filename
@@ -84,6 +94,10 @@ function downloadJson(data: unknown, filename: string) {
 	a.click()
 	document.body.removeChild(a)
 	URL.revokeObjectURL(a.href)
+}
+
+function downloadJson(data: unknown, filename: string) {
+	downloadFile(JSON.stringify(data, null, 2), filename)
 }
 
 async function onAction(device: Device, action: DeviceAction) {
@@ -115,40 +129,34 @@ async function onAction(device: Device, action: DeviceAction) {
 		)
 		return
 	}
-	if (action.type === 'factory-reset') {
+	if (action.type === 'backup-nvm') {
 		const app = appInstance()
 		if (!app) return
-		const result = await app.confirm(
-			'Hard Reset',
-			'Your controller will be reset to factory and all paired devices will be removed',
+		const confirmed = await app.confirm(
+			'NVM Backup',
+			'While doing the backup the Z-Wave radio will be turned on/off',
 			'alert',
-			{
-				confirmText: 'Ok',
-				inputs: [
-					{
-						type: 'text',
-						label: 'Confirm',
-						required: true,
-						key: 'confirm',
-						hint: 'Type "yes" and press OK to confirm',
-					},
-				],
-			},
+			{ confirmText: 'Ok' },
 		)
-		if (!result || typeof result !== 'object' || result.confirm !== 'yes') {
-			return
-		}
+		if (!confirmed) return
 		const key = actionPendingKey(device, action)
 		if (key) setStatus(key, 'pending')
 		let ok = false
 		try {
-			const response = await app.apiRequest('hardReset', [], {
+			const response = await app.apiRequest('backupNVMRaw', [], {
 				infoSnack: false,
 				errorSnack: true,
 			})
 			ok = response.success
+			if (ok && response.result) {
+				const r = response.result as {
+					data: ArrayBuffer | Uint8Array
+					fileName: string
+				}
+				downloadFile(r.data, r.fileName, 'application/octet-stream')
+			}
 		} finally {
-			if (key) completeAction(key, ok)
+			if (key) completeAction(key, ok, DONE_VISIBLE_MS)
 		}
 		return
 	}
@@ -196,7 +204,94 @@ async function onAction(device: Device, action: DeviceAction) {
 			)
 			ok = response.success
 		} finally {
-			if (key) completeAction(key, ok)
+			if (key) completeAction(key, ok, DONE_VISIBLE_MS)
+		}
+		return
+	}
+	if (action.type === 'factory-reset') {
+		const app = appInstance()
+		if (!app) return
+		const result = await app.confirm(
+			'Hard Reset',
+			'Your controller will be reset to factory and all paired devices will be removed',
+			'alert',
+			{
+				confirmText: 'Ok',
+				inputs: [
+					{
+						type: 'text',
+						label: 'Confirm',
+						required: true,
+						key: 'confirm',
+						hint: 'Type "yes" and press OK to confirm',
+					},
+				],
+			},
+		)
+		if (!result || typeof result !== 'object' || result.confirm !== 'yes') {
+			return
+		}
+		const key = actionPendingKey(device, action)
+		if (key) setStatus(key, 'pending')
+		let ok = false
+		try {
+			const response = await app.apiRequest('hardReset', [], {
+				infoSnack: false,
+				errorSnack: true,
+			})
+			ok = response.success
+		} finally {
+			if (key) completeAction(key, ok, DONE_VISIBLE_MS)
+		}
+		return
+	}
+	if (action.type === 'soft-reset') {
+		const app = appInstance()
+		if (!app) return
+		const confirmed = await app.confirm(
+			'Info',
+			`<p>Are you sure you want to soft-reset your controller?</p>
+			<p>USB modules will reconnect, meaning that they might get a new address. Make sure to configure your device address in a way that prevents it from changing, e.g. by using <code>/dev/serial/by-id/...</code> on Linux.</p>
+			<p><strong>This method may cause problems in Docker containers with certain Z-Wave stick.</strong> If that happens, you may need to restart your host OS and docker container.</p>`,
+			'info',
+			{ confirmText: 'ok', cancelText: 'cancel', width: 900 },
+		)
+		if (!confirmed) return
+		const key = actionPendingKey(device, action)
+		if (key) setStatus(key, 'pending')
+		let ok = false
+		try {
+			const response = await app.apiRequest('softReset', [], {
+				infoSnack: false,
+				errorSnack: true,
+			})
+			ok = response.success
+		} finally {
+			if (key) completeAction(key, ok, DONE_VISIBLE_MS)
+		}
+		return
+	}
+	if (action.type === 'shutdown') {
+		const app = appInstance()
+		if (!app) return
+		const confirmed = await app.confirm(
+			'Info',
+			'Are you sure you want to shutdown the Zwave API? You will have to unplug and replug the Zwave stick manually to restart it.',
+			'warning',
+			{ confirmText: 'ok', cancelText: 'cancel' },
+		)
+		if (!confirmed) return
+		const key = actionPendingKey(device, action)
+		if (key) setStatus(key, 'pending')
+		let ok = false
+		try {
+			const response = await app.apiRequest('shutdownZwaveAPI', [], {
+				infoSnack: false,
+				errorSnack: true,
+			})
+			ok = response.success
+		} finally {
+			if (key) completeAction(key, ok, DONE_VISIBLE_MS)
 		}
 		return
 	}

--- a/src/views/ControlPanelNew.vue
+++ b/src/views/ControlPanelNew.vue
@@ -37,6 +37,12 @@ interface AppLike {
 		args?: unknown[],
 		opts?: { infoSnack?: boolean; errorSnack?: boolean },
 	) => Promise<ApiResponse>
+	confirm: (
+		title: string,
+		text: string,
+		level?: string,
+		options?: Record<string, unknown>,
+	) => Promise<Record<string, unknown> | boolean>
 	showSnackbar: (msg: string, level?: string) => void
 	restart: () => Promise<void>
 	showUpdateDialog: () => Promise<void>
@@ -86,6 +92,18 @@ async function onAction(device: Device, action: DeviceAction) {
 		if (node) downloadJson(node, `node_${device.nodeId}.json`)
 		return
 	}
+	if (action.type === 'export-json') {
+		const app = appInstance()
+		if (!app) return
+		const response = await app.apiRequest('dumpNode', [device.nodeId], {
+			infoSnack: false,
+			errorSnack: true,
+		})
+		if (response.success && response.result) {
+			downloadJson(response.result, `node_${device.nodeId}_dump.json`)
+		}
+		return
+	}
 	if (action.type === 'firmware-upload') {
 		const app = appInstance()
 		if (!app) return
@@ -95,6 +113,91 @@ async function onAction(device: Device, action: DeviceAction) {
 			[device.nodeId, [{ name: action.file.name, data }]],
 			{ infoSnack: true, errorSnack: true },
 		)
+		return
+	}
+	if (action.type === 'factory-reset') {
+		const app = appInstance()
+		if (!app) return
+		const result = await app.confirm(
+			'Hard Reset',
+			'Your controller will be reset to factory and all paired devices will be removed',
+			'alert',
+			{
+				confirmText: 'Ok',
+				inputs: [
+					{
+						type: 'text',
+						label: 'Confirm',
+						required: true,
+						key: 'confirm',
+						hint: 'Type "yes" and press OK to confirm',
+					},
+				],
+			},
+		)
+		if (!result || typeof result !== 'object' || result.confirm !== 'yes') {
+			return
+		}
+		const key = actionPendingKey(device, action)
+		if (key) setStatus(key, 'pending')
+		let ok = false
+		try {
+			const response = await app.apiRequest('hardReset', [], {
+				infoSnack: false,
+				errorSnack: true,
+			})
+			ok = response.success
+		} finally {
+			if (key) completeAction(key, ok)
+		}
+		return
+	}
+	if (action.type === 'restore-nvm') {
+		const app = appInstance()
+		if (!app) return
+		const result = await app.confirm(
+			'NVM Restore',
+			'While doing the restore the Z-Wave radio will be turned on/off.\n<strong>A failure during this process may brick your controller. Use at your own risk!</strong>',
+			'alert',
+			{
+				confirmText: 'Ok',
+				width: 500,
+				inputs: [
+					{
+						type: 'file',
+						label: 'File',
+						hint: 'NVM file',
+						key: 'file',
+					},
+					{
+						type: 'checkbox',
+						label: 'Skip compatibility check',
+						hint: 'This needs to be checked in order to allow restoring NVM backups on older controllers, with the risk of restoring an incompatible backup',
+						key: 'useRaw',
+					},
+				],
+			},
+		)
+		if (!result || typeof result !== 'object' || !result.file) return
+		let nvmData: ArrayBuffer
+		try {
+			nvmData = await (result.file as File).arrayBuffer()
+		} catch {
+			return
+		}
+		const key = actionPendingKey(device, action)
+		if (key) setStatus(key, 'pending')
+		let ok = false
+		try {
+			const response = await app.apiRequest(
+				'restoreNVM',
+				[nvmData, result.useRaw],
+				{ infoSnack: true, errorSnack: true },
+			)
+			ok = response.success
+		} finally {
+			if (key) completeAction(key, ok)
+		}
 		return
 	}
 	const req = dispatchAction(device, action)


### PR DESCRIPTION
Overview tab (controller only) now stacks: Statistics → Controller Options (RF settings) → Firmware. The old Device and Security Keys cards are dropped for the controller.

Debug tab (controller) replaces the stats cards with two action-list groups: Export+NVM in one card, Shutdown+Reset+Factory in another.

Stats cards gain a hint prop for subtitle text. The device projection now populates commStats from the controller's statistics object.

---

<img width="838" height="843" alt="image" src="https://github.com/user-attachments/assets/6995697b-5275-41f3-9a7c-0b6770e60b2c" />

<img width="837" height="377" alt="image" src="https://github.com/user-attachments/assets/79c09880-fd59-4a17-8389-7358db50db87" />
