### PR TITLE
feat: allow managing statistics opt-in via external settings

### DIFF
--- a/api/app.ts
+++ b/api/app.ts
@@ -1500,6 +1500,12 @@ app.post(
 					'Gateway is restarting, wait a moment before doing another request',
 				)
 			}
+			// Reject changes when the statistics opt-in belongs to the managing application
+			if (
+				getExternallyManagedPaths().includes('zwave.enableStatistics')
+			) {
+				throw Error('Statistics are managed externally')
+			}
 			const { enableStatistics } = req.body
 
 			const settings: Settings =

--- a/api/lib/externalSettings.ts
+++ b/api/lib/externalSettings.ts
@@ -45,6 +45,7 @@ export interface ExternalZwaveSettings {
 
 	// Features
 	enableSoftReset?: boolean
+	enableStatistics?: boolean
 
 	// Z-Wave JS Server settings
 	serverEnabled?: boolean
@@ -119,6 +120,8 @@ export function getExternallyManagedPaths(): string[] {
 	// Features
 	if (settings.enableSoftReset !== undefined)
 		paths.push('zwave.enableSoftReset')
+	if (settings.enableStatistics !== undefined)
+		paths.push('zwave.enableStatistics')
 
 	// Device config
 	if (settings.deviceConfigPriorityDir !== undefined)
@@ -236,6 +239,8 @@ export function mergeExternalSettings(
 	// Features
 	if (settings.enableSoftReset !== undefined)
 		zwaveConfig.enableSoftReset = settings.enableSoftReset
+	if (settings.enableStatistics !== undefined)
+		zwaveConfig.enableStatistics = settings.enableStatistics
 
 	// Device config
 	if (settings.deviceConfigPriorityDir !== undefined)

--- a/docs/usage/setup.md
+++ b/docs/usage/setup.md
@@ -416,6 +416,7 @@ The external settings file should be a JSON file with the following structure:
 **Features**:
 
 - `enableSoftReset` (boolean): Enable soft reset functionality
+- `enableStatistics` (boolean): Enable Z-Wave JS usage statistics. When set, the statistics opt-in dialog is not shown and the managing application is expected to control the statistics opt-in (e.g. via the Z-Wave JS Server API)
 
 **Z-Wave JS Server Settings**:
 

--- a/src/App.vue
+++ b/src/App.vue
@@ -436,6 +436,7 @@ export default {
 			'znifferState',
 			'inited',
 			'nodes',
+			'isSettingManagedExternally',
 		]),
 		...mapState(useBaseStore, {
 			darkMode: (store) => store.uiState.darkMode,
@@ -1264,9 +1265,13 @@ export default {
 					}
 
 					if (
-						!data.settings ||
-						!data.settings.zwave ||
-						data.settings.zwave.enableStatistics === undefined
+						(!data.settings ||
+							!data.settings.zwave ||
+							data.settings.zwave.enableStatistics ===
+								undefined) &&
+						!this.isSettingManagedExternally(
+							'zwave.enableStatistics',
+						)
 					) {
 						const result = await this.confirm(
 							'Usage statistics',

--- a/src/views/Settings.vue
+++ b/src/views/Settings.vue
@@ -1161,7 +1161,15 @@
 											></v-switch>
 										</v-col>
 
-										<v-col cols="12" sm="6">
+										<v-col
+											cols="12"
+											sm="6"
+											v-if="
+												!isSettingManagedExternally(
+													'zwave.enableStatistics',
+												)
+											"
+										>
 											<v-switch
 												hint="Usage statistics allows us to gain insight how `zwave-js` is used, which manufacturers and devices are most prevalent and where to best focus our efforts in order to improve `zwave-js` the most. We do not store any personal information. Details can be found under https://zwave-js.github.io/node-zwave-js/#/data-collection/data-collection?id=usage-statistics"
 												persistent-hint


### PR DESCRIPTION
I noticed quite the uptick in Z-Wave JS UI installations, but none at all in HA - turns out this was a bug. The way we run Z-UI in HA caused Z-Wave JS UI to report to the statistics backend (after opt-in there), without HA ever having the chance to announce that it was involved. To fix this, we'll make the statistics opt-in as externally managed.

When `enableStatistics` is set in the external settings file, the statistics opt-in dialog is no longer shown, the setting is hidden in the UI and the /api/statistics endpoint rejects changes. This lets a managing application (e.g. the Home Assistant add-on) own the statistics opt-in through the Z-Wave JS Server API, so usage is attributed to the correct application name and version.