### PR TITLE
refactor(zwave): extract schedules and configuration templates

### DIFF
--- a/api/lib/ZwaveClient.ts
+++ b/api/lib/ZwaveClient.ts
@@ -109,13 +109,10 @@ import {
 	QRCodeVersion,
 	RemoveNodeReason,
 	RFRegion,
-	ScheduleEntryLockCC,
-	ScheduleEntryLockScheduleKind,
 	SerialAPISetupCommand,
 	setValueFailed,
 	SetValueStatus,
 	setValueWasUnsupervisedOrSucceeded,
-	UserCodeCC,
 	UserIDStatus,
 	ProvisioningEntryStatus,
 	AssociationCheckResult,
@@ -168,8 +165,24 @@ import type {
 } from '../hass/types.ts'
 import { ScheduleService } from './zwave/ScheduleService.ts'
 import { ConfigurationTemplateService } from './zwave/ConfigurationTemplateService.ts'
+import {
+	ZUIScheduleEntryLockMode,
+	type ZUIConfigurationTemplate,
+	type ZUIConfigurationTemplateValue,
+	type ZUISchedule,
+	type ZUIScheduleConfig,
+	type ZUISlot,
+} from './zwave/ports.ts'
 
 export type { HassDevice } from '../hass/types.ts'
+export { ZUIScheduleEntryLockMode }
+export type {
+	ZUIConfigurationTemplate,
+	ZUIConfigurationTemplateValue,
+	ZUISchedule,
+	ZUIScheduleConfig,
+	ZUISlot,
+}
 
 export const configManager = new ConfigManager({
 	deviceConfigPriorityDir,
@@ -455,32 +468,6 @@ export type ZUIScene = {
 	values: ZUIValueIdScene[]
 }
 
-export type ZUIConfigurationTemplateValue = {
-	property: number
-	propertyKey?: number | null
-	endpoint: number
-	value: unknown
-	label?: string
-	description?: string
-}
-
-export type ZUIConfigurationTemplate = {
-	id: string
-	name: string
-	deviceId: string
-	manufacturerId?: number
-	productId?: number
-	productType?: number
-	manufacturer?: string
-	productLabel?: string
-	firmwareRange?: { min?: string; max?: string }
-	values: ZUIConfigurationTemplateValue[]
-	autoApply: boolean
-	contentHash: string
-	createdAt: string
-	updatedAt: string
-}
-
 export type ZUIDeviceClass = {
 	basic: number
 	generic: number
@@ -546,27 +533,6 @@ export interface ZUIEndpoint {
 		generic: number
 		specific: number
 	}
-}
-
-export const ZUIScheduleEntryLockMode = {
-	DAILY: 'daily',
-	WEEKLY: 'weekly',
-	YEARLY: 'yearly',
-} as const
-export type ZUIScheduleEntryLockMode =
-	(typeof ZUIScheduleEntryLockMode)[keyof typeof ZUIScheduleEntryLockMode]
-
-export interface ZUISchedule {
-	[ZUIScheduleEntryLockMode.DAILY]: ZUIScheduleConfig<ScheduleEntryLockDailyRepeatingSchedule>
-	[ZUIScheduleEntryLockMode.WEEKLY]: ZUIScheduleConfig<ScheduleEntryLockWeekDaySchedule>
-	[ZUIScheduleEntryLockMode.YEARLY]: ZUIScheduleConfig<ScheduleEntryLockYearDaySchedule>
-}
-
-export type ZUISlot<T> = T & { enabled: boolean } & ScheduleEntryLockSlotId
-
-export interface ZUIScheduleConfig<T> {
-	numSlots: number
-	slots: ZUISlot<T>[]
 }
 
 export type ZUINode = {

--- a/api/lib/ZwaveClient.ts
+++ b/api/lib/ZwaveClient.ts
@@ -166,6 +166,8 @@ import type {
 	HassDeviceMap,
 	StoreHassDevicesResult,
 } from '../hass/types.ts'
+import { ScheduleService } from './zwave/ScheduleService.ts'
+import { ConfigurationTemplateService } from './zwave/ConfigurationTemplateService.ts'
 
 export type { HassDevice } from '../hass/types.ts'
 
@@ -776,7 +778,6 @@ class ZwaveClient extends TypedEventEmitter<ZwaveClientEventCallbacks> {
 	private _driverReady: boolean
 	private scenes: ZUIScene[]
 	private groups: Group[]
-	private _configTemplates: ZUIConfigurationTemplate[]
 	private _nodes: Map<number, ZUINode>
 	/**
 	 * Holds the live driver-side virtual-node instances (multicast groups +
@@ -883,8 +884,8 @@ class ZwaveClient extends TypedEventEmitter<ZwaveClientEventCallbacks> {
 	private pollIntervals: Record<string, NodeJS.Timeout>
 
 	private _lockNeighborsRefresh: boolean
-	private _lockGetSchedule: boolean
-	private _cancelGetSchedule: boolean
+	private _scheduleService: ScheduleService
+	private _configTemplateService: ConfigurationTemplateService
 
 	private nvmEvent: string
 
@@ -1000,12 +1001,82 @@ class ZwaveClient extends TypedEventEmitter<ZwaveClientEventCallbacks> {
 		this.driverReady = false
 		this.scenes = jsonStore.get(store.scenes)
 		this.groups = jsonStore.get(store.groups)
-		this._configTemplates = jsonStore.get(store.configurationTemplates)
 
 		this._nodes = new Map()
 		this._virtualNodes = new Map()
 		this._nodeToGroups = new Map()
 		this._rebuildNodeToGroupsIndex()
+
+		// Construct service ports that resolve current state across restarts
+		const scheduleDriverPort = {
+			getDriver: () => this._driver,
+		}
+		const scheduleNodeStorePort = {
+			getNode: (nodeId: number) => this._nodes.get(nodeId),
+			emitNodeUpdate: (
+				node: ZUINode,
+				changedProps: utils.DeepPartial<ZUINode>,
+			) => this.emitNodeUpdate(node, changedProps),
+		}
+		const scheduleUtilsPort = {
+			deepEqual: (a: unknown, b: unknown) => utils.deepEqual(a, b),
+		}
+		this._scheduleService = new ScheduleService(
+			scheduleDriverPort,
+			scheduleNodeStorePort,
+			scheduleUtilsPort,
+		)
+
+		const templateDriverPort = {
+			getDriver: () => this._driver,
+		}
+		const templateNodeStorePort = {
+			getNode: (nodeId: number) => this._nodes.get(nodeId),
+			getNodes: () => this._nodes.entries(),
+			getStoreNode: (nodeId: number) => this.storeNodes[nodeId],
+			setStoreNode: (nodeId: number, data: Partial<ZUINode>) => {
+				if (!this.storeNodes[nodeId]) {
+					this.storeNodes[nodeId] = {} as any
+				}
+				Object.assign(this.storeNodes[nodeId], data)
+			},
+			updateStoreNodes: (rebuildRoutes?: boolean) =>
+				this.updateStoreNodes(rebuildRoutes),
+			emitNodeUpdate: (
+				node: ZUINode,
+				changedProps: utils.DeepPartial<ZUINode>,
+			) => this.emitNodeUpdate(node, changedProps),
+			writeValue: (
+				valueId: {
+					nodeId: number
+					commandClass: number
+					endpoint: number
+					property: number
+					propertyKey?: number | null
+				},
+				value: unknown,
+			) => this.writeValue(valueId as ZUIValueId, value),
+			logNode: (zwaveNode: ZWaveNode, level: string, message: string) =>
+				this.logNode(zwaveNode, level as LogManager.LogLevel, message),
+			throttle: (key: string, fn: () => void, wait: number) =>
+				this.throttle(key, fn, wait),
+		}
+		const templatePersistencePort = {
+			get: () => jsonStore.get(store.configurationTemplates),
+			put: (data: ZUIConfigurationTemplate[]) =>
+				jsonStore.put(store.configurationTemplates, data),
+		}
+		const templateUtilsPort = {
+			generateId: () => utils.generateId(),
+		}
+		this._configTemplateService = new ConfigurationTemplateService(
+			templateDriverPort,
+			templateNodeStorePort,
+			templatePersistencePort,
+			templateUtilsPort,
+			logger,
+			jsonStore.get(store.configurationTemplates),
+		)
 
 		this._devices = {}
 		this.driverInfo = {}
@@ -1450,246 +1521,11 @@ class ZwaveClient extends TypedEventEmitter<ZwaveClientEventCallbacks> {
 			fromCache: true,
 		},
 	) {
-		const zwaveNode = this.getNode(nodeId)
-
-		if (!zwaveNode?.commandClasses['Schedule Entry Lock'].isSupported()) {
-			throw new Error(
-				'Schedule Entry Lock CC not supported on node ' + nodeId,
-			)
-		}
-
-		if (this._lockGetSchedule) {
-			throw new Error(
-				'Another request is in progress, cancel it or wait...',
-			)
-		}
-
-		const promise = async () => {
-			this._cancelGetSchedule = false
-			this._lockGetSchedule = true
-			const { mode, fromCache } = opts
-			// TODO: should we check also other endpoints?
-			const endpointIndex = 0
-			const endpoint = zwaveNode.getEndpoint(endpointIndex)
-
-			const userCodes = UserCodeCC.getSupportedUsersCached(
-				this.driver,
-				endpoint,
-			)
-
-			const numSlots = {
-				numWeekDaySlots: ScheduleEntryLockCC.getNumWeekDaySlotsCached(
-					this.driver,
-					endpoint,
-				),
-				numYearDaySlots: ScheduleEntryLockCC.getNumYearDaySlotsCached(
-					this.driver,
-					endpoint,
-				),
-				numDailyRepeatingSlots:
-					ScheduleEntryLockCC.getNumDailyRepeatingSlotsCached(
-						this.driver,
-						endpoint,
-					),
-			}
-
-			const node = this._nodes.get(nodeId)
-
-			const weeklySchedules: ZUISlot<ScheduleEntryLockWeekDaySchedule>[] =
-				node.schedule?.weekly?.slots ?? []
-			const yearlySchedules: ZUISlot<ScheduleEntryLockYearDaySchedule>[] =
-				node.schedule?.yearly?.slots ?? []
-			const dailySchedules: ZUISlot<ScheduleEntryLockDailyRepeatingSchedule>[] =
-				node.schedule?.daily?.slots ?? []
-
-			node.schedule = {
-				daily: {
-					numSlots: numSlots.numDailyRepeatingSlots,
-					slots: dailySchedules,
-				},
-				weekly: {
-					numSlots: numSlots.numWeekDaySlots,
-					slots: weeklySchedules,
-				},
-				yearly: {
-					numSlots: numSlots.numYearDaySlots,
-					slots: yearlySchedules,
-				},
-			}
-
-			node.userCodes = {
-				total: userCodes,
-				available: [],
-				enabled: [],
-			}
-
-			const pushSchedule = (
-				arr: ZUISlot<any>[],
-				slot: ScheduleEntryLockSlotId,
-				schedule:
-					| ScheduleEntryLockWeekDaySchedule
-					| ScheduleEntryLockYearDaySchedule
-					| ScheduleEntryLockDailyRepeatingSchedule,
-				enabled: boolean,
-			) => {
-				const index = arr.findIndex(
-					(s) => s.userId === slot.userId && s.slotId === slot.slotId,
-				)
-				if (schedule) {
-					const newSlot = {
-						...slot,
-						...schedule,
-						enabled,
-					}
-					if (index === -1) {
-						arr.push(newSlot)
-					} else {
-						arr[index] = newSlot
-					}
-				} else if (index !== -1) {
-					arr.splice(index, 1)
-				}
-			}
-
-			for (let i = 1; i <= userCodes; i++) {
-				const status = UserCodeCC.getUserIdStatusCached(
-					this.driver,
-					endpoint,
-					i,
-				)
-
-				if (
-					status === undefined ||
-					status === UserIDStatus.Available ||
-					status === UserIDStatus.StatusNotAvailable
-				) {
-					// skip query on not enabled userIds or empty codes
-					continue
-				}
-
-				node.userCodes.available.push(i)
-
-				const enabledUserId =
-					ScheduleEntryLockCC.getUserCodeScheduleEnabledCached(
-						this.driver,
-						endpoint,
-						i,
-					)
-
-				if (enabledUserId) {
-					node.userCodes.enabled.push(i)
-				}
-
-				const enabledType =
-					ScheduleEntryLockCC.getUserCodeScheduleKindCached(
-						this.driver,
-						endpoint,
-						i,
-					)
-
-				const getCached = (
-					kind: ScheduleEntryLockScheduleKind,
-					slotId: number,
-				) =>
-					ScheduleEntryLockCC.getScheduleCached(
-						this.driver,
-						endpoint,
-						kind,
-						i,
-						slotId,
-					)
-
-				if (!mode || mode === ZUIScheduleEntryLockMode.WEEKLY) {
-					const enabled =
-						enabledType === ScheduleEntryLockScheduleKind.WeekDay
-
-					for (let s = 1; s <= numSlots.numWeekDaySlots; s++) {
-						if (this._cancelGetSchedule) return
-
-						const slot: ScheduleEntryLockSlotId = {
-							userId: i,
-							slotId: s,
-						}
-
-						const schedule = fromCache
-							? (getCached(
-									ScheduleEntryLockScheduleKind.WeekDay,
-									s,
-								) as ScheduleEntryLockWeekDaySchedule)
-							: await zwaveNode.commandClasses[
-									'Schedule Entry Lock'
-								].getWeekDaySchedule(slot)
-
-						pushSchedule(weeklySchedules, slot, schedule, enabled)
-					}
-				}
-
-				if (!mode || mode === ZUIScheduleEntryLockMode.YEARLY) {
-					const enabled =
-						enabledType === ScheduleEntryLockScheduleKind.YearDay
-
-					for (let s = 1; s <= numSlots.numYearDaySlots; s++) {
-						if (this._cancelGetSchedule) return
-
-						const slot: ScheduleEntryLockSlotId = {
-							userId: i,
-							slotId: s,
-						}
-						const schedule = fromCache
-							? (getCached(
-									ScheduleEntryLockScheduleKind.YearDay,
-									s,
-								) as ScheduleEntryLockYearDaySchedule)
-							: await zwaveNode.commandClasses[
-									'Schedule Entry Lock'
-								].getYearDaySchedule(slot)
-
-						pushSchedule(yearlySchedules, slot, schedule, enabled)
-					}
-				}
-
-				if (!mode || mode === ZUIScheduleEntryLockMode.DAILY) {
-					const enabled =
-						enabledType ===
-						ScheduleEntryLockScheduleKind.DailyRepeating
-
-					for (let s = 1; s <= numSlots.numDailyRepeatingSlots; s++) {
-						if (this._cancelGetSchedule) return
-
-						const slot: ScheduleEntryLockSlotId = {
-							userId: i,
-							slotId: s,
-						}
-						const schedule = fromCache
-							? (getCached(
-									ScheduleEntryLockScheduleKind.DailyRepeating,
-									s,
-								) as ScheduleEntryLockDailyRepeatingSchedule)
-							: await zwaveNode.commandClasses[
-									'Schedule Entry Lock'
-								].getDailyRepeatingSchedule(slot)
-
-						pushSchedule(dailySchedules, slot, schedule, enabled)
-					}
-				}
-			}
-
-			this.emitNodeUpdate(node, {
-				schedule: node.schedule,
-				userCodes: node.userCodes,
-			})
-
-			return node.schedule
-		}
-
-		return promise().finally(() => {
-			this._lockGetSchedule = false
-			this._cancelGetSchedule = false
-		})
+		return this._scheduleService.getSchedules(nodeId, opts)
 	}
 
 	cancelGetSchedule() {
-		this._cancelGetSchedule = true
+		this._scheduleService.cancelGetSchedule()
 	}
 
 	async setSchedule(
@@ -1702,182 +1538,11 @@ class ZwaveClient extends TypedEventEmitter<ZwaveClientEventCallbacks> {
 				| ScheduleEntryLockYearDaySchedule
 			),
 	) {
-		const zwaveNode = this.getNode(nodeId)
-
-		if (!zwaveNode?.commandClasses['Schedule Entry Lock'].isSupported()) {
-			throw new Error(
-				'Schedule Entry Lock CC not supported on node ' + nodeId,
-			)
-		}
-
-		const slot: ScheduleEntryLockSlotId = {
-			userId: schedule.userId,
-			slotId: schedule.slotId,
-		}
-
-		delete schedule.userId
-		delete schedule.slotId
-		delete schedule['enabled']
-
-		const isDelete = Object.keys(schedule).length === 0
-
-		if (isDelete) {
-			schedule = undefined
-		}
-
-		let result: SupervisionResult
-
-		if (type === 'daily') {
-			result = await zwaveNode.commandClasses[
-				'Schedule Entry Lock'
-			].setDailyRepeatingSchedule(
-				slot,
-				schedule as ScheduleEntryLockDailyRepeatingSchedule,
-			)
-		} else if (type === 'weekly') {
-			result = await zwaveNode.commandClasses[
-				'Schedule Entry Lock'
-			].setWeekDaySchedule(
-				slot,
-				schedule as ScheduleEntryLockWeekDaySchedule,
-			)
-		} else if (type === 'yearly') {
-			result = await zwaveNode.commandClasses[
-				'Schedule Entry Lock'
-			].setYearDaySchedule(
-				slot,
-				schedule as ScheduleEntryLockYearDaySchedule,
-			)
-		} else {
-			throw new Error('Invalid schedule type')
-		}
-
-		// means that is not using supervision, read slot and check if it matches
-		if (!result) {
-			const methods = {
-				daily: 'getDailyRepeatingSchedule',
-				weekly: 'getWeekDaySchedule',
-				yearly: 'getYearDaySchedule',
-			}
-			const res =
-				await zwaveNode.commandClasses['Schedule Entry Lock'][
-					methods[type]
-				](slot)
-
-			if (
-				(isDelete && !res) ||
-				(!isDelete && res && utils.deepEqual(res, schedule))
-			) {
-				result = {
-					status: SupervisionStatus.Success,
-				}
-			} else {
-				result = {
-					status: SupervisionStatus.Fail,
-				}
-			}
-		}
-
-		if (result.status === SupervisionStatus.Success) {
-			const node = this._nodes.get(nodeId)
-
-			// update enabled state
-			for (const mode in node.schedule) {
-				node.schedule[mode].slots = node.schedule[mode].slots.map(
-					(s: ZUISlot<any>) => ({
-						...s,
-						enabled: mode === type,
-					}),
-				)
-			}
-
-			const slots = node.schedule?.[type]?.slots
-
-			if (slots) {
-				const slotIndex = slots.findIndex(
-					(s) => s.userId === slot.userId && s.slotId === slot.slotId,
-				)
-				const newSlot = isDelete
-					? null
-					: {
-							...slot,
-							...schedule,
-							enabled: true,
-						}
-
-				if (isDelete) {
-					if (slotIndex !== -1) {
-						slots.splice(slotIndex, 1)
-					}
-				} else if (slotIndex !== -1) {
-					slots[slotIndex] = newSlot
-				} else {
-					slots.push(newSlot as any)
-				}
-
-				const isEnabledUsercode = node.userCodes?.enabled?.includes(
-					slot.userId,
-				)
-
-				if (!isDelete && !isEnabledUsercode) {
-					node.userCodes.enabled.push(slot.userId)
-				} else if (isDelete && isEnabledUsercode) {
-					const index = node.userCodes.enabled.indexOf(slot.userId)
-					if (index >= 0) {
-						node.userCodes.enabled.splice(index, 1)
-					}
-				}
-
-				this.emitNodeUpdate(node, {
-					schedule: node.schedule,
-					userCodes: node.userCodes,
-				})
-			}
-		}
-
-		return result
+		return this._scheduleService.setSchedule(nodeId, type, schedule)
 	}
 
 	async setEnabledSchedule(nodeId: number, enabled: boolean, userId: number) {
-		const zwaveNode = this.getNode(nodeId)
-
-		if (!zwaveNode) {
-			throw new Error('Node not found')
-		}
-
-		const result = await zwaveNode.commandClasses[
-			'Schedule Entry Lock'
-		].setEnabled(enabled, userId)
-
-		// if result is not defined here we don't have a way
-		// to know if the command was successful or not as there is no
-		// 'get' command for this, so we just assume it was successful
-		if (isUnsupervisedOrSucceeded(result)) {
-			const node = this._nodes.get(nodeId)
-
-			if (node) {
-				if (userId) {
-					if (enabled) {
-						node.userCodes?.enabled.push(userId)
-					} else {
-						const index = node.userCodes?.enabled.indexOf(userId)
-						if (index >= 0) {
-							node.userCodes.enabled.splice(index, 1)
-						}
-					}
-				} else {
-					node.userCodes.enabled = enabled
-						? node.userCodes.available.slice()
-						: []
-				}
-
-				this.emitNodeUpdate(node, {
-					userCodes: node.userCodes,
-				})
-			}
-		}
-
-		return result
+		return this._scheduleService.setEnabledSchedule(nodeId, enabled, userId)
 	}
 
 	/**
@@ -3271,7 +2936,7 @@ class ZwaveClient extends TypedEventEmitter<ZwaveClientEventCallbacks> {
 	 * Get all configuration templates
 	 */
 	getConfigurationTemplates(): ZUIConfigurationTemplate[] {
-		return this._configTemplates
+		return this._configTemplateService.getConfigurationTemplates()
 	}
 
 	/**
@@ -3281,65 +2946,9 @@ class ZwaveClient extends TypedEventEmitter<ZwaveClientEventCallbacks> {
 	async getDeviceConfigurationParams(
 		deviceId: string,
 	): Promise<Partial<ZUIValueId>[]> {
-		const parts = deviceId.split('-')
-		if (parts.length !== 3) {
-			throw new Error(
-				'Invalid deviceId format, expected manufacturerId-productId-productType',
-			)
-		}
-
-		const manufacturerId = parseInt(parts[0], 10)
-		const productId = parseInt(parts[1], 10)
-		const productType = parseInt(parts[2], 10)
-
-		if (isNaN(manufacturerId) || isNaN(productId) || isNaN(productType)) {
-			throw new Error('Invalid deviceId: non-numeric components')
-		}
-
-		await configManager.loadDeviceIndex()
-
-		const device = await configManager.lookupDevice(
-			manufacturerId,
-			productType,
-			productId,
-		)
-
-		if (!device || !device.paramInformation) {
-			return []
-		}
-
-		const result: Partial<ZUIValueId>[] = []
-
-		for (const [key, param] of device.paramInformation.entries()) {
-			const propertyKey = key.valueBitMask
-			const id = `0-112-0-${key.parameter}${propertyKey != null ? '-' + propertyKey : ''}`
-
-			result.push({
-				id,
-				commandClass: 112,
-				property: key.parameter,
-				propertyKey: propertyKey,
-				endpoint: 0,
-				type: 'number',
-				readable: true,
-				writeable: !param.readOnly,
-				label: param.label,
-				description: param.description,
-				min: param.minValue,
-				max: param.maxValue,
-				default: param.defaultValue,
-				unit: param.unit,
-				list: param.options?.length > 0,
-				allowManualEntry: param.allowManualEntry,
-				states: param.options?.map((o) => ({
-					text: o.label,
-					value: o.value,
-				})),
-				newValue: param.defaultValue,
-			} as any)
-		}
-
-		return result
+		return this._configTemplateService.getDeviceConfigurationParams(
+			deviceId,
+		) as Promise<Partial<ZUIValueId>[]>
 	}
 
 	/**
@@ -3352,87 +2961,13 @@ class ZwaveClient extends TypedEventEmitter<ZwaveClientEventCallbacks> {
 		values?: ZUIConfigurationTemplateValue[],
 		firmwareRange?: { min?: string; max?: string },
 	): Promise<ZUIConfigurationTemplate> {
-		const node = this._nodes.get(nodeId)
-
-		if (!node) {
-			throw Error(`Node ${nodeId} not found`)
-		}
-
-		if (!node.ready) {
-			throw Error(`Node ${nodeId} is not ready`)
-		}
-
-		let configValues: ZUIConfigurationTemplateValue[]
-
-		if (values && values.length > 0) {
-			// Use custom values provided by the wizard
-			configValues = values
-		} else {
-			// Extract CC 112 (Configuration) writeable values
-			configValues = []
-
-			for (const id in node.values) {
-				const v = node.values[id]
-				if (
-					v.commandClass === CommandClasses.Configuration &&
-					v.writeable
-				) {
-					configValues.push({
-						property: v.property as number,
-						propertyKey:
-							v.propertyKey != null
-								? (v.propertyKey as number)
-								: null,
-						endpoint: v.endpoint || 0,
-						value: v.value,
-						label: v.label,
-						description: v.description,
-					})
-				}
-			}
-		}
-
-		if (configValues.length === 0) {
-			throw Error(
-				`Node ${nodeId} has no writeable Configuration CC values`,
-			)
-		}
-
-		const id = utils.generateId()
-
-		const now = new Date().toISOString()
-
-		const template: ZUIConfigurationTemplate = {
-			id,
+		return this._configTemplateService.createConfigurationTemplate(
+			nodeId,
 			name,
-			deviceId: node.deviceId,
-			manufacturerId: node.manufacturerId,
-			productId: node.productId,
-			productType: node.productType,
-			manufacturer: node.manufacturer,
-			productLabel: node.productLabel,
-			firmwareRange:
-				firmwareRange?.min || firmwareRange?.max
-					? firmwareRange
-					: undefined,
-			values: configValues,
 			autoApply,
-			contentHash: this._generateTemplateContentHash(
-				configValues,
-				firmwareRange,
-			),
-			createdAt: now,
-			updatedAt: now,
-		}
-
-		this._configTemplates.push(template)
-		await jsonStore.put(store.configurationTemplates, this._configTemplates)
-
-		if (autoApply) {
-			this._autoApplyTemplateToNodes(template)
-		}
-
-		return template
+			values,
+			firmwareRange,
+		)
 	}
 
 	/**
@@ -3447,68 +2982,17 @@ class ZwaveClient extends TypedEventEmitter<ZwaveClientEventCallbacks> {
 			values?: ZUIConfigurationTemplateValue[]
 		},
 	): Promise<ZUIConfigurationTemplate> {
-		const template = this._configTemplates.find((t) => t.id === id)
-
-		if (!template) {
-			throw Error(`Template ${id} not found`)
-		}
-
-		if (updates.name !== undefined) template.name = updates.name
-		if (updates.autoApply !== undefined)
-			template.autoApply = updates.autoApply
-
-		const contentChanged =
-			updates.firmwareRange !== undefined || updates.values !== undefined
-
-		if (updates.firmwareRange !== undefined)
-			template.firmwareRange = updates.firmwareRange
-		if (updates.values !== undefined) template.values = updates.values
-
-		if (contentChanged) {
-			template.contentHash = this._generateTemplateContentHash(
-				template.values,
-				template.firmwareRange,
-			)
-		}
-
-		template.updatedAt = new Date().toISOString()
-
-		await jsonStore.put(store.configurationTemplates, this._configTemplates)
-
-		if (template.autoApply && contentChanged) {
-			this._autoApplyTemplateToNodes(template)
-		}
-
-		return template
+		return this._configTemplateService.updateConfigurationTemplate(
+			id,
+			updates,
+		)
 	}
 
 	/**
 	 * Delete a configuration template
 	 */
 	async deleteConfigurationTemplate(id: string): Promise<boolean> {
-		const index = this._configTemplates.findIndex((t) => t.id === id)
-
-		if (index < 0) {
-			throw Error(`Template ${id} not found`)
-		}
-
-		const deletedHash = this._configTemplates[index].contentHash
-
-		this._configTemplates.splice(index, 1)
-		await jsonStore.put(store.configurationTemplates, this._configTemplates)
-
-		// Cleanup the deleted template's hash from all nodes
-		if (deletedHash) {
-			for (const [, node] of this._nodes) {
-				const hashes = node.appliedTemplateContentHashes
-				if (hashes && hashes.includes(deletedHash)) {
-					// _cleanupAppliedTemplateHashes removes any hash not matching an existing template
-					await this._cleanupAppliedTemplateHashes(node)
-				}
-			}
-		}
-
-		return true
+		return this._configTemplateService.deleteConfigurationTemplate(id)
 	}
 
 	/**
@@ -3595,126 +3079,11 @@ class ZwaveClient extends TypedEventEmitter<ZwaveClientEventCallbacks> {
 		errors: string[]
 		reason?: string
 	}> {
-		const template = this._configTemplates.find((t) => t.id === templateId)
-
-		if (!template) {
-			throw Error(`Template ${templateId} not found`)
-		}
-
-		const node = this._nodes.get(nodeId)
-
-		if (!node) {
-			throw Error(`Node ${nodeId} not found`)
-		}
-
-		if (!node.ready) {
-			throw Error(`Node ${nodeId} is not ready`)
-		}
-
-		if (
-			!force &&
-			template.deviceId &&
-			node.deviceId &&
-			template.deviceId !== node.deviceId
-		) {
-			throw Error(
-				`Template device type "${template.deviceId}" does not match node device type "${node.deviceId}". Use force to override.`,
-			)
-		}
-
-		const results: {
-			success: number
-			failed: number
-			errors: string[]
-			reason?: string
-		} = { success: 0, failed: 0, errors: [] }
-
-		for (const tv of template.values) {
-			try {
-				// skip writing `undefined` configuration values to prevent errors
-				if (tv.value === undefined) {
-					results.success++
-					continue
-				}
-
-				const result = await this.writeValue(
-					{
-						nodeId,
-						commandClass: CommandClasses.Configuration,
-						endpoint: tv.endpoint,
-						property: tv.property,
-						propertyKey: tv.propertyKey,
-					} as ZUIValueId,
-					tv.value,
-				)
-
-				if (setValueFailed(result)) {
-					results.failed++
-					results.errors.push(
-						`Parameter ${tv.property}: ${result.message || getEnumMemberName(SetValueStatus, result.status)}`,
-					)
-
-					// Fail + node is dead means no point continuing
-					if (
-						result.status === SetValueStatus.Fail &&
-						node.status === 'Dead'
-					) {
-						const remaining =
-							template.values.length -
-							results.success -
-							results.failed
-						if (remaining > 0) {
-							results.failed += remaining
-						}
-						results.reason = 'Node is dead'
-						break
-					}
-				} else {
-					results.success++
-				}
-			} catch (error) {
-				results.failed++
-				results.errors.push(
-					`Parameter ${tv.property}: ${error.message}`,
-				)
-			}
-		}
-
-		logger.info(
-			`Applied template "${template.name}" to node ${nodeId}: ${results.success} OK, ${results.failed} failed`,
+		return this._configTemplateService.applyConfigurationTemplate(
+			templateId,
+			nodeId,
+			force,
 		)
-
-		// Record content hash if any values were applied successfully
-		if (results.success > 0 && template.contentHash) {
-			if (!node.appliedTemplateContentHashes) {
-				node.appliedTemplateContentHashes = []
-			}
-
-			if (
-				!node.appliedTemplateContentHashes.includes(
-					template.contentHash,
-				)
-			) {
-				node.appliedTemplateContentHashes.push(template.contentHash)
-
-				if (!this.storeNodes[nodeId]) {
-					this.storeNodes[nodeId] = {} as any
-				}
-				this.storeNodes[nodeId].appliedTemplateContentHashes =
-					node.appliedTemplateContentHashes
-
-				this.throttle(
-					'applyTemplate_storeNodes',
-					() => {
-						// eslint-disable-next-line @typescript-eslint/no-floating-promises
-						this.updateStoreNodes(false)
-					},
-					1000,
-				)
-			}
-		}
-
-		return results
 	}
 
 	/**
@@ -3723,69 +3092,9 @@ class ZwaveClient extends TypedEventEmitter<ZwaveClientEventCallbacks> {
 	async importConfigurationTemplates(
 		templates: ZUIConfigurationTemplate[],
 	): Promise<ZUIConfigurationTemplate[]> {
-		// Migrate legacy minFirmwareVersion to firmwareRange
-		for (const t of templates) {
-			if ((t as any).minFirmwareVersion && !t.firmwareRange) {
-				t.firmwareRange = { min: (t as any).minFirmwareVersion }
-				delete (t as any).minFirmwareVersion
-			}
-			t.id = utils.generateId()
-			if (!t.contentHash) {
-				t.contentHash = this._generateTemplateContentHash(
-					t.values,
-					t.firmwareRange,
-				)
-			}
-			this._configTemplates.push(t)
-		}
-
-		await jsonStore.put(store.configurationTemplates, this._configTemplates)
-
-		return this._configTemplates
-	}
-
-	/**
-	 * Generate a short content hash for a template based on its applied values
-	 */
-	private _generateTemplateContentHash(
-		values: ZUIConfigurationTemplateValue[],
-		firmwareRange?: { min?: string; max?: string },
-	): string {
-		// Normalize values to ensure deterministic key ordering across
-		// different code paths (create vs import)
-		const normalized = values.map((v) => ({
-			property: v.property,
-			propertyKey: v.propertyKey ?? null,
-			endpoint: v.endpoint,
-			value: v.value,
-		}))
-		return createHash('sha256')
-			.update(JSON.stringify({ values: normalized, firmwareRange }))
-			.digest('hex')
-			.slice(0, 12)
-	}
-
-	/**
-	 * Remove applied template hashes that no longer match any existing template
-	 */
-	private async _cleanupAppliedTemplateHashes(node: ZUINode) {
-		const hashes = node.appliedTemplateContentHashes
-		if (!hashes || hashes.length === 0) return
-
-		const validHashes = new Set(
-			this._configTemplates.map((t) => t.contentHash),
+		return this._configTemplateService.importConfigurationTemplates(
+			templates,
 		)
-		const cleaned = hashes.filter((h) => validHashes.has(h))
-
-		if (cleaned.length !== hashes.length) {
-			node.appliedTemplateContentHashes = cleaned
-
-			if (!this.storeNodes[node.id]) {
-				this.storeNodes[node.id] = {} as any
-			}
-			this.storeNodes[node.id].appliedTemplateContentHashes = cleaned
-			await this.updateStoreNodes(false)
-		}
 	}
 
 	/**
@@ -4210,137 +3519,11 @@ class ZwaveClient extends TypedEventEmitter<ZwaveClientEventCallbacks> {
 	}
 
 	/**
-	 * Auto-apply a template to all matching ready nodes that haven't received it yet
-	 */
-	private _autoApplyTemplateToNodes(template: ZUIConfigurationTemplate) {
-		if (!this._driver?.controller) return
-
-		for (const [, node] of this._nodes) {
-			if (!node.ready || !node.deviceId) continue
-
-			const matching = this._getMatchingTemplates(node)
-			if (!matching.some((t) => t.id === template.id)) continue
-
-			const hashes = node.appliedTemplateContentHashes || []
-			if (hashes.includes(template.contentHash)) continue
-
-			const zwaveNode = this._driver.controller.nodes.get(node.id)
-
-			if (zwaveNode) {
-				this.logNode(
-					zwaveNode,
-					'info',
-					`Auto-applying configuration template "${template.name}"`,
-				)
-			}
-
-			this.applyConfigurationTemplate(template.id, node.id, true)
-				.then((result) => {
-					if (result.failed > 0 && zwaveNode) {
-						this.logNode(
-							zwaveNode,
-							'warn',
-							`Template "${template.name}" partially applied: ${result.success} OK, ${result.failed} failed`,
-						)
-					}
-				})
-				.catch((error) => {
-					if (zwaveNode) {
-						this.logNode(
-							zwaveNode,
-							'error',
-							`Failed to auto-apply template "${template.name}": ${error.message}`,
-						)
-					}
-				})
-		}
-	}
-
-	/**
-	 * Get templates matching a node's device type and firmware version
-	 */
-	private _getMatchingTemplates(node: ZUINode): ZUIConfigurationTemplate[] {
-		if (!node.deviceId) return []
-
-		return this._configTemplates.filter((t) => {
-			if (t.deviceId !== node.deviceId) return false
-
-			// Check firmware version range if specified
-			if (t.firmwareRange?.min || t.firmwareRange?.max) {
-				if (!node.firmwareVersion) {
-					return false
-				}
-
-				const nodeFw = semverCoerce(node.firmwareVersion)
-				if (!nodeFw) return false
-
-				if (t.firmwareRange.min) {
-					const minFw = semverCoerce(t.firmwareRange.min)
-					if (!minFw || !semverGte(nodeFw, minFw)) {
-						return false
-					}
-				}
-
-				if (t.firmwareRange.max) {
-					const maxFw = semverCoerce(t.firmwareRange.max)
-					if (!maxFw || !semverLte(nodeFw, maxFw)) {
-						return false
-					}
-				}
-			}
-
-			return true
-		})
-	}
-
-	/**
-	 * Check and auto-apply matching configuration templates for a node
+	 * Check and auto-apply matching configuration templates for a node.
+	 * Delegates to ConfigurationTemplateService.
 	 */
 	private _checkConfigurationTemplates(node: ZUINode, zwaveNode: ZWaveNode) {
-		// Cleanup stale applied hashes on node ready
-		// eslint-disable-next-line @typescript-eslint/no-floating-promises
-		this._cleanupAppliedTemplateHashes(node)
-
-		const matching = this._getMatchingTemplates(node)
-
-		if (matching.length === 0) {
-			return
-		}
-
-		const appliedHashes = node.appliedTemplateContentHashes || []
-
-		// Filter auto-apply templates that haven't been applied yet
-		const autoApplyTemplates = matching.filter(
-			(t) =>
-				t.autoApply &&
-				t.contentHash &&
-				!appliedHashes.includes(t.contentHash),
-		)
-
-		for (const template of autoApplyTemplates) {
-			this.logNode(
-				zwaveNode,
-				'info',
-				`Auto-applying configuration template "${template.name}"`,
-			)
-			this.applyConfigurationTemplate(template.id, node.id, true)
-				.then((result) => {
-					if (result.failed > 0) {
-						this.logNode(
-							zwaveNode,
-							'warn',
-							`Template "${template.name}" partially applied: ${result.success} OK, ${result.failed} failed`,
-						)
-					}
-				})
-				.catch((error) => {
-					this.logNode(
-						zwaveNode,
-						'error',
-						`Failed to auto-apply template "${template.name}": ${error.message}`,
-					)
-				})
-		}
+		this._configTemplateService.checkConfigurationTemplates(node, zwaveNode)
 	}
 
 	/**

--- a/api/lib/ZwaveClient.ts
+++ b/api/lib/ZwaveClient.ts
@@ -1036,7 +1036,7 @@ class ZwaveClient extends TypedEventEmitter<ZwaveClientEventCallbacks> {
 			getStoreNode: (nodeId: number) => this.storeNodes[nodeId],
 			setStoreNode: (nodeId: number, data: Partial<ZUINode>) => {
 				if (!this.storeNodes[nodeId]) {
-					this.storeNodes[nodeId] = {} as any
+					this.storeNodes[nodeId] = {}
 				}
 				Object.assign(this.storeNodes[nodeId], data)
 			},

--- a/api/lib/ZwaveClient.ts
+++ b/api/lib/ZwaveClient.ts
@@ -947,6 +947,26 @@ class ZwaveClient extends TypedEventEmitter<ZwaveClientEventCallbacks> {
 			updateStoreNodes: () => this.updateStoreNodes(),
 		})
 
+		// Keep request locks across restarts while live ports resolve replacement state
+		const scheduleDriverPort = {
+			getDriver: () => this._driver,
+		}
+		const scheduleNodeStorePort = {
+			getNode: (nodeId: number) => this._nodes.get(nodeId),
+			emitNodeUpdate: (
+				node: ZUINode,
+				changedProps: utils.DeepPartial<ZUINode>,
+			) => this.emitNodeUpdate(node, changedProps),
+		}
+		const scheduleUtilsPort = {
+			deepEqual: (a: unknown, b: unknown) => utils.deepEqual(a, b),
+		}
+		this._scheduleService = new ScheduleService(
+			scheduleDriverPort,
+			scheduleNodeStorePort,
+			scheduleUtilsPort,
+		)
+
 		this.init()
 	}
 
@@ -972,26 +992,6 @@ class ZwaveClient extends TypedEventEmitter<ZwaveClientEventCallbacks> {
 		this._virtualNodes = new Map()
 		this._nodeToGroups = new Map()
 		this._rebuildNodeToGroupsIndex()
-
-		// Resolve current driver via closure so services survive a restart-driven swap
-		const scheduleDriverPort = {
-			getDriver: () => this._driver,
-		}
-		const scheduleNodeStorePort = {
-			getNode: (nodeId: number) => this._nodes.get(nodeId),
-			emitNodeUpdate: (
-				node: ZUINode,
-				changedProps: utils.DeepPartial<ZUINode>,
-			) => this.emitNodeUpdate(node, changedProps),
-		}
-		const scheduleUtilsPort = {
-			deepEqual: (a: unknown, b: unknown) => utils.deepEqual(a, b),
-		}
-		this._scheduleService = new ScheduleService(
-			scheduleDriverPort,
-			scheduleNodeStorePort,
-			scheduleUtilsPort,
-		)
 
 		const templateDriverPort = {
 			getDriver: () => this._driver,

--- a/api/lib/ZwaveClient.ts
+++ b/api/lib/ZwaveClient.ts
@@ -1007,6 +1007,7 @@ class ZwaveClient extends TypedEventEmitter<ZwaveClientEventCallbacks> {
 		this._nodeToGroups = new Map()
 		this._rebuildNodeToGroupsIndex()
 
+		// Resolve current driver via closure so services survive a restart-driven swap
 		const scheduleDriverPort = {
 			getDriver: () => this._driver,
 		}

--- a/api/lib/ZwaveClient.ts
+++ b/api/lib/ZwaveClient.ts
@@ -1007,7 +1007,6 @@ class ZwaveClient extends TypedEventEmitter<ZwaveClientEventCallbacks> {
 		this._nodeToGroups = new Map()
 		this._rebuildNodeToGroupsIndex()
 
-		// Construct service ports that resolve current state across restarts
 		const scheduleDriverPort = {
 			getDriver: () => this._driver,
 		}
@@ -3518,10 +3517,6 @@ class ZwaveClient extends TypedEventEmitter<ZwaveClientEventCallbacks> {
 		}
 	}
 
-	/**
-	 * Check and auto-apply matching configuration templates for a node.
-	 * Delegates to ConfigurationTemplateService.
-	 */
 	private _checkConfigurationTemplates(node: ZUINode, zwaveNode: ZWaveNode) {
 		this._configTemplateService.checkConfigurationTemplates(node, zwaveNode)
 	}

--- a/api/lib/ZwaveClient.ts
+++ b/api/lib/ZwaveClient.ts
@@ -1076,6 +1076,7 @@ class ZwaveClient extends TypedEventEmitter<ZwaveClientEventCallbacks> {
 			templateUtilsPort,
 			logger,
 			jsonStore.get(store.configurationTemplates),
+			configManager,
 		)
 
 		this._devices = {}

--- a/api/lib/zwave/ConfigurationTemplateService.ts
+++ b/api/lib/zwave/ConfigurationTemplateService.ts
@@ -421,12 +421,15 @@ export class ConfigurationTemplateService {
 		templates: ZUIConfigurationTemplate[],
 	): Promise<ZUIConfigurationTemplate[]> {
 		for (const t of templates) {
-			const legacy = t as unknown as { minFirmwareVersion?: string }
-			if (legacy.minFirmwareVersion && !t.firmwareRange) {
+			if (
+				'minFirmwareVersion' in t &&
+				typeof t.minFirmwareVersion === 'string' &&
+				!t.firmwareRange
+			) {
 				t.firmwareRange = {
-					min: legacy.minFirmwareVersion,
+					min: t.minFirmwareVersion,
 				}
-				delete legacy.minFirmwareVersion
+				delete t.minFirmwareVersion
 			}
 			t.id = this._utils.generateId()
 			if (!t.contentHash) {

--- a/api/lib/zwave/ConfigurationTemplateService.ts
+++ b/api/lib/zwave/ConfigurationTemplateService.ts
@@ -12,8 +12,6 @@ import {
 	gte as semverGte,
 	lte as semverLte,
 } from 'semver'
-import { ConfigManager } from '@zwave-js/config'
-import { deviceConfigPriorityDir } from '../Constants.ts'
 import { getErrorMessage } from '../errors.ts'
 
 import type {
@@ -24,13 +22,12 @@ import type {
 	TemplatePersistencePort,
 	TemplateUtilsPort,
 	TemplateNodeState,
+	TemplateConfigManagerPort,
 	ServiceLogger,
 } from './ports.ts'
 
 // Re-export types so ZwaveClient can import from one place
 export type { ZUIConfigurationTemplate, ZUIConfigurationTemplateValue }
-
-const configManager = new ConfigManager({ deviceConfigPriorityDir })
 
 export class ConfigurationTemplateService {
 	private _templates: ZUIConfigurationTemplate[]
@@ -39,6 +36,7 @@ export class ConfigurationTemplateService {
 	private readonly _nodes: TemplateNodeStorePort
 	private readonly _persistence: TemplatePersistencePort
 	private readonly _utils: TemplateUtilsPort
+	private readonly _configManager: TemplateConfigManagerPort
 	private readonly _logger: ServiceLogger
 
 	constructor(
@@ -48,6 +46,7 @@ export class ConfigurationTemplateService {
 		utils: TemplateUtilsPort,
 		logger: ServiceLogger,
 		initialTemplates: ZUIConfigurationTemplate[],
+		configManager: TemplateConfigManagerPort,
 	) {
 		this._driver = driver
 		this._nodes = nodes
@@ -55,6 +54,7 @@ export class ConfigurationTemplateService {
 		this._utils = utils
 		this._logger = logger
 		this._templates = initialTemplates
+		this._configManager = configManager
 	}
 
 	getConfigurationTemplates(): ZUIConfigurationTemplate[] {
@@ -79,9 +79,9 @@ export class ConfigurationTemplateService {
 			throw new Error('Invalid deviceId: non-numeric components')
 		}
 
-		await configManager.loadDeviceIndex()
+		await this._configManager.loadDeviceIndex()
 
-		const device = await configManager.lookupDevice(
+		const device = await this._configManager.lookupDevice(
 			manufacturerId,
 			productType,
 			productId,

--- a/api/lib/zwave/ConfigurationTemplateService.ts
+++ b/api/lib/zwave/ConfigurationTemplateService.ts
@@ -26,9 +26,6 @@ import type {
 	ServiceLogger,
 } from './ports.ts'
 
-// Re-export types so ZwaveClient can import from one place
-export type { ZUIConfigurationTemplate, ZUIConfigurationTemplateValue }
-
 export class ConfigurationTemplateService {
 	private _templates: ZUIConfigurationTemplate[]
 

--- a/api/lib/zwave/ConfigurationTemplateService.ts
+++ b/api/lib/zwave/ConfigurationTemplateService.ts
@@ -95,11 +95,11 @@ export class ConfigurationTemplateService {
 
 		for (const [key, param] of device.paramInformation.entries()) {
 			const propertyKey = key.valueBitMask
-			const id = `0-112-0-${key.parameter}${propertyKey != null ? '-' + String(propertyKey) : ''}`
+			const id = `0-${CommandClasses.Configuration}-0-${key.parameter}${propertyKey != null ? '-' + String(propertyKey) : ''}`
 
 			result.push({
 				id,
-				commandClass: 112,
+				commandClass: CommandClasses.Configuration,
 				property: key.parameter,
 				propertyKey: propertyKey,
 				endpoint: 0,

--- a/api/lib/zwave/ConfigurationTemplateService.ts
+++ b/api/lib/zwave/ConfigurationTemplateService.ts
@@ -1,0 +1,654 @@
+/**
+ * ConfigurationTemplateService – owns configuration template CRUD,
+ * persistence, auto-apply logic, and content-hash bookkeeping.
+ *
+ * Extracted from ZwaveClient to keep the monolith slim. The service is
+ * strict-clean (no broad `any` casts, no non-null assertions, no
+ * ts-ignore).
+ *
+ * Ports:
+ *   driver      – resolves current driver/controller/nodes across restarts
+ *   nodes       – read/update in-memory ZUINode state, write values, log
+ *   persistence – read/write configurationTemplates.json via jsonStore
+ *   utils       – ID generation
+ *   logger      – structured logging
+ */
+
+import { createHash } from 'node:crypto'
+import { CommandClasses } from '@zwave-js/core'
+import {
+	setValueFailed,
+	SetValueStatus,
+	type ZWaveNode,
+	type SetValueResult,
+} from 'zwave-js'
+import { getEnumMemberName } from '@zwave-js/shared'
+import {
+	coerce as semverCoerce,
+	gte as semverGte,
+	lte as semverLte,
+} from 'semver'
+import { ConfigManager } from '@zwave-js/config'
+import { deviceConfigPriorityDir } from '../Constants.ts'
+import { getErrorMessage } from '../errors.ts'
+
+import type {
+	ZUIConfigurationTemplate,
+	ZUIConfigurationTemplateValue,
+	TemplateDriverPort,
+	TemplateNodeStorePort,
+	TemplatePersistencePort,
+	TemplateUtilsPort,
+	TemplateNodeState,
+	ServiceLogger,
+} from './ports.ts'
+
+// Re-export types so ZwaveClient can import from one place
+export type { ZUIConfigurationTemplate, ZUIConfigurationTemplateValue }
+
+/** Shared config manager for device parameter lookups. */
+const configManager = new ConfigManager({ deviceConfigPriorityDir })
+
+export class ConfigurationTemplateService {
+	private _templates: ZUIConfigurationTemplate[]
+
+	private readonly _driver: TemplateDriverPort
+	private readonly _nodes: TemplateNodeStorePort
+	private readonly _persistence: TemplatePersistencePort
+	private readonly _utils: TemplateUtilsPort
+	private readonly _logger: ServiceLogger
+
+	constructor(
+		driver: TemplateDriverPort,
+		nodes: TemplateNodeStorePort,
+		persistence: TemplatePersistencePort,
+		utils: TemplateUtilsPort,
+		logger: ServiceLogger,
+		initialTemplates: ZUIConfigurationTemplate[],
+	) {
+		this._driver = driver
+		this._nodes = nodes
+		this._persistence = persistence
+		this._utils = utils
+		this._logger = logger
+		this._templates = initialTemplates
+	}
+
+	// ---------------------------------------------------------------
+	// Accessors
+	// ---------------------------------------------------------------
+
+	get templates(): ZUIConfigurationTemplate[] {
+		return this._templates
+	}
+
+	// ---------------------------------------------------------------
+	// Public API – exact signatures preserved from ZwaveClient
+	// ---------------------------------------------------------------
+
+	getConfigurationTemplates(): ZUIConfigurationTemplate[] {
+		return this._templates
+	}
+
+	async getDeviceConfigurationParams(
+		deviceId: string,
+	): Promise<Partial<Record<string, unknown>>[]> {
+		const parts = deviceId.split('-')
+		if (parts.length !== 3) {
+			throw new Error(
+				'Invalid deviceId format, expected manufacturerId-productId-productType',
+			)
+		}
+
+		const manufacturerId = parseInt(parts[0], 10)
+		const productId = parseInt(parts[1], 10)
+		const productType = parseInt(parts[2], 10)
+
+		if (isNaN(manufacturerId) || isNaN(productId) || isNaN(productType)) {
+			throw new Error('Invalid deviceId: non-numeric components')
+		}
+
+		await configManager.loadDeviceIndex()
+
+		const device = await configManager.lookupDevice(
+			manufacturerId,
+			productType,
+			productId,
+		)
+
+		if (!device?.paramInformation) {
+			return []
+		}
+
+		const result: Partial<Record<string, unknown>>[] = []
+
+		for (const [key, param] of device.paramInformation.entries()) {
+			const propertyKey = key.valueBitMask
+			const id = `0-112-0-${key.parameter}${propertyKey != null ? '-' + String(propertyKey) : ''}`
+
+			result.push({
+				id,
+				commandClass: 112,
+				property: key.parameter,
+				propertyKey: propertyKey,
+				endpoint: 0,
+				type: 'number',
+				readable: true,
+				writeable: !param.readOnly,
+				label: param.label,
+				description: param.description,
+				min: param.minValue,
+				max: param.maxValue,
+				default: param.defaultValue,
+				unit: param.unit,
+				list: param.options?.length > 0,
+				allowManualEntry: param.allowManualEntry,
+				states: param.options?.map((o) => ({
+					text: o.label,
+					value: o.value,
+				})),
+				newValue: param.defaultValue,
+			})
+		}
+
+		return result
+	}
+
+	async createConfigurationTemplate(
+		nodeId: number,
+		name: string,
+		autoApply = false,
+		values?: ZUIConfigurationTemplateValue[],
+		firmwareRange?: { min?: string; max?: string },
+	): Promise<ZUIConfigurationTemplate> {
+		const node = this._nodes.getNode(nodeId)
+
+		if (!node) {
+			throw Error(`Node ${nodeId} not found`)
+		}
+
+		if (!node.ready) {
+			throw Error(`Node ${nodeId} is not ready`)
+		}
+
+		let configValues: ZUIConfigurationTemplateValue[]
+
+		if (values && values.length > 0) {
+			configValues = values
+		} else {
+			configValues = []
+
+			if (node.values) {
+				for (const id in node.values) {
+					const v = node.values[id]
+					if (
+						v.commandClass === CommandClasses.Configuration &&
+						v.writeable
+					) {
+						configValues.push({
+							property: v.property as number,
+							propertyKey:
+								v.propertyKey != null
+									? (v.propertyKey as number)
+									: null,
+							endpoint: v.endpoint ?? 0,
+							value: v.value,
+							label: v.label,
+							description: v.description,
+						})
+					}
+				}
+			}
+		}
+
+		if (configValues.length === 0) {
+			throw Error(
+				`Node ${nodeId} has no writeable Configuration CC values`,
+			)
+		}
+
+		const id = this._utils.generateId()
+		const now = new Date().toISOString()
+
+		const template: ZUIConfigurationTemplate = {
+			id,
+			name,
+			deviceId: node.deviceId ?? '',
+			manufacturerId: node.manufacturerId,
+			productId: node.productId,
+			productType: node.productType,
+			manufacturer: node.manufacturer,
+			productLabel: node.productLabel,
+			firmwareRange:
+				firmwareRange?.min || firmwareRange?.max
+					? firmwareRange
+					: undefined,
+			values: configValues,
+			autoApply,
+			contentHash: ConfigurationTemplateService._generateContentHash(
+				configValues,
+				firmwareRange,
+			),
+			createdAt: now,
+			updatedAt: now,
+		}
+
+		this._templates.push(template)
+		await this._persistence.put(this._templates)
+
+		if (autoApply) {
+			this._autoApplyToNodes(template)
+		}
+
+		return template
+	}
+
+	async updateConfigurationTemplate(
+		id: string,
+		updates: {
+			name?: string
+			autoApply?: boolean
+			firmwareRange?: { min?: string; max?: string }
+			values?: ZUIConfigurationTemplateValue[]
+		},
+	): Promise<ZUIConfigurationTemplate> {
+		const template = this._templates.find((t) => t.id === id)
+
+		if (!template) {
+			throw Error(`Template ${id} not found`)
+		}
+
+		if (updates.name !== undefined) template.name = updates.name
+		if (updates.autoApply !== undefined)
+			template.autoApply = updates.autoApply
+
+		const contentChanged =
+			updates.firmwareRange !== undefined || updates.values !== undefined
+
+		if (updates.firmwareRange !== undefined)
+			template.firmwareRange = updates.firmwareRange
+		if (updates.values !== undefined) template.values = updates.values
+
+		if (contentChanged) {
+			template.contentHash =
+				ConfigurationTemplateService._generateContentHash(
+					template.values,
+					template.firmwareRange,
+				)
+		}
+
+		template.updatedAt = new Date().toISOString()
+
+		await this._persistence.put(this._templates)
+
+		if (template.autoApply && contentChanged) {
+			this._autoApplyToNodes(template)
+		}
+
+		return template
+	}
+
+	async deleteConfigurationTemplate(id: string): Promise<boolean> {
+		const index = this._templates.findIndex((t) => t.id === id)
+
+		if (index < 0) {
+			throw Error(`Template ${id} not found`)
+		}
+
+		const deletedHash = this._templates[index].contentHash
+
+		this._templates.splice(index, 1)
+		await this._persistence.put(this._templates)
+
+		if (deletedHash) {
+			for (const [, node] of this._nodes.getNodes()) {
+				const hashes = node.appliedTemplateContentHashes
+				if (hashes && hashes.includes(deletedHash)) {
+					await this._cleanupAppliedHashes(node)
+				}
+			}
+		}
+
+		return true
+	}
+
+	async applyConfigurationTemplate(
+		templateId: string,
+		nodeId: number,
+		force = false,
+	): Promise<{
+		success: number
+		failed: number
+		errors: string[]
+		reason?: string
+	}> {
+		const template = this._templates.find((t) => t.id === templateId)
+
+		if (!template) {
+			throw Error(`Template ${templateId} not found`)
+		}
+
+		const node = this._nodes.getNode(nodeId)
+
+		if (!node) {
+			throw Error(`Node ${nodeId} not found`)
+		}
+
+		if (!node.ready) {
+			throw Error(`Node ${nodeId} is not ready`)
+		}
+
+		if (
+			!force &&
+			template.deviceId &&
+			node.deviceId &&
+			template.deviceId !== node.deviceId
+		) {
+			throw Error(
+				`Template device type "${template.deviceId}" does not match node device type "${node.deviceId}". Use force to override.`,
+			)
+		}
+
+		const results: {
+			success: number
+			failed: number
+			errors: string[]
+			reason?: string
+		} = { success: 0, failed: 0, errors: [] }
+
+		for (const tv of template.values) {
+			try {
+				if (tv.value === undefined) {
+					results.success++
+					continue
+				}
+
+				const result: SetValueResult = await this._nodes.writeValue(
+					{
+						nodeId,
+						commandClass: CommandClasses.Configuration,
+						endpoint: tv.endpoint,
+						property: tv.property,
+						propertyKey: tv.propertyKey,
+					},
+					tv.value,
+				)
+
+				if (setValueFailed(result)) {
+					results.failed++
+					results.errors.push(
+						`Parameter ${tv.property}: ${result.message ?? getEnumMemberName(SetValueStatus, result.status)}`,
+					)
+
+					if (
+						result.status === SetValueStatus.Fail &&
+						node.status === 'Dead'
+					) {
+						const remaining =
+							template.values.length -
+							results.success -
+							results.failed
+						if (remaining > 0) {
+							results.failed += remaining
+						}
+						results.reason = 'Node is dead'
+						break
+					}
+				} else {
+					results.success++
+				}
+			} catch (error: unknown) {
+				results.failed++
+				const msg = getErrorMessage(error)
+				results.errors.push(`Parameter ${tv.property}: ${msg}`)
+			}
+		}
+
+		this._logger.info(
+			`Applied template "${template.name}" to node ${nodeId}: ${results.success} OK, ${results.failed} failed`,
+		)
+
+		if (results.success > 0 && template.contentHash) {
+			if (!node.appliedTemplateContentHashes) {
+				node.appliedTemplateContentHashes = []
+			}
+
+			if (
+				!node.appliedTemplateContentHashes.includes(
+					template.contentHash,
+				)
+			) {
+				node.appliedTemplateContentHashes.push(template.contentHash)
+
+				const storeNode = this._nodes.getStoreNode(nodeId)
+				if (!storeNode) {
+					this._nodes.setStoreNode(
+						nodeId,
+						{} as Partial<TemplateNodeState>,
+					)
+				}
+				this._nodes.setStoreNode(nodeId, {
+					appliedTemplateContentHashes:
+						node.appliedTemplateContentHashes,
+				})
+
+				this._nodes.throttle(
+					'applyTemplate_storeNodes',
+					() => {
+						// eslint-disable-next-line @typescript-eslint/no-floating-promises
+						this._nodes.updateStoreNodes(false)
+					},
+					1000,
+				)
+			}
+		}
+
+		return results
+	}
+
+	async importConfigurationTemplates(
+		templates: ZUIConfigurationTemplate[],
+	): Promise<ZUIConfigurationTemplate[]> {
+		for (const t of templates) {
+			const legacy = t as unknown as { minFirmwareVersion?: string }
+			if (legacy.minFirmwareVersion && !t.firmwareRange) {
+				t.firmwareRange = {
+					min: legacy.minFirmwareVersion,
+				}
+				delete legacy.minFirmwareVersion
+			}
+			t.id = this._utils.generateId()
+			if (!t.contentHash) {
+				t.contentHash =
+					ConfigurationTemplateService._generateContentHash(
+						t.values,
+						t.firmwareRange,
+					)
+			}
+			this._templates.push(t)
+		}
+
+		await this._persistence.put(this._templates)
+
+		return this._templates
+	}
+
+	// ---------------------------------------------------------------
+	// Node-ready hook – called from ZwaveClient._onNodeReady
+	// ---------------------------------------------------------------
+
+	checkConfigurationTemplates(
+		node: TemplateNodeState,
+		zwaveNode: ZWaveNode,
+	): void {
+		// eslint-disable-next-line @typescript-eslint/no-floating-promises
+		this._cleanupAppliedHashes(node)
+
+		const matching = this._getMatchingTemplates(node)
+
+		if (matching.length === 0) {
+			return
+		}
+
+		const appliedHashes = node.appliedTemplateContentHashes ?? []
+
+		const autoApplyTemplates = matching.filter(
+			(t) =>
+				t.autoApply &&
+				t.contentHash &&
+				!appliedHashes.includes(t.contentHash),
+		)
+
+		for (const template of autoApplyTemplates) {
+			this._nodes.logNode(
+				zwaveNode,
+				'info',
+				`Auto-applying configuration template "${template.name}"`,
+			)
+			this.applyConfigurationTemplate(template.id, node.id, true)
+				.then((result) => {
+					if (result.failed > 0) {
+						this._nodes.logNode(
+							zwaveNode,
+							'warn',
+							`Template "${template.name}" partially applied: ${result.success} OK, ${result.failed} failed`,
+						)
+					}
+				})
+				.catch((error: unknown) => {
+					const msg = getErrorMessage(error)
+					this._nodes.logNode(
+						zwaveNode,
+						'error',
+						`Failed to auto-apply template "${template.name}": ${msg}`,
+					)
+				})
+		}
+	}
+
+	// ---------------------------------------------------------------
+	// Private helpers
+	// ---------------------------------------------------------------
+
+	static _generateContentHash(
+		values: ZUIConfigurationTemplateValue[],
+		firmwareRange?: { min?: string; max?: string },
+	): string {
+		const normalized = values.map((v) => ({
+			property: v.property,
+			propertyKey: v.propertyKey ?? null,
+			endpoint: v.endpoint,
+			value: v.value,
+		}))
+		return createHash('sha256')
+			.update(JSON.stringify({ values: normalized, firmwareRange }))
+			.digest('hex')
+			.slice(0, 12)
+	}
+
+	private async _cleanupAppliedHashes(
+		node: TemplateNodeState,
+	): Promise<void> {
+		const hashes = node.appliedTemplateContentHashes
+		if (!hashes || hashes.length === 0) return
+
+		const validHashes = new Set(this._templates.map((t) => t.contentHash))
+		const cleaned = hashes.filter((h) => validHashes.has(h))
+
+		if (cleaned.length !== hashes.length) {
+			node.appliedTemplateContentHashes = cleaned
+
+			const storeNode = this._nodes.getStoreNode(node.id)
+			if (!storeNode) {
+				this._nodes.setStoreNode(
+					node.id,
+					{} as Partial<TemplateNodeState>,
+				)
+			}
+			this._nodes.setStoreNode(node.id, {
+				appliedTemplateContentHashes: cleaned,
+			})
+			await this._nodes.updateStoreNodes(false)
+		}
+	}
+
+	private _getMatchingTemplates(
+		node: TemplateNodeState,
+	): ZUIConfigurationTemplate[] {
+		if (!node.deviceId) return []
+
+		return this._templates.filter((t) => {
+			if (t.deviceId !== node.deviceId) return false
+
+			if (t.firmwareRange?.min || t.firmwareRange?.max) {
+				if (!node.firmwareVersion) {
+					return false
+				}
+
+				const nodeFw = semverCoerce(node.firmwareVersion)
+				if (!nodeFw) return false
+
+				if (t.firmwareRange.min) {
+					const minFw = semverCoerce(t.firmwareRange.min)
+					if (!minFw || !semverGte(nodeFw, minFw)) {
+						return false
+					}
+				}
+
+				if (t.firmwareRange.max) {
+					const maxFw = semverCoerce(t.firmwareRange.max)
+					if (!maxFw || !semverLte(nodeFw, maxFw)) {
+						return false
+					}
+				}
+			}
+
+			return true
+		})
+	}
+
+	private _autoApplyToNodes(template: ZUIConfigurationTemplate): void {
+		const driver = this._driver.getDriver()
+		if (!driver?.controller) return
+
+		for (const [, node] of this._nodes.getNodes()) {
+			if (!node.ready || !node.deviceId) continue
+
+			const matching = this._getMatchingTemplates(node)
+			if (!matching.some((t) => t.id === template.id)) continue
+
+			const hashes = node.appliedTemplateContentHashes ?? []
+			if (hashes.includes(template.contentHash)) continue
+
+			const zwaveNode = driver.controller.nodes.get(node.id)
+
+			if (zwaveNode) {
+				this._nodes.logNode(
+					zwaveNode,
+					'info',
+					`Auto-applying configuration template "${template.name}"`,
+				)
+			}
+
+			this.applyConfigurationTemplate(template.id, node.id, true)
+				.then((result) => {
+					if (result.failed > 0 && zwaveNode) {
+						this._nodes.logNode(
+							zwaveNode,
+							'warn',
+							`Template "${template.name}" partially applied: ${result.success} OK, ${result.failed} failed`,
+						)
+					}
+				})
+				.catch((error: unknown) => {
+					if (zwaveNode) {
+						this._nodes.logNode(
+							zwaveNode,
+							'error',
+							`Failed to auto-apply template "${template.name}": ${getErrorMessage(error)}`,
+						)
+					}
+				})
+		}
+	}
+}

--- a/api/lib/zwave/ConfigurationTemplateService.ts
+++ b/api/lib/zwave/ConfigurationTemplateService.ts
@@ -57,10 +57,6 @@ export class ConfigurationTemplateService {
 		this._templates = initialTemplates
 	}
 
-	get templates(): ZUIConfigurationTemplate[] {
-		return this._templates
-	}
-
 	getConfigurationTemplates(): ZUIConfigurationTemplate[] {
 		return this._templates
 	}

--- a/api/lib/zwave/ConfigurationTemplateService.ts
+++ b/api/lib/zwave/ConfigurationTemplateService.ts
@@ -1,19 +1,3 @@
-/**
- * ConfigurationTemplateService – owns configuration template CRUD,
- * persistence, auto-apply logic, and content-hash bookkeeping.
- *
- * Extracted from ZwaveClient to keep the monolith slim. The service is
- * strict-clean (no broad `any` casts, no non-null assertions, no
- * ts-ignore).
- *
- * Ports:
- *   driver      – resolves current driver/controller/nodes across restarts
- *   nodes       – read/update in-memory ZUINode state, write values, log
- *   persistence – read/write configurationTemplates.json via jsonStore
- *   utils       – ID generation
- *   logger      – structured logging
- */
-
 import { createHash } from 'node:crypto'
 import { CommandClasses } from '@zwave-js/core'
 import {
@@ -46,7 +30,6 @@ import type {
 // Re-export types so ZwaveClient can import from one place
 export type { ZUIConfigurationTemplate, ZUIConfigurationTemplateValue }
 
-/** Shared config manager for device parameter lookups. */
 const configManager = new ConfigManager({ deviceConfigPriorityDir })
 
 export class ConfigurationTemplateService {
@@ -74,17 +57,9 @@ export class ConfigurationTemplateService {
 		this._templates = initialTemplates
 	}
 
-	// ---------------------------------------------------------------
-	// Accessors
-	// ---------------------------------------------------------------
-
 	get templates(): ZUIConfigurationTemplate[] {
 		return this._templates
 	}
-
-	// ---------------------------------------------------------------
-	// Public API – exact signatures preserved from ZwaveClient
-	// ---------------------------------------------------------------
 
 	getConfigurationTemplates(): ZUIConfigurationTemplate[] {
 		return this._templates
@@ -473,10 +448,6 @@ export class ConfigurationTemplateService {
 		return this._templates
 	}
 
-	// ---------------------------------------------------------------
-	// Node-ready hook – called from ZwaveClient._onNodeReady
-	// ---------------------------------------------------------------
-
 	checkConfigurationTemplates(
 		node: TemplateNodeState,
 		zwaveNode: ZWaveNode,
@@ -525,10 +496,6 @@ export class ConfigurationTemplateService {
 				})
 		}
 	}
-
-	// ---------------------------------------------------------------
-	// Private helpers
-	// ---------------------------------------------------------------
 
 	static _generateContentHash(
 		values: ZUIConfigurationTemplateValue[],

--- a/api/lib/zwave/ScheduleService.ts
+++ b/api/lib/zwave/ScheduleService.ts
@@ -142,12 +142,8 @@ export class ScheduleService {
 			const driver = this._driver.getDriver()
 			if (!driver) return undefined
 
-			const userCodes = UserCodeCC.getSupportedUsersCached(
-				driver,
-				endpoint,
-			)
-
-			if (userCodes == null) return undefined
+			const userCodes =
+				UserCodeCC.getSupportedUsersCached(driver, endpoint) ?? 0
 
 			const numSlots = {
 				numWeekDaySlots: ScheduleEntryLockCC.getNumWeekDaySlotsCached(

--- a/api/lib/zwave/ScheduleService.ts
+++ b/api/lib/zwave/ScheduleService.ts
@@ -503,14 +503,11 @@ export class ScheduleService {
 						}
 					}
 				} else {
-					if (!node.userCodes) {
-						throw new TypeError(
-							"Cannot read properties of undefined (reading 'available')",
-						)
+					if (node.userCodes) {
+						node.userCodes.enabled = enabled
+							? node.userCodes.available.slice()
+							: []
 					}
-					node.userCodes.enabled = enabled
-						? node.userCodes.available.slice()
-						: []
 				}
 
 				this._nodes.emitNodeUpdate(node, {

--- a/api/lib/zwave/ScheduleService.ts
+++ b/api/lib/zwave/ScheduleService.ts
@@ -1,0 +1,566 @@
+/**
+ * ScheduleService – owns all Schedule Entry Lock CC interaction state.
+ *
+ * Extracted from ZwaveClient to keep the monolith slim. The service is
+ * strict-clean (no `any` casts, no non-null assertions, no ts-ignore).
+ *
+ * Ports:
+ *   driver  – resolves current driver/controller/nodes across restarts
+ *   nodes   – read/update in-memory ZUINode state + emit socket events
+ *   utils   – deep-equal comparison for verification reads
+ */
+
+import type {
+	ScheduleEntryLockDailyRepeatingSchedule,
+	ScheduleEntryLockSlotId,
+	ScheduleEntryLockWeekDaySchedule,
+	ScheduleEntryLockYearDaySchedule,
+	ZWaveNode,
+} from 'zwave-js'
+import {
+	ScheduleEntryLockCC,
+	ScheduleEntryLockScheduleKind,
+	UserCodeCC,
+	UserIDStatus,
+	type Driver,
+} from 'zwave-js'
+import { isUnsupervisedOrSucceeded, SupervisionStatus } from '@zwave-js/core'
+import type { SupervisionResult } from '@zwave-js/core'
+
+import {
+	ZUIScheduleEntryLockMode,
+	type ZUIScheduleEntryLockMode as ZUIScheduleEntryLockModeType,
+	type ZUISchedule,
+	type ZUISlot,
+	type ScheduleDriverPort,
+	type ScheduleNodeStorePort,
+	type ScheduleUtilsPort,
+	type ScheduleNodeState,
+} from './ports.ts'
+
+// Re-export the mode constant so ZwaveClient doesn't need two imports
+export { ZUIScheduleEntryLockMode }
+
+type AnySchedule =
+	| ScheduleEntryLockDailyRepeatingSchedule
+	| ScheduleEntryLockWeekDaySchedule
+	| ScheduleEntryLockYearDaySchedule
+
+export class ScheduleService {
+	private _lockGetSchedule = false
+	private _cancelGetSchedule = false
+
+	private readonly _driver: ScheduleDriverPort
+	private readonly _nodes: ScheduleNodeStorePort
+	private readonly _utils: ScheduleUtilsPort
+
+	constructor(
+		driver: ScheduleDriverPort,
+		nodes: ScheduleNodeStorePort,
+		utils: ScheduleUtilsPort,
+	) {
+		this._driver = driver
+		this._nodes = nodes
+		this._utils = utils
+	}
+
+	// ---------------------------------------------------------------
+	// Internal helpers
+	// ---------------------------------------------------------------
+
+	private _getZwaveNode(nodeId: number): ZWaveNode | undefined {
+		return this._driver.getDriver()?.controller.nodes.get(nodeId)
+	}
+
+	private _requireScheduleCC(nodeId: number): ZWaveNode {
+		const zwaveNode = this._getZwaveNode(nodeId)
+		if (!zwaveNode?.commandClasses['Schedule Entry Lock'].isSupported()) {
+			throw new Error(
+				'Schedule Entry Lock CC not supported on node ' + nodeId,
+			)
+		}
+		return zwaveNode
+	}
+
+	/**
+	 * Push or replace a slot entry in the local cache array.
+	 */
+	private static _pushSchedule(
+		arr: ZUISlot<AnySchedule>[],
+		slot: ScheduleEntryLockSlotId,
+		schedule: AnySchedule | undefined,
+		enabled: boolean,
+	): void {
+		const index = arr.findIndex(
+			(s) => s.userId === slot.userId && s.slotId === slot.slotId,
+		)
+		if (schedule) {
+			const newSlot: ZUISlot<AnySchedule> = {
+				...slot,
+				...schedule,
+				enabled,
+			} as ZUISlot<AnySchedule>
+			if (index === -1) {
+				arr.push(newSlot)
+			} else {
+				arr[index] = newSlot
+			}
+		} else if (index !== -1) {
+			arr.splice(index, 1)
+		}
+	}
+
+	// ---------------------------------------------------------------
+	// Public API – exact signatures preserved from ZwaveClient
+	// ---------------------------------------------------------------
+
+	/**
+	 * If the node supports Schedule Lock CC, parse all available schedules
+	 * and cache them.
+	 */
+	async getSchedules(
+		nodeId: number,
+		opts: { mode?: ZUIScheduleEntryLockModeType; fromCache: boolean } = {
+			fromCache: true,
+		},
+	): Promise<ZUISchedule | undefined> {
+		const zwaveNode = this._requireScheduleCC(nodeId)
+
+		if (this._lockGetSchedule) {
+			throw new Error(
+				'Another request is in progress, cancel it or wait...',
+			)
+		}
+
+		const promise = async (): Promise<ZUISchedule | undefined> => {
+			this._cancelGetSchedule = false
+			this._lockGetSchedule = true
+			const { mode, fromCache } = opts
+			const endpointIndex = 0
+			const endpoint = zwaveNode.getEndpoint(endpointIndex)
+
+			const driver = this._driver.getDriver()
+			if (!driver) return undefined
+
+			const userCodes = UserCodeCC.getSupportedUsersCached(
+				driver,
+				endpoint,
+			)
+
+			if (userCodes == null) return undefined
+
+			const numSlots = {
+				numWeekDaySlots: ScheduleEntryLockCC.getNumWeekDaySlotsCached(
+					driver,
+					endpoint,
+				),
+				numYearDaySlots: ScheduleEntryLockCC.getNumYearDaySlotsCached(
+					driver,
+					endpoint,
+				),
+				numDailyRepeatingSlots:
+					ScheduleEntryLockCC.getNumDailyRepeatingSlotsCached(
+						driver,
+						endpoint,
+					),
+			}
+
+			const node = this._nodes.getNode(nodeId)
+			if (!node) return undefined
+
+			const weeklySchedules: ZUISlot<ScheduleEntryLockWeekDaySchedule>[] =
+				node.schedule?.weekly?.slots ?? []
+			const yearlySchedules: ZUISlot<ScheduleEntryLockYearDaySchedule>[] =
+				node.schedule?.yearly?.slots ?? []
+			const dailySchedules: ZUISlot<ScheduleEntryLockDailyRepeatingSchedule>[] =
+				node.schedule?.daily?.slots ?? []
+
+			node.schedule = {
+				daily: {
+					numSlots: numSlots.numDailyRepeatingSlots,
+					slots: dailySchedules,
+				},
+				weekly: {
+					numSlots: numSlots.numWeekDaySlots,
+					slots: weeklySchedules,
+				},
+				yearly: {
+					numSlots: numSlots.numYearDaySlots,
+					slots: yearlySchedules,
+				},
+			}
+
+			node.userCodes = {
+				total: userCodes,
+				available: [],
+				enabled: [],
+			}
+
+			for (let i = 1; i <= userCodes; i++) {
+				const status = UserCodeCC.getUserIdStatusCached(
+					driver,
+					endpoint,
+					i,
+				)
+
+				if (
+					status === undefined ||
+					status === UserIDStatus.Available ||
+					status === UserIDStatus.StatusNotAvailable
+				) {
+					continue
+				}
+
+				node.userCodes.available.push(i)
+
+				const enabledUserId =
+					ScheduleEntryLockCC.getUserCodeScheduleEnabledCached(
+						driver,
+						endpoint,
+						i,
+					)
+
+				if (enabledUserId) {
+					node.userCodes.enabled.push(i)
+				}
+
+				const enabledType =
+					ScheduleEntryLockCC.getUserCodeScheduleKindCached(
+						driver,
+						endpoint,
+						i,
+					)
+
+				const getCached = (
+					kind: ScheduleEntryLockScheduleKind,
+					slotId: number,
+				) =>
+					ScheduleEntryLockCC.getScheduleCached(
+						driver,
+						endpoint,
+						kind,
+						i,
+						slotId,
+					)
+
+				if (!mode || mode === ZUIScheduleEntryLockMode.WEEKLY) {
+					const enabled =
+						enabledType === ScheduleEntryLockScheduleKind.WeekDay
+
+					for (let s = 1; s <= numSlots.numWeekDaySlots; s++) {
+						if (this._cancelGetSchedule) return undefined
+
+						const slot: ScheduleEntryLockSlotId = {
+							userId: i,
+							slotId: s,
+						}
+
+						const schedule = fromCache
+							? (getCached(
+									ScheduleEntryLockScheduleKind.WeekDay,
+									s,
+								) as ScheduleEntryLockWeekDaySchedule)
+							: await zwaveNode.commandClasses[
+									'Schedule Entry Lock'
+								].getWeekDaySchedule(slot)
+
+						ScheduleService._pushSchedule(
+							weeklySchedules as ZUISlot<AnySchedule>[],
+							slot,
+							schedule,
+							enabled,
+						)
+					}
+				}
+
+				if (!mode || mode === ZUIScheduleEntryLockMode.YEARLY) {
+					const enabled =
+						enabledType === ScheduleEntryLockScheduleKind.YearDay
+
+					for (let s = 1; s <= numSlots.numYearDaySlots; s++) {
+						if (this._cancelGetSchedule) return undefined
+
+						const slot: ScheduleEntryLockSlotId = {
+							userId: i,
+							slotId: s,
+						}
+						const schedule = fromCache
+							? (getCached(
+									ScheduleEntryLockScheduleKind.YearDay,
+									s,
+								) as ScheduleEntryLockYearDaySchedule)
+							: await zwaveNode.commandClasses[
+									'Schedule Entry Lock'
+								].getYearDaySchedule(slot)
+
+						ScheduleService._pushSchedule(
+							yearlySchedules as ZUISlot<AnySchedule>[],
+							slot,
+							schedule,
+							enabled,
+						)
+					}
+				}
+
+				if (!mode || mode === ZUIScheduleEntryLockMode.DAILY) {
+					const enabled =
+						enabledType ===
+						ScheduleEntryLockScheduleKind.DailyRepeating
+
+					for (let s = 1; s <= numSlots.numDailyRepeatingSlots; s++) {
+						if (this._cancelGetSchedule) return undefined
+
+						const slot: ScheduleEntryLockSlotId = {
+							userId: i,
+							slotId: s,
+						}
+						const schedule = fromCache
+							? (getCached(
+									ScheduleEntryLockScheduleKind.DailyRepeating,
+									s,
+								) as ScheduleEntryLockDailyRepeatingSchedule)
+							: await zwaveNode.commandClasses[
+									'Schedule Entry Lock'
+								].getDailyRepeatingSchedule(slot)
+
+						ScheduleService._pushSchedule(
+							dailySchedules as ZUISlot<AnySchedule>[],
+							slot,
+							schedule,
+							enabled,
+						)
+					}
+				}
+			}
+
+			this._nodes.emitNodeUpdate(node, {
+				id: node.id,
+				schedule: node.schedule,
+				userCodes: node.userCodes,
+			})
+
+			return node.schedule
+		}
+
+		return promise().finally(() => {
+			this._lockGetSchedule = false
+			this._cancelGetSchedule = false
+		})
+	}
+
+	cancelGetSchedule(): void {
+		this._cancelGetSchedule = true
+	}
+
+	async setSchedule(
+		nodeId: number,
+		type: 'daily' | 'weekly' | 'yearly',
+		schedule: ScheduleEntryLockSlotId &
+			(
+				| ScheduleEntryLockDailyRepeatingSchedule
+				| ScheduleEntryLockWeekDaySchedule
+				| ScheduleEntryLockYearDaySchedule
+			),
+	): Promise<SupervisionResult | undefined> {
+		const zwaveNode = this._requireScheduleCC(nodeId)
+
+		const slot: ScheduleEntryLockSlotId = {
+			userId: schedule.userId,
+			slotId: schedule.slotId,
+		}
+
+		// Mutate the incoming schedule to remove slot/enabled keys – matches
+		// original ZwaveClient semantics exactly (callers rely on this).
+		delete (
+			schedule as Partial<ScheduleEntryLockSlotId & { enabled: unknown }>
+		).userId
+		delete (
+			schedule as Partial<ScheduleEntryLockSlotId & { enabled: unknown }>
+		).slotId
+		delete (
+			schedule as Partial<ScheduleEntryLockSlotId & { enabled: unknown }>
+		)['enabled']
+
+		const isDelete = Object.keys(schedule).length === 0
+
+		let scheduleData: AnySchedule | undefined
+		if (isDelete) {
+			scheduleData = undefined
+		} else {
+			scheduleData = schedule as AnySchedule
+		}
+
+		let result: SupervisionResult | undefined
+
+		if (type === 'daily') {
+			result = await zwaveNode.commandClasses[
+				'Schedule Entry Lock'
+			].setDailyRepeatingSchedule(
+				slot,
+				scheduleData as ScheduleEntryLockDailyRepeatingSchedule,
+			)
+		} else if (type === 'weekly') {
+			result = await zwaveNode.commandClasses[
+				'Schedule Entry Lock'
+			].setWeekDaySchedule(
+				slot,
+				scheduleData as ScheduleEntryLockWeekDaySchedule,
+			)
+		} else if (type === 'yearly') {
+			result = await zwaveNode.commandClasses[
+				'Schedule Entry Lock'
+			].setYearDaySchedule(
+				slot,
+				scheduleData as ScheduleEntryLockYearDaySchedule,
+			)
+		} else {
+			throw new Error('Invalid schedule type')
+		}
+
+		// When not using supervision, read slot and check if it matches
+		if (!result) {
+			const methods = {
+				daily: 'getDailyRepeatingSchedule',
+				weekly: 'getWeekDaySchedule',
+				yearly: 'getYearDaySchedule',
+			} as const
+
+			const res =
+				await zwaveNode.commandClasses['Schedule Entry Lock'][
+					methods[type]
+				](slot)
+
+			if (
+				(isDelete && !res) ||
+				(!isDelete && res && this._utils.deepEqual(res, scheduleData))
+			) {
+				result = {
+					status: SupervisionStatus.Success,
+				}
+			} else {
+				result = {
+					status: SupervisionStatus.Fail,
+				}
+			}
+		}
+
+		if (result.status === SupervisionStatus.Success) {
+			const node = this._nodes.getNode(nodeId)
+			if (!node?.schedule) return result
+
+			// Update enabled state across all modes
+			for (const mode in node.schedule) {
+				const scheduleMode = node.schedule[mode as keyof ZUISchedule]
+				if (scheduleMode) {
+					scheduleMode.slots = scheduleMode.slots.map((s) => ({
+						...s,
+						enabled: mode === type,
+					})) as typeof scheduleMode.slots
+				}
+			}
+
+			const slots = node.schedule[type]?.slots
+
+			if (slots) {
+				const slotIndex = slots.findIndex(
+					(s) => s.userId === slot.userId && s.slotId === slot.slotId,
+				)
+
+				if (isDelete) {
+					if (slotIndex !== -1) {
+						slots.splice(slotIndex, 1)
+					}
+				} else if (slotIndex !== -1) {
+					;(slots as ZUISlot<AnySchedule>[])[slotIndex] = {
+						...slot,
+						...scheduleData,
+						enabled: true,
+					} as ZUISlot<AnySchedule>
+				} else {
+					;(slots as ZUISlot<AnySchedule>[]).push({
+						...slot,
+						...scheduleData,
+						enabled: true,
+					} as ZUISlot<AnySchedule>)
+				}
+
+				const isEnabledUsercode = node.userCodes?.enabled?.includes(
+					slot.userId,
+				)
+
+				if (!isDelete && !isEnabledUsercode && node.userCodes) {
+					node.userCodes.enabled.push(slot.userId)
+				} else if (isDelete && isEnabledUsercode && node.userCodes) {
+					const index = node.userCodes.enabled.indexOf(slot.userId)
+					if (index >= 0) {
+						node.userCodes.enabled.splice(index, 1)
+					}
+				}
+
+				this._nodes.emitNodeUpdate(node, {
+					id: node.id,
+					schedule: node.schedule,
+					userCodes: node.userCodes,
+				})
+			}
+		}
+
+		return result
+	}
+
+	async setEnabledSchedule(
+		nodeId: number,
+		enabled: boolean,
+		userId: number,
+	): Promise<SupervisionResult | undefined> {
+		const zwaveNode = this._getZwaveNode(nodeId)
+
+		if (!zwaveNode) {
+			throw new Error('Node not found')
+		}
+
+		const result = await zwaveNode.commandClasses[
+			'Schedule Entry Lock'
+		].setEnabled(enabled, userId)
+
+		if (isUnsupervisedOrSucceeded(result)) {
+			const node = this._nodes.getNode(nodeId)
+
+			if (node?.userCodes) {
+				if (userId) {
+					if (enabled) {
+						node.userCodes.enabled.push(userId)
+					} else {
+						const index = node.userCodes.enabled.indexOf(userId)
+						if (index >= 0) {
+							node.userCodes.enabled.splice(index, 1)
+						}
+					}
+				} else {
+					node.userCodes.enabled = enabled
+						? node.userCodes.available.slice()
+						: []
+				}
+
+				this._nodes.emitNodeUpdate(node, {
+					id: node.id,
+					userCodes: node.userCodes,
+				})
+			}
+		}
+
+		return result
+	}
+
+	// ---------------------------------------------------------------
+	// State accessors for testing / debugging
+	// ---------------------------------------------------------------
+
+	get lockGetSchedule(): boolean {
+		return this._lockGetSchedule
+	}
+
+	get cancelGetScheduleFlag(): boolean {
+		return this._cancelGetSchedule
+	}
+}

--- a/api/lib/zwave/ScheduleService.ts
+++ b/api/lib/zwave/ScheduleService.ts
@@ -384,6 +384,7 @@ export class ScheduleService {
 			throw new Error('Invalid schedule type')
 		}
 
+		// Without supervision confirmation, verify the write via slot readback
 		if (!result) {
 			const methods = {
 				daily: 'getDailyRepeatingSchedule',
@@ -414,6 +415,7 @@ export class ScheduleService {
 			const node = this._nodes.getNode(nodeId)
 			if (!node?.schedule) return result
 
+			// Schedule Entry Lock CC allows only one active mode at a time
 			for (const mode in node.schedule) {
 				const scheduleMode = node.schedule[mode as keyof ZUISchedule]
 				if (scheduleMode) {

--- a/api/lib/zwave/ScheduleService.ts
+++ b/api/lib/zwave/ScheduleService.ts
@@ -1,15 +1,3 @@
-/**
- * ScheduleService – owns all Schedule Entry Lock CC interaction state.
- *
- * Extracted from ZwaveClient to keep the monolith slim. The service is
- * strict-clean (no `any` casts, no non-null assertions, no ts-ignore).
- *
- * Ports:
- *   driver  – resolves current driver/controller/nodes across restarts
- *   nodes   – read/update in-memory ZUINode state + emit socket events
- *   utils   – deep-equal comparison for verification reads
- */
-
 import type {
 	ScheduleEntryLockDailyRepeatingSchedule,
 	ScheduleEntryLockSlotId,
@@ -38,7 +26,7 @@ import {
 	type ScheduleNodeState,
 } from './ports.ts'
 
-// Re-export the mode constant so ZwaveClient doesn't need two imports
+// Re-export so ZwaveClient doesn't need two imports
 export { ZUIScheduleEntryLockMode }
 
 type AnySchedule =
@@ -64,10 +52,6 @@ export class ScheduleService {
 		this._utils = utils
 	}
 
-	// ---------------------------------------------------------------
-	// Internal helpers
-	// ---------------------------------------------------------------
-
 	private _getZwaveNode(nodeId: number): ZWaveNode | undefined {
 		return this._driver.getDriver()?.controller.nodes.get(nodeId)
 	}
@@ -82,9 +66,6 @@ export class ScheduleService {
 		return zwaveNode
 	}
 
-	/**
-	 * Push or replace a slot entry in the local cache array.
-	 */
 	private static _pushSchedule(
 		arr: ZUISlot<AnySchedule>[],
 		slot: ScheduleEntryLockSlotId,
@@ -110,14 +91,6 @@ export class ScheduleService {
 		}
 	}
 
-	// ---------------------------------------------------------------
-	// Public API – exact signatures preserved from ZwaveClient
-	// ---------------------------------------------------------------
-
-	/**
-	 * If the node supports Schedule Lock CC, parse all available schedules
-	 * and cache them.
-	 */
 	async getSchedules(
 		nodeId: number,
 		opts: { mode?: ZUIScheduleEntryLockModeType; fromCache: boolean } = {
@@ -365,8 +338,7 @@ export class ScheduleService {
 			slotId: schedule.slotId,
 		}
 
-		// Mutate the incoming schedule to remove slot/enabled keys – matches
-		// original ZwaveClient semantics exactly (callers rely on this).
+		// Strip slot/enabled keys so an empty remainder signals a delete
 		delete (
 			schedule as Partial<ScheduleEntryLockSlotId & { enabled: unknown }>
 		).userId
@@ -413,7 +385,6 @@ export class ScheduleService {
 			throw new Error('Invalid schedule type')
 		}
 
-		// When not using supervision, read slot and check if it matches
 		if (!result) {
 			const methods = {
 				daily: 'getDailyRepeatingSchedule',
@@ -444,7 +415,6 @@ export class ScheduleService {
 			const node = this._nodes.getNode(nodeId)
 			if (!node?.schedule) return result
 
-			// Update enabled state across all modes
 			for (const mode in node.schedule) {
 				const scheduleMode = node.schedule[mode as keyof ZUISchedule]
 				if (scheduleMode) {
@@ -547,10 +517,6 @@ export class ScheduleService {
 
 		return result
 	}
-
-	// ---------------------------------------------------------------
-	// State accessors for testing / debugging
-	// ---------------------------------------------------------------
 
 	get lockGetSchedule(): boolean {
 		return this._lockGetSchedule

--- a/api/lib/zwave/ScheduleService.ts
+++ b/api/lib/zwave/ScheduleService.ts
@@ -517,12 +517,4 @@ export class ScheduleService {
 
 		return result
 	}
-
-	get lockGetSchedule(): boolean {
-		return this._lockGetSchedule
-	}
-
-	get cancelGetScheduleFlag(): boolean {
-		return this._cancelGetSchedule
-	}
 }

--- a/api/lib/zwave/ScheduleService.ts
+++ b/api/lib/zwave/ScheduleService.ts
@@ -303,7 +303,6 @@ export class ScheduleService {
 			}
 
 			this._nodes.emitNodeUpdate(node, {
-				id: node.id,
 				schedule: node.schedule,
 				userCodes: node.userCodes,
 			})
@@ -464,7 +463,6 @@ export class ScheduleService {
 				}
 
 				this._nodes.emitNodeUpdate(node, {
-					id: node.id,
 					schedule: node.schedule,
 					userCodes: node.userCodes,
 				})
@@ -492,24 +490,28 @@ export class ScheduleService {
 		if (isUnsupervisedOrSucceeded(result)) {
 			const node = this._nodes.getNode(nodeId)
 
-			if (node?.userCodes) {
+			if (node) {
 				if (userId) {
 					if (enabled) {
-						node.userCodes.enabled.push(userId)
+						node.userCodes?.enabled.push(userId)
 					} else {
-						const index = node.userCodes.enabled.indexOf(userId)
-						if (index >= 0) {
-							node.userCodes.enabled.splice(index, 1)
+						const index = node.userCodes?.enabled.indexOf(userId)
+						if (index !== undefined && index >= 0) {
+							node.userCodes?.enabled.splice(index, 1)
 						}
 					}
 				} else {
+					if (!node.userCodes) {
+						throw new TypeError(
+							"Cannot read properties of undefined (reading 'available')",
+						)
+					}
 					node.userCodes.enabled = enabled
 						? node.userCodes.available.slice()
 						: []
 				}
 
 				this._nodes.emitNodeUpdate(node, {
-					id: node.id,
 					userCodes: node.userCodes,
 				})
 			}

--- a/api/lib/zwave/ScheduleService.ts
+++ b/api/lib/zwave/ScheduleService.ts
@@ -26,9 +26,6 @@ import {
 	type ScheduleNodeState,
 } from './ports.ts'
 
-// Re-export so ZwaveClient doesn't need two imports
-export { ZUIScheduleEntryLockMode }
-
 type AnySchedule =
 	| ScheduleEntryLockDailyRepeatingSchedule
 	| ScheduleEntryLockWeekDaySchedule

--- a/api/lib/zwave/ports.ts
+++ b/api/lib/zwave/ports.ts
@@ -155,6 +155,40 @@ export interface ServiceLogger {
 	error(message: string, ...meta: unknown[]): void
 }
 
+export interface TemplateConfigManagerPort {
+	loadDeviceIndex(): Promise<void>
+	lookupDevice(
+		manufacturerId: number,
+		productType: number,
+		productId: number,
+	): Promise<
+		| {
+				paramInformation?: {
+					entries(): Iterable<
+						[
+							{ parameter: number; valueBitMask?: number },
+							{
+								label?: string
+								description?: string
+								readOnly?: boolean
+								minValue?: number
+								maxValue?: number
+								defaultValue?: number
+								unit?: string
+								allowManualEntry?: boolean
+								options?: readonly {
+									label: string
+									value: number
+								}[]
+							},
+						]
+					>
+				}
+		  }
+		| undefined
+	>
+}
+
 export interface TemplateUtilsPort {
 	generateId(): string
 }

--- a/api/lib/zwave/ports.ts
+++ b/api/lib/zwave/ports.ts
@@ -1,0 +1,213 @@
+/**
+ * Narrow access ports for extracted Z-Wave services.
+ *
+ * Each port interface defines the minimum surface a service needs to
+ * interact with the driver, node store, or ZwaveClient – so the services
+ * never import the monolithic ZwaveClient directly and stay independently
+ * testable. Every accessor resolves the CURRENT value, so a driver swap
+ * on restart is honoured without capturing state at construction time.
+ */
+
+import type {
+	ScheduleEntryLockDailyRepeatingSchedule,
+	ScheduleEntryLockSlotId,
+	ScheduleEntryLockWeekDaySchedule,
+	ScheduleEntryLockYearDaySchedule,
+	SetValueResult,
+	ZWaveNode,
+	Driver,
+} from 'zwave-js'
+import type { SupervisionResult } from '@zwave-js/core'
+import type { DeepPartial } from '../utils.ts'
+
+// ---------------------------------------------------------------------------
+// Schedule types re-exported so services don't import ZwaveClient
+// ---------------------------------------------------------------------------
+
+export const ZUIScheduleEntryLockMode = {
+	DAILY: 'daily',
+	WEEKLY: 'weekly',
+	YEARLY: 'yearly',
+} as const
+
+export type ZUIScheduleEntryLockMode =
+	(typeof ZUIScheduleEntryLockMode)[keyof typeof ZUIScheduleEntryLockMode]
+
+export type ZUISlot<T> = T & { enabled: boolean } & ScheduleEntryLockSlotId
+
+export interface ZUIScheduleConfig<T> {
+	numSlots: number
+	slots: ZUISlot<T>[]
+}
+
+export interface ZUISchedule {
+	[ZUIScheduleEntryLockMode.DAILY]: ZUIScheduleConfig<ScheduleEntryLockDailyRepeatingSchedule>
+	[ZUIScheduleEntryLockMode.WEEKLY]: ZUIScheduleConfig<ScheduleEntryLockWeekDaySchedule>
+	[ZUIScheduleEntryLockMode.YEARLY]: ZUIScheduleConfig<ScheduleEntryLockYearDaySchedule>
+}
+
+// ---------------------------------------------------------------------------
+// Configuration template types
+// ---------------------------------------------------------------------------
+
+export interface ZUIConfigurationTemplateValue {
+	property: number
+	propertyKey?: number | null
+	endpoint: number
+	value: unknown
+	label?: string
+	description?: string
+}
+
+export interface ZUIConfigurationTemplate {
+	id: string
+	name: string
+	deviceId: string
+	manufacturerId?: number
+	productId?: number
+	productType?: number
+	manufacturer?: string
+	productLabel?: string
+	firmwareRange?: { min?: string; max?: string }
+	values: ZUIConfigurationTemplateValue[]
+	autoApply: boolean
+	contentHash: string
+	createdAt: string
+	updatedAt: string
+}
+
+// ---------------------------------------------------------------------------
+// Minimal node shape the services need
+// ---------------------------------------------------------------------------
+
+export interface ScheduleNodeState {
+	id: number
+	schedule?: ZUISchedule
+	userCodes?: {
+		total: number
+		available: number[]
+		enabled: number[]
+	}
+}
+
+export interface TemplateNodeState {
+	id: number
+	ready: boolean
+	deviceId?: string
+	manufacturerId?: number
+	productId?: number
+	productType?: number
+	manufacturer?: string
+	productLabel?: string
+	firmwareVersion?: string
+	values?: Record<
+		string,
+		{
+			commandClass: number
+			writeable: boolean
+			property: string | number
+			propertyKey?: string | number | null
+			endpoint?: number
+			value?: unknown
+			label?: string
+			description?: string
+		}
+	>
+	appliedTemplateContentHashes?: string[]
+	status?: string
+}
+
+// ---------------------------------------------------------------------------
+// Port: driver + node access for ScheduleService
+// ---------------------------------------------------------------------------
+
+export interface ScheduleDriverPort {
+	getDriver(): Driver | null
+}
+
+// ---------------------------------------------------------------------------
+// Port: node store access for ScheduleService
+// ---------------------------------------------------------------------------
+
+export interface ScheduleNodeStorePort {
+	getNode(nodeId: number): ScheduleNodeState | undefined
+	emitNodeUpdate(
+		node: ScheduleNodeState,
+		changedProps: DeepPartial<ScheduleNodeState>,
+	): void
+}
+
+// ---------------------------------------------------------------------------
+// Port: deep-equal utility for ScheduleService
+// ---------------------------------------------------------------------------
+
+export interface ScheduleUtilsPort {
+	deepEqual(a: unknown, b: unknown): boolean
+}
+
+// ---------------------------------------------------------------------------
+// Port: driver + node access for ConfigurationTemplateService
+// ---------------------------------------------------------------------------
+
+export interface TemplateDriverPort {
+	getDriver(): {
+		controller: {
+			nodes: { get(nodeId: number): ZWaveNode | undefined }
+		}
+	} | null
+}
+
+// ---------------------------------------------------------------------------
+// Port: node store for templates
+// ---------------------------------------------------------------------------
+
+export interface TemplateNodeStorePort {
+	getNode(nodeId: number): TemplateNodeState | undefined
+	getNodes(): Iterable<readonly [number, TemplateNodeState]>
+	getStoreNode(nodeId: number): Partial<TemplateNodeState> | undefined
+	setStoreNode(nodeId: number, data: Partial<TemplateNodeState>): void
+	updateStoreNodes(rebuildRoutes?: boolean): Promise<void>
+	emitNodeUpdate(
+		node: TemplateNodeState,
+		changedProps: DeepPartial<TemplateNodeState>,
+	): void
+	writeValue(
+		valueId: {
+			nodeId: number
+			commandClass: number
+			endpoint: number
+			property: number
+			propertyKey?: number | null
+		},
+		value: unknown,
+	): Promise<SetValueResult>
+	logNode(zwaveNode: ZWaveNode, level: string, message: string): void
+	throttle(key: string, fn: () => void, wait: number): void
+}
+
+// ---------------------------------------------------------------------------
+// Port: persistence (jsonStore) for templates
+// ---------------------------------------------------------------------------
+
+export interface TemplatePersistencePort {
+	get(): ZUIConfigurationTemplate[]
+	put(data: ZUIConfigurationTemplate[]): Promise<unknown>
+}
+
+// ---------------------------------------------------------------------------
+// Port: logger
+// ---------------------------------------------------------------------------
+
+export interface ServiceLogger {
+	info(message: string, ...meta: unknown[]): void
+	warn(message: string, ...meta: unknown[]): void
+	error(message: string, ...meta: unknown[]): void
+}
+
+// ---------------------------------------------------------------------------
+// Port: ID generation + hashing
+// ---------------------------------------------------------------------------
+
+export interface TemplateUtilsPort {
+	generateId(): string
+}

--- a/api/lib/zwave/ports.ts
+++ b/api/lib/zwave/ports.ts
@@ -1,3 +1,4 @@
+// Port accessors return live values so a driver swap on restart is honoured
 import type {
 	ScheduleEntryLockDailyRepeatingSchedule,
 	ScheduleEntryLockSlotId,

--- a/api/lib/zwave/ports.ts
+++ b/api/lib/zwave/ports.ts
@@ -1,13 +1,3 @@
-/**
- * Narrow access ports for extracted Z-Wave services.
- *
- * Each port interface defines the minimum surface a service needs to
- * interact with the driver, node store, or ZwaveClient – so the services
- * never import the monolithic ZwaveClient directly and stay independently
- * testable. Every accessor resolves the CURRENT value, so a driver swap
- * on restart is honoured without capturing state at construction time.
- */
-
 import type {
 	ScheduleEntryLockDailyRepeatingSchedule,
 	ScheduleEntryLockSlotId,
@@ -19,10 +9,6 @@ import type {
 } from 'zwave-js'
 import type { SupervisionResult } from '@zwave-js/core'
 import type { DeepPartial } from '../utils.ts'
-
-// ---------------------------------------------------------------------------
-// Schedule types re-exported so services don't import ZwaveClient
-// ---------------------------------------------------------------------------
 
 export const ZUIScheduleEntryLockMode = {
 	DAILY: 'daily',
@@ -45,10 +31,6 @@ export interface ZUISchedule {
 	[ZUIScheduleEntryLockMode.WEEKLY]: ZUIScheduleConfig<ScheduleEntryLockWeekDaySchedule>
 	[ZUIScheduleEntryLockMode.YEARLY]: ZUIScheduleConfig<ScheduleEntryLockYearDaySchedule>
 }
-
-// ---------------------------------------------------------------------------
-// Configuration template types
-// ---------------------------------------------------------------------------
 
 export interface ZUIConfigurationTemplateValue {
 	property: number
@@ -75,10 +57,6 @@ export interface ZUIConfigurationTemplate {
 	createdAt: string
 	updatedAt: string
 }
-
-// ---------------------------------------------------------------------------
-// Minimal node shape the services need
-// ---------------------------------------------------------------------------
 
 export interface ScheduleNodeState {
 	id: number
@@ -117,17 +95,9 @@ export interface TemplateNodeState {
 	status?: string
 }
 
-// ---------------------------------------------------------------------------
-// Port: driver + node access for ScheduleService
-// ---------------------------------------------------------------------------
-
 export interface ScheduleDriverPort {
 	getDriver(): Driver | null
 }
-
-// ---------------------------------------------------------------------------
-// Port: node store access for ScheduleService
-// ---------------------------------------------------------------------------
 
 export interface ScheduleNodeStorePort {
 	getNode(nodeId: number): ScheduleNodeState | undefined
@@ -137,17 +107,9 @@ export interface ScheduleNodeStorePort {
 	): void
 }
 
-// ---------------------------------------------------------------------------
-// Port: deep-equal utility for ScheduleService
-// ---------------------------------------------------------------------------
-
 export interface ScheduleUtilsPort {
 	deepEqual(a: unknown, b: unknown): boolean
 }
-
-// ---------------------------------------------------------------------------
-// Port: driver + node access for ConfigurationTemplateService
-// ---------------------------------------------------------------------------
 
 export interface TemplateDriverPort {
 	getDriver(): {
@@ -156,10 +118,6 @@ export interface TemplateDriverPort {
 		}
 	} | null
 }
-
-// ---------------------------------------------------------------------------
-// Port: node store for templates
-// ---------------------------------------------------------------------------
 
 export interface TemplateNodeStorePort {
 	getNode(nodeId: number): TemplateNodeState | undefined
@@ -185,28 +143,16 @@ export interface TemplateNodeStorePort {
 	throttle(key: string, fn: () => void, wait: number): void
 }
 
-// ---------------------------------------------------------------------------
-// Port: persistence (jsonStore) for templates
-// ---------------------------------------------------------------------------
-
 export interface TemplatePersistencePort {
 	get(): ZUIConfigurationTemplate[]
 	put(data: ZUIConfigurationTemplate[]): Promise<unknown>
 }
-
-// ---------------------------------------------------------------------------
-// Port: logger
-// ---------------------------------------------------------------------------
 
 export interface ServiceLogger {
 	info(message: string, ...meta: unknown[]): void
 	warn(message: string, ...meta: unknown[]): void
 	error(message: string, ...meta: unknown[]): void
 }
-
-// ---------------------------------------------------------------------------
-// Port: ID generation + hashing
-// ---------------------------------------------------------------------------
 
 export interface TemplateUtilsPort {
 	generateId(): string

--- a/api/lib/zwave/ports.ts
+++ b/api/lib/zwave/ports.ts
@@ -9,6 +9,7 @@ import type {
 	Driver,
 } from 'zwave-js'
 import type { SupervisionResult } from '@zwave-js/core'
+import type { ConfigManager } from '@zwave-js/config'
 import type { DeepPartial } from '../utils.ts'
 
 export const ZUIScheduleEntryLockMode = {
@@ -155,39 +156,10 @@ export interface ServiceLogger {
 	error(message: string, ...meta: unknown[]): void
 }
 
-export interface TemplateConfigManagerPort {
-	loadDeviceIndex(): Promise<void>
-	lookupDevice(
-		manufacturerId: number,
-		productType: number,
-		productId: number,
-	): Promise<
-		| {
-				paramInformation?: {
-					entries(): Iterable<
-						[
-							{ parameter: number; valueBitMask?: number },
-							{
-								label?: string
-								description?: string
-								readOnly?: boolean
-								minValue?: number
-								maxValue?: number
-								defaultValue?: number
-								unit?: string
-								allowManualEntry?: boolean
-								options?: readonly {
-									label: string
-									value: number
-								}[]
-							},
-						]
-					>
-				}
-		  }
-		| undefined
-	>
-}
+export type TemplateConfigManagerPort = Pick<
+	ConfigManager,
+	'loadDeviceIndex' | 'lookupDevice'
+>
 
 export interface TemplateUtilsPort {
 	generateId(): string

--- a/test/lib/zwave/ConfigurationTemplateService.test.ts
+++ b/test/lib/zwave/ConfigurationTemplateService.test.ts
@@ -10,10 +10,6 @@ import type { ZWaveNode } from 'zwave-js'
 import { CommandClasses } from '@zwave-js/core'
 import { SetValueStatus } from 'zwave-js'
 
-// ---------------------------------------------------------------------------
-// Helpers: minimal fakes for ports
-// ---------------------------------------------------------------------------
-
 let idCounter = 0
 
 function createUtilsPort() {
@@ -120,10 +116,6 @@ function makeTemplate(
 		...overrides,
 	}
 }
-
-// ---------------------------------------------------------------------------
-// Tests
-// ---------------------------------------------------------------------------
 
 describe('ConfigurationTemplateService', () => {
 	beforeEach(() => {
@@ -473,7 +465,6 @@ describe('ConfigurationTemplateService', () => {
 			expect(result.failed).toBe(0)
 			expect(nodeStore.writeValue).toHaveBeenCalledTimes(2)
 
-			// Assert exact write arguments in order: nodeId, CC, endpoint, property, propertyKey, value
 			expect(nodeStore.writeValue).toHaveBeenNthCalledWith(
 				1,
 				{
@@ -674,7 +665,6 @@ describe('ConfigurationTemplateService', () => {
 			expect(result.failed).toBe(1)
 			expect(result.errors[0]).toContain('Custom error message')
 
-			// Verify all 3 writes were attempted with exact args
 			expect(nodeStore.writeValue).toHaveBeenCalledTimes(3)
 			expect(nodeStore.writeValue).toHaveBeenNthCalledWith(
 				1,
@@ -858,7 +848,6 @@ describe('ConfigurationTemplateService', () => {
 			const zwaveNode = { id: 2 } as ZWaveNode
 			svc.checkConfigurationTemplates(node, zwaveNode)
 
-			// Allow async auto-apply to complete
 			await new Promise((r) => setTimeout(r, 10))
 
 			expect(nodeStore.writeValue).toHaveBeenCalled()
@@ -1023,7 +1012,6 @@ describe('ConfigurationTemplateService', () => {
 		})
 
 		it('returns mapped params from ConfigManager with correct lookup ordering', async () => {
-			// Mock ConfigManager at the module level
 			const mockParamInfo = new Map()
 			mockParamInfo.set(
 				{ parameter: 2, valueBitMask: undefined },
@@ -1061,7 +1049,6 @@ describe('ConfigurationTemplateService', () => {
 				paramInformation: mockParamInfo,
 			}
 
-			// We need to mock the module-level configManager
 			const configModule = await import('@zwave-js/config')
 			const loadSpy = vi
 				.spyOn(configModule.ConfigManager.prototype, 'loadDeviceIndex')
@@ -1083,19 +1070,14 @@ describe('ConfigurationTemplateService', () => {
 				[],
 			)
 
-			// deviceId = "134-2-100" → manufacturerId=134, productId=2, productType=100
 			const result = await svc.getDeviceConfigurationParams('134-2-100')
 
-			// Verify loadDeviceIndex was called
 			expect(loadSpy).toHaveBeenCalled()
 
-			// Verify lookupDevice ordering: manufacturer, productType, productId
 			expect(lookupSpy).toHaveBeenCalledWith(134, 100, 2)
 
-			// Verify exact output mapping
 			expect(result.length).toBe(2)
 
-			// First param: parameter 2, no bitmask
 			expect(result[0]).toEqual({
 				id: '0-112-0-2',
 				commandClass: 112,
@@ -1117,7 +1099,6 @@ describe('ConfigurationTemplateService', () => {
 				newValue: 0,
 			})
 
-			// Second param: parameter 5 with bitmask 1
 			expect(result[1]).toEqual({
 				id: '0-112-0-5-1',
 				commandClass: 112,
@@ -1258,7 +1239,6 @@ describe('ConfigurationTemplateService', () => {
 			const node = makeNode()
 			const nodes = new Map<number, TemplateNodeState>([[2, node]])
 
-			// Use a driver port that returns a real controller.nodes
 			const driverPort = {
 				getDriver: () =>
 					({
@@ -1292,7 +1272,6 @@ describe('ConfigurationTemplateService', () => {
 					],
 				},
 			)
-			// Hash should change
 			expect(updated.contentHash).not.toBe(originalHash)
 		})
 	})
@@ -1381,7 +1360,6 @@ describe('ConfigurationTemplateService', () => {
 			)
 
 			const result = await svc.applyConfigurationTemplate(template.id, 2)
-			// First value fails, then remaining 2 are counted as failed
 			expect(result.failed).toBe(3)
 			expect(result.reason).toBe('Node is dead')
 		})
@@ -1433,7 +1411,6 @@ describe('ConfigurationTemplateService', () => {
 			const node = makeNode({ appliedTemplateContentHashes: [] })
 			const nodes = new Map<number, TemplateNodeState>([[2, node]])
 			const nodeStore = createNodeStorePort(nodes)
-			// First call succeeds, second fails
 			let callCount = 0
 			nodeStore.writeValue = vi.fn(() => {
 				callCount++
@@ -1446,7 +1423,6 @@ describe('ConfigurationTemplateService', () => {
 				return Promise.resolve({ status: SetValueStatus.Success })
 			})
 
-			// add a second value
 			template.values.push({
 				property: 2,
 				propertyKey: null,
@@ -1480,16 +1456,13 @@ describe('ConfigurationTemplateService', () => {
 			)
 
 			svc.checkConfigurationTemplates(node, fakeZwaveNode)
-			// Give async auto-apply time to complete
 			await new Promise((r) => setTimeout(r, 50))
 
-			// Assert exact warning level and message (not info)
 			expect(nodeStore.logNode).toHaveBeenCalledWith(
 				fakeZwaveNode,
 				'warn',
 				expect.stringContaining('partially applied'),
 			)
-			// Ensure the initial info log is separate from the warn
 			const logCalls = (nodeStore.logNode as ReturnType<typeof vi.fn>)
 				.mock.calls
 			const infoLogs = logCalls.filter((c: unknown[]) => c[1] === 'info')
@@ -1524,7 +1497,6 @@ describe('ConfigurationTemplateService', () => {
 
 			const fakeZwaveNode = { id: 2 } as ZWaveNode
 			svc.checkConfigurationTemplates(node, fakeZwaveNode)
-			// Zero writes: template excluded by firmware
 			expect(nodeStore.writeValue).not.toHaveBeenCalled()
 		})
 
@@ -1552,7 +1524,6 @@ describe('ConfigurationTemplateService', () => {
 			)
 
 			svc.checkConfigurationTemplates(node, fakeZwaveNode)
-			// Zero writes: firmware too high
 			expect(nodeStore.writeValue).not.toHaveBeenCalled()
 		})
 
@@ -1581,9 +1552,7 @@ describe('ConfigurationTemplateService', () => {
 			)
 
 			svc.checkConfigurationTemplates(node, fakeZwaveNode)
-			// Give async auto-apply time to complete
 			await new Promise((r) => setTimeout(r, 50))
-			// Template should be applied (firmware in range)
 			expect(nodeStore.logNode).toHaveBeenCalled()
 		})
 
@@ -1610,7 +1579,6 @@ describe('ConfigurationTemplateService', () => {
 
 			const fakeZwaveNode = { id: 2 } as ZWaveNode
 			svc.checkConfigurationTemplates(node, fakeZwaveNode)
-			// Zero writes: missing firmware version
 			expect(nodeStore.writeValue).not.toHaveBeenCalled()
 		})
 	})
@@ -1644,12 +1612,10 @@ describe('ConfigurationTemplateService', () => {
 				[template],
 			)
 
-			// Spy on applyConfigurationTemplate and force it to reject
 			vi.spyOn(svc, 'applyConfigurationTemplate').mockRejectedValue(
 				new Error('Network error'),
 			)
 
-			// Trigger auto-apply via update with content change
 			await svc.updateConfigurationTemplate(template.id, {
 				values: [
 					{
@@ -1663,9 +1629,7 @@ describe('ConfigurationTemplateService', () => {
 				],
 			})
 
-			// Wait for async apply promises to settle
 			await new Promise((r) => setTimeout(r, 100))
-			// The error should be caught and logged at error level
 			const logCalls = (nodeStore.logNode as ReturnType<typeof vi.fn>)
 				.mock.calls
 			const errorLogs = logCalls.filter(
@@ -1694,7 +1658,6 @@ describe('ConfigurationTemplateService', () => {
 			)
 
 			await svc.applyConfigurationTemplate(template.id, 2)
-			// setStoreNode should have been called to create the entry
 			expect(nodeStore.setStoreNode).toHaveBeenCalled()
 		})
 	})
@@ -1710,7 +1673,6 @@ describe('ConfigurationTemplateService', () => {
 				createLogger(),
 				[],
 			)
-			// Should not throw even with no driver - no matching templates
 			const fakeZwaveNode = { id: 2 } as ZWaveNode
 			svc.checkConfigurationTemplates(node, fakeZwaveNode)
 		})
@@ -1742,7 +1704,6 @@ describe('ConfigurationTemplateService', () => {
 			)
 
 			await svc.deleteConfigurationTemplate(template.id)
-			// The deleted hash should be removed, but other-hash remains (its template still exists)
 			expect(node.appliedTemplateContentHashes).not.toContain('del-hash')
 			expect(node.appliedTemplateContentHashes).toContain('other-hash')
 		})
@@ -1768,7 +1729,6 @@ describe('ConfigurationTemplateService', () => {
 			await svc.importConfigurationTemplates([imported])
 			const templates = svc.getConfigurationTemplates()
 			expect(templates.length).toBe(2)
-			// The imported one should have a new ID
 			const importedTemplate = templates.find(
 				(t) => t.name === 'Imported',
 			)
@@ -1893,7 +1853,6 @@ describe('ConfigurationTemplateService', () => {
 			)
 
 			await svc.applyConfigurationTemplate(template.id, 2)
-			// appliedTemplateContentHashes should now be initialized
 			expect(node.appliedTemplateContentHashes).toBeDefined()
 			expect(node.appliedTemplateContentHashes.length).toBe(1)
 		})
@@ -1930,7 +1889,6 @@ describe('ConfigurationTemplateService', () => {
 				[template],
 			)
 
-			// Trigger auto-apply via update
 			await svc.updateConfigurationTemplate(template.id, {
 				values: [
 					{
@@ -1944,9 +1902,7 @@ describe('ConfigurationTemplateService', () => {
 				],
 			})
 
-			// Wait for async operations
 			await new Promise((r) => setTimeout(r, 50))
-			// writeValue should not be called since node is not ready
 			expect(nodeStore.writeValue).not.toHaveBeenCalled()
 		})
 
@@ -1982,7 +1938,6 @@ describe('ConfigurationTemplateService', () => {
 			const fakeZwaveNode = { id: 2 } as ZWaveNode
 			svc.checkConfigurationTemplates(node, fakeZwaveNode)
 
-			// writeValue should not be called since hash is already applied
 			expect(nodeStore.writeValue).not.toHaveBeenCalled()
 		})
 	})
@@ -1995,10 +1950,7 @@ describe('ConfigurationTemplateService', () => {
 			})
 			const node = makeNode({ appliedTemplateContentHashes: [] })
 			const nodes = new Map<number, TemplateNodeState>([[2, node]])
-			// Make getNode return undefined to trigger "not found" error
-			// inside applyConfigurationTemplate
 			const nodeStore = createNodeStorePort(nodes)
-			// Override getNode to fail for node 2 (but getNodes still works)
 			nodeStore.getNode = vi.fn(() => undefined)
 
 			const fakeZwaveNode = { id: 2 } as ZWaveNode
@@ -2025,10 +1977,8 @@ describe('ConfigurationTemplateService', () => {
 			)
 
 			svc.checkConfigurationTemplates(node, fakeZwaveNode)
-			// Wait for async catch handler
 			await new Promise((r) => setTimeout(r, 100))
 
-			// The error should be caught and logged at 'error' level
 			const logCalls = (nodeStore.logNode as ReturnType<typeof vi.fn>)
 				.mock.calls
 			const errorLogs = logCalls.filter(
@@ -2038,7 +1988,6 @@ describe('ConfigurationTemplateService', () => {
 			expect(errorLogs[0][2]).toMatch(/Failed to auto-apply/)
 			expect(errorLogs[0][2]).toMatch(/Node 2 not found/)
 
-			// Ensure info log (auto-applying) is separate and doesn't satisfy assertion
 			const infoLogs = logCalls.filter((c: unknown[]) => c[1] === 'info')
 			expect(infoLogs.length).toBe(1)
 			expect(infoLogs[0][2]).toMatch(/Auto-applying/)

--- a/test/lib/zwave/ConfigurationTemplateService.test.ts
+++ b/test/lib/zwave/ConfigurationTemplateService.test.ts
@@ -4,7 +4,10 @@ import type {
 	ZUIConfigurationTemplate,
 	ZUIConfigurationTemplateValue,
 	TemplateNodeState,
+	TemplateDriverPort,
 } from '../../../api/lib/zwave/ports.ts'
+import type { ZWaveNode } from 'zwave-js'
+import { CommandClasses } from '@zwave-js/core'
 import { SetValueStatus } from 'zwave-js'
 
 // ---------------------------------------------------------------------------
@@ -46,7 +49,7 @@ function createDriverPort() {
 				controller: {
 					nodes: { get: vi.fn(() => undefined) },
 				},
-			}) as any,
+			}) as ReturnType<TemplateDriverPort['getDriver']>,
 	}
 }
 
@@ -434,11 +437,21 @@ describe('ConfigurationTemplateService', () => {
 	})
 
 	describe('applyConfigurationTemplate', () => {
-		it('applies values via writeValue and records hash', async () => {
+		it('applies values via writeValue with exact arguments in order and records hash', async () => {
 			const template = makeTemplate({
 				values: [
-					{ property: 1, endpoint: 0, value: 42 },
-					{ property: 2, endpoint: 0, value: 100 },
+					{
+						property: 1,
+						propertyKey: null,
+						endpoint: 0,
+						value: 42,
+					},
+					{
+						property: 2,
+						propertyKey: 3,
+						endpoint: 1,
+						value: 100,
+					},
 				],
 			})
 			const node = makeNode()
@@ -459,6 +472,31 @@ describe('ConfigurationTemplateService', () => {
 			expect(result.success).toBe(2)
 			expect(result.failed).toBe(0)
 			expect(nodeStore.writeValue).toHaveBeenCalledTimes(2)
+
+			// Assert exact write arguments in order: nodeId, CC, endpoint, property, propertyKey, value
+			expect(nodeStore.writeValue).toHaveBeenNthCalledWith(
+				1,
+				{
+					nodeId: 2,
+					commandClass: CommandClasses.Configuration,
+					endpoint: 0,
+					property: 1,
+					propertyKey: null,
+				},
+				42,
+			)
+			expect(nodeStore.writeValue).toHaveBeenNthCalledWith(
+				2,
+				{
+					nodeId: 2,
+					commandClass: CommandClasses.Configuration,
+					endpoint: 1,
+					property: 2,
+					propertyKey: 3,
+				},
+				100,
+			)
+
 			expect(node.appliedTemplateContentHashes).toContain('abc123')
 			expect(loggerFake.info).toHaveBeenCalled()
 		})
@@ -582,6 +620,97 @@ describe('ConfigurationTemplateService', () => {
 			expect(result.success).toBe(1)
 		})
 
+		it('handles partial failure: asserts exact write args and records failures', async () => {
+			const template = makeTemplate({
+				values: [
+					{
+						property: 1,
+						propertyKey: null,
+						endpoint: 0,
+						value: 1,
+					},
+					{
+						property: 2,
+						propertyKey: null,
+						endpoint: 0,
+						value: 2,
+					},
+					{
+						property: 3,
+						propertyKey: null,
+						endpoint: 0,
+						value: 3,
+					},
+				],
+			})
+			const node = makeNode()
+			const nodes = new Map([[2, node]])
+			const nodeStore = createNodeStorePort(nodes)
+			let callIdx = 0
+			nodeStore.writeValue = vi.fn(() => {
+				callIdx++
+				if (callIdx === 2) {
+					return Promise.resolve({
+						status: SetValueStatus.Fail,
+						message: 'Custom error message',
+					})
+				}
+				return Promise.resolve({ status: SetValueStatus.Success })
+			})
+
+			const loggerFake = createLogger()
+			const svc = new ConfigurationTemplateService(
+				createDriverPort(),
+				nodeStore,
+				createPersistencePort(),
+				createUtilsPort(),
+				loggerFake,
+				[template],
+			)
+
+			const result = await svc.applyConfigurationTemplate('tmpl-1', 2)
+
+			expect(result.success).toBe(2)
+			expect(result.failed).toBe(1)
+			expect(result.errors[0]).toContain('Custom error message')
+
+			// Verify all 3 writes were attempted with exact args
+			expect(nodeStore.writeValue).toHaveBeenCalledTimes(3)
+			expect(nodeStore.writeValue).toHaveBeenNthCalledWith(
+				1,
+				{
+					nodeId: 2,
+					commandClass: CommandClasses.Configuration,
+					endpoint: 0,
+					property: 1,
+					propertyKey: null,
+				},
+				1,
+			)
+			expect(nodeStore.writeValue).toHaveBeenNthCalledWith(
+				2,
+				{
+					nodeId: 2,
+					commandClass: CommandClasses.Configuration,
+					endpoint: 0,
+					property: 2,
+					propertyKey: null,
+				},
+				2,
+			)
+			expect(nodeStore.writeValue).toHaveBeenNthCalledWith(
+				3,
+				{
+					nodeId: 2,
+					commandClass: CommandClasses.Configuration,
+					endpoint: 0,
+					property: 3,
+					propertyKey: null,
+				},
+				3,
+			)
+		})
+
 		it('handles write failures and dead node early exit', async () => {
 			const template = makeTemplate({
 				values: [
@@ -676,13 +805,16 @@ describe('ConfigurationTemplateService', () => {
 				...makeTemplate(),
 				minFirmwareVersion: '1.0',
 				firmwareRange: undefined,
-			} as any
+			} as ZUIConfigurationTemplate & { minFirmwareVersion?: string }
 			const result = await svc.importConfigurationTemplates([
 				legacyTemplate,
 			])
 
 			expect(result[0].firmwareRange).toEqual({ min: '1.0' })
-			expect((result[0] as any).minFirmwareVersion).toBeUndefined()
+			expect(
+				(result[0] as unknown as { minFirmwareVersion?: string })
+					.minFirmwareVersion,
+			).toBeUndefined()
 		})
 
 		it('preserves existing contentHash if present', async () => {
@@ -723,7 +855,7 @@ describe('ConfigurationTemplateService', () => {
 				[template],
 			)
 
-			const zwaveNode = { id: 2 } as any
+			const zwaveNode = { id: 2 } as ZWaveNode
 			svc.checkConfigurationTemplates(node, zwaveNode)
 
 			// Allow async auto-apply to complete
@@ -751,7 +883,7 @@ describe('ConfigurationTemplateService', () => {
 				[template],
 			)
 
-			const zwaveNode = { id: 2 } as any
+			const zwaveNode = { id: 2 } as ZWaveNode
 			svc.checkConfigurationTemplates(node, zwaveNode)
 
 			expect(nodeStore.writeValue).not.toHaveBeenCalled()
@@ -774,7 +906,7 @@ describe('ConfigurationTemplateService', () => {
 				[template],
 			)
 
-			const zwaveNode = { id: 2 } as any
+			const zwaveNode = { id: 2 } as ZWaveNode
 			svc.checkConfigurationTemplates(node, zwaveNode)
 
 			expect(nodeStore.writeValue).not.toHaveBeenCalled()
@@ -797,7 +929,7 @@ describe('ConfigurationTemplateService', () => {
 				[template],
 			)
 
-			const zwaveNode = { id: 2 } as any
+			const zwaveNode = { id: 2 } as ZWaveNode
 			svc.checkConfigurationTemplates(node, zwaveNode)
 
 			expect(nodeStore.writeValue).not.toHaveBeenCalled()
@@ -888,6 +1020,151 @@ describe('ConfigurationTemplateService', () => {
 			await expect(
 				svc.getDeviceConfigurationParams('abc-def-ghi'),
 			).rejects.toThrow('non-numeric')
+		})
+
+		it('returns mapped params from ConfigManager with correct lookup ordering', async () => {
+			// Mock ConfigManager at the module level
+			const mockParamInfo = new Map()
+			mockParamInfo.set(
+				{ parameter: 2, valueBitMask: undefined },
+				{
+					label: 'Wake After Power On',
+					description: 'Wake duration',
+					readOnly: false,
+					minValue: 0,
+					maxValue: 255,
+					defaultValue: 0,
+					unit: 'seconds',
+					allowManualEntry: true,
+					options: [],
+				},
+			)
+			mockParamInfo.set(
+				{ parameter: 5, valueBitMask: 1 },
+				{
+					label: 'Sensor Report',
+					description: 'Bitmask param',
+					readOnly: true,
+					minValue: 0,
+					maxValue: 3,
+					defaultValue: 1,
+					unit: undefined,
+					allowManualEntry: false,
+					options: [
+						{ label: 'Off', value: 0 },
+						{ label: 'On', value: 1 },
+					],
+				},
+			)
+
+			const mockDevice = {
+				paramInformation: mockParamInfo,
+			}
+
+			// We need to mock the module-level configManager
+			const configModule = await import('@zwave-js/config')
+			const loadSpy = vi
+				.spyOn(configModule.ConfigManager.prototype, 'loadDeviceIndex')
+				.mockResolvedValue(undefined)
+			const lookupSpy = vi
+				.spyOn(configModule.ConfigManager.prototype, 'lookupDevice')
+				.mockResolvedValue(
+					mockDevice as ReturnType<
+						typeof configModule.ConfigManager.prototype.lookupDevice
+					>,
+				)
+
+			const svc = new ConfigurationTemplateService(
+				createDriverPort(),
+				createNodeStorePort(),
+				createPersistencePort(),
+				createUtilsPort(),
+				createLogger(),
+				[],
+			)
+
+			// deviceId = "134-2-100" → manufacturerId=134, productId=2, productType=100
+			const result = await svc.getDeviceConfigurationParams('134-2-100')
+
+			// Verify loadDeviceIndex was called
+			expect(loadSpy).toHaveBeenCalled()
+
+			// Verify lookupDevice ordering: manufacturer, productType, productId
+			expect(lookupSpy).toHaveBeenCalledWith(134, 100, 2)
+
+			// Verify exact output mapping
+			expect(result.length).toBe(2)
+
+			// First param: parameter 2, no bitmask
+			expect(result[0]).toEqual({
+				id: '0-112-0-2',
+				commandClass: 112,
+				property: 2,
+				propertyKey: undefined,
+				endpoint: 0,
+				type: 'number',
+				readable: true,
+				writeable: true,
+				label: 'Wake After Power On',
+				description: 'Wake duration',
+				min: 0,
+				max: 255,
+				default: 0,
+				unit: 'seconds',
+				list: false,
+				allowManualEntry: true,
+				states: [],
+				newValue: 0,
+			})
+
+			// Second param: parameter 5 with bitmask 1
+			expect(result[1]).toEqual({
+				id: '0-112-0-5-1',
+				commandClass: 112,
+				property: 5,
+				propertyKey: 1,
+				endpoint: 0,
+				type: 'number',
+				readable: true,
+				writeable: false, // readOnly=true
+				label: 'Sensor Report',
+				description: 'Bitmask param',
+				min: 0,
+				max: 3,
+				default: 1,
+				unit: undefined,
+				list: true, // options.length > 0
+				allowManualEntry: false,
+				states: [
+					{ text: 'Off', value: 0 },
+					{ text: 'On', value: 1 },
+				],
+				newValue: 1,
+			})
+		})
+
+		it('returns empty array when device has no paramInformation', async () => {
+			const configModule = await import('@zwave-js/config')
+			vi.spyOn(
+				configModule.ConfigManager.prototype,
+				'loadDeviceIndex',
+			).mockResolvedValue(undefined)
+			vi.spyOn(
+				configModule.ConfigManager.prototype,
+				'lookupDevice',
+			).mockResolvedValue(undefined)
+
+			const svc = new ConfigurationTemplateService(
+				createDriverPort(),
+				createNodeStorePort(),
+				createPersistencePort(),
+				createUtilsPort(),
+				createLogger(),
+				[],
+			)
+
+			const result = await svc.getDeviceConfigurationParams('134-2-100')
+			expect(result).toEqual([])
 		})
 	})
 
@@ -988,7 +1265,7 @@ describe('ConfigurationTemplateService', () => {
 						controller: {
 							nodes: new Map<number, unknown>(),
 						},
-					}) as any,
+					}) as ReturnType<TemplateDriverPort['getDriver']>,
 			}
 
 			const svc = new ConfigurationTemplateService(
@@ -1085,7 +1362,7 @@ describe('ConfigurationTemplateService', () => {
 					},
 				],
 			})
-			const node = makeNode({ status: 'Dead' as any })
+			const node = makeNode({ status: 'Dead' })
 			const nodes = new Map<number, TemplateNodeState>([[2, node]])
 			const nodeStore = createNodeStorePort(nodes)
 			nodeStore.writeValue = vi.fn(() =>
@@ -1148,7 +1425,7 @@ describe('ConfigurationTemplateService', () => {
 	})
 
 	describe('checkConfigurationTemplates – partial failure', () => {
-		it('logs warning when auto-apply has partial failures', async () => {
+		it('logs warning (not info) when auto-apply has partial failures', async () => {
 			const template = makeTemplate({
 				autoApply: true,
 				contentHash: 'unique-hash',
@@ -1179,7 +1456,7 @@ describe('ConfigurationTemplateService', () => {
 				description: '',
 			})
 
-			const fakeZwaveNode = { id: 2 } as any
+			const fakeZwaveNode = { id: 2 } as ZWaveNode
 			const driverPort = {
 				getDriver: () =>
 					({
@@ -1189,7 +1466,7 @@ describe('ConfigurationTemplateService', () => {
 									id === 2 ? fakeZwaveNode : undefined,
 							},
 						},
-					}) as any,
+					}) as ReturnType<TemplateDriverPort['getDriver']>,
 			}
 			const logger = createLogger()
 
@@ -1205,34 +1482,53 @@ describe('ConfigurationTemplateService', () => {
 			svc.checkConfigurationTemplates(node, fakeZwaveNode)
 			// Give async auto-apply time to complete
 			await new Promise((r) => setTimeout(r, 50))
-			// Should have logged
-			expect(nodeStore.logNode).toHaveBeenCalled()
+
+			// Assert exact warning level and message (not info)
+			expect(nodeStore.logNode).toHaveBeenCalledWith(
+				fakeZwaveNode,
+				'warn',
+				expect.stringContaining('partially applied'),
+			)
+			// Ensure the initial info log is separate from the warn
+			const logCalls = (nodeStore.logNode as ReturnType<typeof vi.fn>)
+				.mock.calls
+			const infoLogs = logCalls.filter((c: unknown[]) => c[1] === 'info')
+			const warnLogs = logCalls.filter((c: unknown[]) => c[1] === 'warn')
+			expect(infoLogs.length).toBeGreaterThanOrEqual(1)
+			expect(warnLogs.length).toBe(1)
+			expect(warnLogs[0][2]).toMatch(/1 OK, 1 failed/)
 		})
 	})
 
 	describe('_getMatchingTemplates – firmware range filtering', () => {
-		it('excludes templates with min firmware above node firmware', () => {
+		it('excludes templates with min firmware above node firmware: zero writes', () => {
 			const template = makeTemplate({
+				autoApply: true,
 				firmwareRange: { min: '2.0.0', max: undefined },
 			})
-			const node = makeNode({ firmwareVersion: '1.0.0' })
+			const node = makeNode({
+				firmwareVersion: '1.0.0',
+				appliedTemplateContentHashes: [],
+			})
 			const nodes = new Map<number, TemplateNodeState>([[2, node]])
+			const nodeStore = createNodeStorePort(nodes)
 
 			const svc = new ConfigurationTemplateService(
 				createDriverPort(),
-				createNodeStorePort(nodes),
+				nodeStore,
 				createPersistencePort([template]),
 				createUtilsPort(),
 				createLogger(),
 				[template],
 			)
 
-			const fakeZwaveNode = { id: 2 } as any
+			const fakeZwaveNode = { id: 2 } as ZWaveNode
 			svc.checkConfigurationTemplates(node, fakeZwaveNode)
-			// The template should not match, so no auto-apply happens
+			// Zero writes: template excluded by firmware
+			expect(nodeStore.writeValue).not.toHaveBeenCalled()
 		})
 
-		it('excludes templates with max firmware below node firmware', () => {
+		it('excludes templates with max firmware below node firmware: zero writes', () => {
 			const template = makeTemplate({
 				autoApply: true,
 				firmwareRange: { min: undefined, max: '1.0.0' },
@@ -1242,12 +1538,13 @@ describe('ConfigurationTemplateService', () => {
 				appliedTemplateContentHashes: [],
 			})
 			const nodes = new Map<number, TemplateNodeState>([[2, node]])
+			const nodeStore = createNodeStorePort(nodes)
 
-			const fakeZwaveNode = { id: 2 } as any
+			const fakeZwaveNode = { id: 2 } as ZWaveNode
 
 			const svc = new ConfigurationTemplateService(
 				createDriverPort(),
-				createNodeStorePort(nodes),
+				nodeStore,
 				createPersistencePort([template]),
 				createUtilsPort(),
 				createLogger(),
@@ -1255,7 +1552,8 @@ describe('ConfigurationTemplateService', () => {
 			)
 
 			svc.checkConfigurationTemplates(node, fakeZwaveNode)
-			// Template should not be applied (firmware too high)
+			// Zero writes: firmware too high
+			expect(nodeStore.writeValue).not.toHaveBeenCalled()
 		})
 
 		it('includes template when node firmware is within range', async () => {
@@ -1270,7 +1568,7 @@ describe('ConfigurationTemplateService', () => {
 			})
 			const nodes = new Map<number, TemplateNodeState>([[2, node]])
 
-			const fakeZwaveNode = { id: 2 } as any
+			const fakeZwaveNode = { id: 2 } as ZWaveNode
 			const nodeStore = createNodeStorePort(nodes)
 
 			const svc = new ConfigurationTemplateService(
@@ -1289,34 +1587,36 @@ describe('ConfigurationTemplateService', () => {
 			expect(nodeStore.logNode).toHaveBeenCalled()
 		})
 
-		it('skips template when node has no firmwareVersion', () => {
+		it('skips template when node has no firmwareVersion: zero writes', () => {
 			const template = makeTemplate({
 				autoApply: true,
 				firmwareRange: { min: '1.0.0', max: undefined },
 			})
 			const node = makeNode({
-				firmwareVersion: undefined as any,
+				firmwareVersion: undefined,
 				appliedTemplateContentHashes: [],
 			})
 			const nodes = new Map<number, TemplateNodeState>([[2, node]])
+			const nodeStore = createNodeStorePort(nodes)
 
 			const svc = new ConfigurationTemplateService(
 				createDriverPort(),
-				createNodeStorePort(nodes),
+				nodeStore,
 				createPersistencePort([template]),
 				createUtilsPort(),
 				createLogger(),
 				[template],
 			)
 
-			const fakeZwaveNode = { id: 2 } as any
+			const fakeZwaveNode = { id: 2 } as ZWaveNode
 			svc.checkConfigurationTemplates(node, fakeZwaveNode)
-			// No auto-apply should happen
+			// Zero writes: missing firmware version
+			expect(nodeStore.writeValue).not.toHaveBeenCalled()
 		})
 	})
 
 	describe('_autoApplyToNodes – error handling', () => {
-		it('logs error when auto-apply promise rejects', async () => {
+		it('logs error (not warn/info) when auto-apply promise rejects', async () => {
 			const template = makeTemplate({
 				autoApply: true,
 				contentHash: 'err-hash',
@@ -1324,18 +1624,15 @@ describe('ConfigurationTemplateService', () => {
 			const node = makeNode({ appliedTemplateContentHashes: [] })
 			const nodes = new Map<number, TemplateNodeState>([[2, node]])
 			const nodeStore = createNodeStorePort(nodes)
-			nodeStore.writeValue = vi.fn(() =>
-				Promise.reject(new Error('Network error')),
-			)
 
-			const fakeZwaveNode = { id: 2 } as any
+			const fakeZwaveNode = { id: 2 } as ZWaveNode
 			const driverPort = {
 				getDriver: () =>
 					({
 						controller: {
 							nodes: new Map([[2, fakeZwaveNode]]),
 						},
-					}) as any,
+					}) as ReturnType<TemplateDriverPort['getDriver']>,
 			}
 
 			const svc = new ConfigurationTemplateService(
@@ -1345,6 +1642,11 @@ describe('ConfigurationTemplateService', () => {
 				createUtilsPort(),
 				createLogger(),
 				[template],
+			)
+
+			// Spy on applyConfigurationTemplate and force it to reject
+			vi.spyOn(svc, 'applyConfigurationTemplate').mockRejectedValue(
+				new Error('Network error'),
 			)
 
 			// Trigger auto-apply via update with content change
@@ -1363,8 +1665,14 @@ describe('ConfigurationTemplateService', () => {
 
 			// Wait for async apply promises to settle
 			await new Promise((r) => setTimeout(r, 100))
-			// The error should be caught and logged, not thrown
-			expect(nodeStore.logNode).toHaveBeenCalled()
+			// The error should be caught and logged at error level
+			const logCalls = (nodeStore.logNode as ReturnType<typeof vi.fn>)
+				.mock.calls
+			const errorLogs = logCalls.filter(
+				(c: unknown[]) => c[1] === 'error',
+			)
+			expect(errorLogs.length).toBe(1)
+			expect(errorLogs[0][2]).toMatch(/Failed to auto-apply/)
 		})
 	})
 
@@ -1403,7 +1711,7 @@ describe('ConfigurationTemplateService', () => {
 				[],
 			)
 			// Should not throw even with no driver - no matching templates
-			const fakeZwaveNode = { id: 2 } as any
+			const fakeZwaveNode = { id: 2 } as ZWaveNode
 			svc.checkConfigurationTemplates(node, fakeZwaveNode)
 		})
 	})
@@ -1471,7 +1779,7 @@ describe('ConfigurationTemplateService', () => {
 
 	describe('createConfigurationTemplate – edge cases', () => {
 		it('throws when node has no values (values=undefined)', async () => {
-			const node = makeNode({ values: undefined as any })
+			const node = makeNode({ values: undefined })
 			const nodes = new Map<number, TemplateNodeState>([[2, node]])
 			const svc = new ConfigurationTemplateService(
 				createDriverPort(),
@@ -1494,7 +1802,7 @@ describe('ConfigurationTemplateService', () => {
 						commandClass: 112,
 						writeable: true,
 						property: 1,
-						endpoint: undefined as any,
+						endpoint: undefined,
 						value: 42,
 						label: 'P1',
 						description: 'A param',
@@ -1517,7 +1825,7 @@ describe('ConfigurationTemplateService', () => {
 
 		it('defaults deviceId when node.deviceId is falsy', async () => {
 			const node = makeNode({
-				deviceId: undefined as any,
+				deviceId: undefined,
 				values: {
 					'0-112-0-1': {
 						commandClass: 112,
@@ -1570,7 +1878,7 @@ describe('ConfigurationTemplateService', () => {
 		it('initializes appliedTemplateContentHashes when undefined', async () => {
 			const template = makeTemplate()
 			const node = makeNode({
-				appliedTemplateContentHashes: undefined as any,
+				appliedTemplateContentHashes: undefined,
 			})
 			const nodes = new Map<number, TemplateNodeState>([[2, node]])
 			const nodeStore = createNodeStorePort(nodes)
@@ -1610,7 +1918,7 @@ describe('ConfigurationTemplateService', () => {
 						controller: {
 							nodes: new Map([[2, { id: 2 }]]),
 						},
-					}) as any,
+					}) as ReturnType<TemplateDriverPort['getDriver']>,
 			}
 
 			const svc = new ConfigurationTemplateService(
@@ -1659,7 +1967,7 @@ describe('ConfigurationTemplateService', () => {
 						controller: {
 							nodes: new Map([[2, { id: 2 }]]),
 						},
-					}) as any,
+					}) as ReturnType<TemplateDriverPort['getDriver']>,
 			}
 
 			const svc = new ConfigurationTemplateService(
@@ -1671,10 +1979,7 @@ describe('ConfigurationTemplateService', () => {
 				[template],
 			)
 
-			// Trigger auto-apply via update with name change (no content change - but autoApply set)
-			// Actually we need content change for autoApply to trigger
-			// Let's use checkConfigurationTemplates instead
-			const fakeZwaveNode = { id: 2 } as any
+			const fakeZwaveNode = { id: 2 } as ZWaveNode
 			svc.checkConfigurationTemplates(node, fakeZwaveNode)
 
 			// writeValue should not be called since hash is already applied
@@ -1682,8 +1987,8 @@ describe('ConfigurationTemplateService', () => {
 		})
 	})
 
-	describe('checkConfigurationTemplates – catch handler', () => {
-		it('logs error when applyConfigurationTemplate rejects', async () => {
+	describe('checkConfigurationTemplates – outer catch', () => {
+		it('logs error when applyConfigurationTemplate rejects (checkConfigurationTemplates catch)', async () => {
 			const template = makeTemplate({
 				autoApply: true,
 				contentHash: 'check-catch-hash',
@@ -1696,7 +2001,7 @@ describe('ConfigurationTemplateService', () => {
 			// Override getNode to fail for node 2 (but getNodes still works)
 			nodeStore.getNode = vi.fn(() => undefined)
 
-			const fakeZwaveNode = { id: 2 } as any
+			const fakeZwaveNode = { id: 2 } as ZWaveNode
 			const driverPort = {
 				getDriver: () =>
 					({
@@ -1706,7 +2011,7 @@ describe('ConfigurationTemplateService', () => {
 									id === 2 ? fakeZwaveNode : undefined,
 							},
 						},
-					}) as any,
+					}) as ReturnType<TemplateDriverPort['getDriver']>,
 			}
 			const logger = createLogger()
 
@@ -1722,12 +2027,21 @@ describe('ConfigurationTemplateService', () => {
 			svc.checkConfigurationTemplates(node, fakeZwaveNode)
 			// Wait for async catch handler
 			await new Promise((r) => setTimeout(r, 100))
-			// The error should be caught and logged
-			expect(nodeStore.logNode).toHaveBeenCalledWith(
-				fakeZwaveNode,
-				'error',
-				expect.stringContaining('Failed to auto-apply'),
+
+			// The error should be caught and logged at 'error' level
+			const logCalls = (nodeStore.logNode as ReturnType<typeof vi.fn>)
+				.mock.calls
+			const errorLogs = logCalls.filter(
+				(c: unknown[]) => c[1] === 'error',
 			)
+			expect(errorLogs.length).toBe(1)
+			expect(errorLogs[0][2]).toMatch(/Failed to auto-apply/)
+			expect(errorLogs[0][2]).toMatch(/Node 2 not found/)
+
+			// Ensure info log (auto-applying) is separate and doesn't satisfy assertion
+			const infoLogs = logCalls.filter((c: unknown[]) => c[1] === 'info')
+			expect(infoLogs.length).toBe(1)
+			expect(infoLogs[0][2]).toMatch(/Auto-applying/)
 		})
 	})
 })

--- a/test/lib/zwave/ConfigurationTemplateService.test.ts
+++ b/test/lib/zwave/ConfigurationTemplateService.test.ts
@@ -90,7 +90,7 @@ function makeNode(
 		firmwareVersion: '1.5.0',
 		values: {
 			'0-112-0-1': {
-				commandClass: 112,
+				commandClass: CommandClasses.Configuration,
 				writeable: true,
 				property: 1,
 				endpoint: 0,
@@ -166,7 +166,7 @@ describe('ConfigurationTemplateService', () => {
 	})
 
 	describe('createConfigurationTemplate', () => {
-		it('creates a template from node CC 112 values', async () => {
+		it('creates a template from node Configuration CC values', async () => {
 			const node = makeNode()
 			const nodes = new Map([[2, node]])
 			const persistence = createPersistencePort()
@@ -749,9 +749,7 @@ describe('ConfigurationTemplateService', () => {
 			const node = makeNode({ status: 'Dead' })
 			const nodes = new Map([[2, node]])
 			const nodeStore = createNodeStorePort(nodes)
-			;(
-				nodeStore.writeValue as ReturnType<typeof vi.fn>
-			).mockResolvedValue({
+			vi.mocked(nodeStore.writeValue).mockResolvedValue({
 				status: SetValueStatus.Fail,
 			})
 
@@ -778,9 +776,9 @@ describe('ConfigurationTemplateService', () => {
 			const node = makeNode()
 			const nodes = new Map([[2, node]])
 			const nodeStore = createNodeStorePort(nodes)
-			;(
-				nodeStore.writeValue as ReturnType<typeof vi.fn>
-			).mockRejectedValue(new Error('Timeout'))
+			vi.mocked(nodeStore.writeValue).mockRejectedValue(
+				new Error('Timeout'),
+			)
 
 			const svc = new ConfigurationTemplateService(
 				createDriverPort(),
@@ -971,7 +969,7 @@ describe('ConfigurationTemplateService', () => {
 	})
 
 	describe('contentHash via public API', () => {
-		it('produces deterministic 12-char hex hash via createConfigurationTemplate', async () => {
+		it('produces deterministic content hash for identical values', async () => {
 			const node = makeNode()
 			const nodes = new Map([[2, node]])
 			const svc = new ConfigurationTemplateService(
@@ -997,8 +995,7 @@ describe('ConfigurationTemplateService', () => {
 				[{ property: 1, endpoint: 0, value: 42 }],
 			)
 
-			expect(result1.contentHash.length).toBe(12)
-			expect(/^[0-9a-f]{12}$/.test(result1.contentHash)).toBe(true)
+			expect(result1.contentHash).toBeTruthy()
 			expect(result1.contentHash).toBe(result2.contentHash)
 		})
 
@@ -1202,7 +1199,7 @@ describe('ConfigurationTemplateService', () => {
 
 			expect(result[0]).toEqual({
 				id: '0-112-0-2',
-				commandClass: 112,
+				commandClass: CommandClasses.Configuration,
 				property: 2,
 				propertyKey: undefined,
 				endpoint: 0,
@@ -1223,7 +1220,7 @@ describe('ConfigurationTemplateService', () => {
 
 			expect(result[1]).toEqual({
 				id: '0-112-0-5-1',
-				commandClass: 112,
+				commandClass: CommandClasses.Configuration,
 				property: 5,
 				propertyKey: 1,
 				endpoint: 0,
@@ -1263,11 +1260,11 @@ describe('ConfigurationTemplateService', () => {
 	})
 
 	describe('createConfigurationTemplate – propertyKey branches', () => {
-		it('captures propertyKey when present on CC112 value', async () => {
+		it('captures propertyKey when present on Configuration CC value', async () => {
 			const node = makeNode({
 				values: {
 					'0-112-0-5-1': {
-						commandClass: 112,
+						commandClass: CommandClasses.Configuration,
 						writeable: true,
 						property: 5,
 						propertyKey: 1,
@@ -1294,11 +1291,11 @@ describe('ConfigurationTemplateService', () => {
 			expect(result.values[0].propertyKey).toBe(1)
 		})
 
-		it('skips non-writable CC112 values', async () => {
+		it('skips non-writable Configuration CC values', async () => {
 			const node = makeNode({
 				values: {
 					'0-112-0-1': {
-						commandClass: 112,
+						commandClass: CommandClasses.Configuration,
 						writeable: false,
 						property: 1,
 						endpoint: 0,
@@ -1307,7 +1304,7 @@ describe('ConfigurationTemplateService', () => {
 						description: 'Should be skipped',
 					},
 					'0-112-0-2': {
-						commandClass: 112,
+						commandClass: CommandClasses.Configuration,
 						writeable: true,
 						property: 2,
 						endpoint: 0,
@@ -1583,8 +1580,7 @@ describe('ConfigurationTemplateService', () => {
 				'warn',
 				expect.stringContaining('partially applied'),
 			)
-			const logCalls = (nodeStore.logNode as ReturnType<typeof vi.fn>)
-				.mock.calls
+			const logCalls = vi.mocked(nodeStore.logNode).mock.calls
 			const infoLogs = logCalls.filter((c: unknown[]) => c[1] === 'info')
 			const warnLogs = logCalls.filter((c: unknown[]) => c[1] === 'warn')
 			expect(infoLogs.length).toBeGreaterThanOrEqual(1)
@@ -1593,8 +1589,8 @@ describe('ConfigurationTemplateService', () => {
 		})
 	})
 
-	describe('_getMatchingTemplates – firmware range filtering', () => {
-		it('excludes templates with min firmware above node firmware: zero writes', () => {
+	describe('checkConfigurationTemplates – firmware range filtering', () => {
+		it('excludes templates with min firmware above node firmware', () => {
 			const template = makeTemplate({
 				autoApply: true,
 				firmwareRange: { min: '2.0.0', max: undefined },
@@ -1621,7 +1617,7 @@ describe('ConfigurationTemplateService', () => {
 			expect(nodeStore.writeValue).not.toHaveBeenCalled()
 		})
 
-		it('excludes templates with max firmware below node firmware: zero writes', () => {
+		it('excludes templates with max firmware below node firmware', () => {
 			const template = makeTemplate({
 				autoApply: true,
 				firmwareRange: { min: undefined, max: '1.0.0' },
@@ -1679,7 +1675,7 @@ describe('ConfigurationTemplateService', () => {
 			expect(nodeStore.logNode).toHaveBeenCalled()
 		})
 
-		it('skips template when node has no firmwareVersion: zero writes', () => {
+		it('skips template when node has no firmwareVersion', () => {
 			const template = makeTemplate({
 				autoApply: true,
 				firmwareRange: { min: '1.0.0', max: undefined },
@@ -1707,8 +1703,8 @@ describe('ConfigurationTemplateService', () => {
 		})
 	})
 
-	describe('_autoApplyToNodes – error handling', () => {
-		it('logs error (not warn/info) when auto-apply promise rejects', async () => {
+	describe('updateConfigurationTemplate – auto-apply error handling', () => {
+		it('logs error when auto-apply rejects', async () => {
 			const template = makeTemplate({
 				autoApply: true,
 				contentHash: 'err-hash',
@@ -1755,8 +1751,7 @@ describe('ConfigurationTemplateService', () => {
 			})
 
 			await new Promise((r) => setTimeout(r, 100))
-			const logCalls = (nodeStore.logNode as ReturnType<typeof vi.fn>)
-				.mock.calls
+			const logCalls = vi.mocked(nodeStore.logNode).mock.calls
 			const errorLogs = logCalls.filter(
 				(c: unknown[]) => c[1] === 'error',
 			)
@@ -1889,7 +1884,7 @@ describe('ConfigurationTemplateService', () => {
 			const node = makeNode({
 				values: {
 					'0-112-0-1': {
-						commandClass: 112,
+						commandClass: CommandClasses.Configuration,
 						writeable: true,
 						property: 1,
 						endpoint: undefined,
@@ -1919,7 +1914,7 @@ describe('ConfigurationTemplateService', () => {
 				deviceId: undefined,
 				values: {
 					'0-112-0-1': {
-						commandClass: 112,
+						commandClass: CommandClasses.Configuration,
 						writeable: true,
 						property: 1,
 						endpoint: 0,
@@ -1992,7 +1987,7 @@ describe('ConfigurationTemplateService', () => {
 		})
 	})
 
-	describe('_autoApplyToNodes – skips nodes', () => {
+	describe('auto-apply – skips non-ready and already-applied nodes', () => {
 		it('skips non-ready nodes', async () => {
 			const template = makeTemplate({
 				autoApply: true,
@@ -2078,8 +2073,8 @@ describe('ConfigurationTemplateService', () => {
 		})
 	})
 
-	describe('checkConfigurationTemplates – outer catch', () => {
-		it('logs error when applyConfigurationTemplate rejects (checkConfigurationTemplates catch)', async () => {
+	describe('checkConfigurationTemplates – apply rejection', () => {
+		it('logs error when applyConfigurationTemplate rejects during auto-apply', async () => {
 			const template = makeTemplate({
 				autoApply: true,
 				contentHash: 'check-catch-hash',
@@ -2116,8 +2111,7 @@ describe('ConfigurationTemplateService', () => {
 			svc.checkConfigurationTemplates(node, fakeZwaveNode)
 			await new Promise((r) => setTimeout(r, 100))
 
-			const logCalls = (nodeStore.logNode as ReturnType<typeof vi.fn>)
-				.mock.calls
+			const logCalls = vi.mocked(nodeStore.logNode).mock.calls
 			const errorLogs = logCalls.filter(
 				(c: unknown[]) => c[1] === 'error',
 			)

--- a/test/lib/zwave/ConfigurationTemplateService.test.ts
+++ b/test/lib/zwave/ConfigurationTemplateService.test.ts
@@ -1149,14 +1149,14 @@ describe('ConfigurationTemplateService', () => {
 				endpoint: 0,
 				type: 'number',
 				readable: true,
-				writeable: false, // readOnly=true
+				writeable: false,
 				label: 'Sensor Report',
 				description: 'Bitmask param',
 				min: 0,
 				max: 3,
 				default: 1,
 				unit: undefined,
-				list: true, // options.length > 0
+				list: true,
 				allowManualEntry: false,
 				states: [
 					{ text: 'Off', value: 0 },

--- a/test/lib/zwave/ConfigurationTemplateService.test.ts
+++ b/test/lib/zwave/ConfigurationTemplateService.test.ts
@@ -1112,6 +1112,7 @@ describe('ConfigurationTemplateService', () => {
 				[],
 			)
 
+			// deviceId format is "mfr-productId-productType"; lookupDevice reorders to (mfr, productType, productId)
 			const result = await svc.getDeviceConfigurationParams('134-2-100')
 
 			expect(loadSpy).toHaveBeenCalled()

--- a/test/lib/zwave/ConfigurationTemplateService.test.ts
+++ b/test/lib/zwave/ConfigurationTemplateService.test.ts
@@ -1,0 +1,1733 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { ConfigurationTemplateService } from '../../../api/lib/zwave/ConfigurationTemplateService.ts'
+import type {
+	ZUIConfigurationTemplate,
+	ZUIConfigurationTemplateValue,
+	TemplateNodeState,
+} from '../../../api/lib/zwave/ports.ts'
+import { SetValueStatus } from 'zwave-js'
+
+// ---------------------------------------------------------------------------
+// Helpers: minimal fakes for ports
+// ---------------------------------------------------------------------------
+
+let idCounter = 0
+
+function createUtilsPort() {
+	return {
+		generateId: () => `test-id-${++idCounter}`,
+	}
+}
+
+function createLogger() {
+	return {
+		info: vi.fn(),
+		warn: vi.fn(),
+		error: vi.fn(),
+	}
+}
+
+function createPersistencePort(initial: ZUIConfigurationTemplate[] = []) {
+	const stored: ZUIConfigurationTemplate[][] = []
+	return {
+		get: () => initial,
+		put: vi.fn((data: ZUIConfigurationTemplate[]) => {
+			stored.push([...data])
+			return Promise.resolve()
+		}),
+		stored,
+	}
+}
+
+function createDriverPort() {
+	return {
+		getDriver: () =>
+			({
+				controller: {
+					nodes: { get: vi.fn(() => undefined) },
+				},
+			}) as any,
+	}
+}
+
+function createNodeStorePort(
+	nodes: Map<number, TemplateNodeState> = new Map(),
+	storeNodes: Record<number, Partial<TemplateNodeState>> = {},
+) {
+	return {
+		getNode: vi.fn((id: number) => nodes.get(id)),
+		getNodes: () => nodes.entries(),
+		getStoreNode: vi.fn((id: number) => storeNodes[id]),
+		setStoreNode: vi.fn((id: number, data: Partial<TemplateNodeState>) => {
+			storeNodes[id] = { ...storeNodes[id], ...data }
+		}),
+		updateStoreNodes: vi.fn(() => Promise.resolve()),
+		emitNodeUpdate: vi.fn(),
+		writeValue: vi.fn(() =>
+			Promise.resolve({
+				status: SetValueStatus.Success,
+			}),
+		),
+		logNode: vi.fn(),
+		throttle: vi.fn((_key: string, fn: () => unknown) => fn()),
+	}
+}
+
+function makeNode(
+	overrides: Partial<TemplateNodeState> = {},
+): TemplateNodeState {
+	return {
+		id: 2,
+		ready: true,
+		deviceId: '0x0086-0x0002-0x0064',
+		manufacturerId: 0x0086,
+		productId: 0x0002,
+		productType: 0x0064,
+		manufacturer: 'ACME',
+		productLabel: 'Widget',
+		firmwareVersion: '1.5.0',
+		values: {
+			'0-112-0-1': {
+				commandClass: 112,
+				writeable: true,
+				property: 1,
+				endpoint: 0,
+				value: 42,
+				label: 'Param 1',
+				description: 'A param',
+			},
+		},
+		appliedTemplateContentHashes: [],
+		...overrides,
+	}
+}
+
+function makeTemplate(
+	overrides: Partial<ZUIConfigurationTemplate> = {},
+): ZUIConfigurationTemplate {
+	return {
+		id: 'tmpl-1',
+		name: 'Test Template',
+		deviceId: '0x0086-0x0002-0x0064',
+		values: [{ property: 1, endpoint: 0, value: 42 }],
+		autoApply: false,
+		contentHash: 'abc123',
+		createdAt: '2024-01-01T00:00:00.000Z',
+		updatedAt: '2024-01-01T00:00:00.000Z',
+		...overrides,
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('ConfigurationTemplateService', () => {
+	beforeEach(() => {
+		vi.restoreAllMocks()
+		idCounter = 0
+	})
+
+	describe('getConfigurationTemplates', () => {
+		it('returns the initial templates', () => {
+			const templates = [makeTemplate()]
+			const svc = new ConfigurationTemplateService(
+				createDriverPort(),
+				createNodeStorePort(),
+				createPersistencePort(templates),
+				createUtilsPort(),
+				createLogger(),
+				templates,
+			)
+			expect(svc.getConfigurationTemplates()).toEqual(templates)
+		})
+
+		it('returns empty array when none exist', () => {
+			const svc = new ConfigurationTemplateService(
+				createDriverPort(),
+				createNodeStorePort(),
+				createPersistencePort(),
+				createUtilsPort(),
+				createLogger(),
+				[],
+			)
+			expect(svc.getConfigurationTemplates()).toEqual([])
+		})
+	})
+
+	describe('createConfigurationTemplate', () => {
+		it('creates a template from node CC 112 values', async () => {
+			const node = makeNode()
+			const nodes = new Map([[2, node]])
+			const persistence = createPersistencePort()
+			const svc = new ConfigurationTemplateService(
+				createDriverPort(),
+				createNodeStorePort(nodes),
+				persistence,
+				createUtilsPort(),
+				createLogger(),
+				[],
+			)
+
+			const result = await svc.createConfigurationTemplate(
+				2,
+				'My Template',
+			)
+
+			expect(result.name).toBe('My Template')
+			expect(result.deviceId).toBe('0x0086-0x0002-0x0064')
+			expect(result.values.length).toBe(1)
+			expect(result.contentHash).toBeTruthy()
+			expect(persistence.put).toHaveBeenCalled()
+		})
+
+		it('creates a template with custom values', async () => {
+			const node = makeNode()
+			const nodes = new Map([[2, node]])
+			const svc = new ConfigurationTemplateService(
+				createDriverPort(),
+				createNodeStorePort(nodes),
+				createPersistencePort(),
+				createUtilsPort(),
+				createLogger(),
+				[],
+			)
+
+			const values: ZUIConfigurationTemplateValue[] = [
+				{ property: 5, endpoint: 0, value: 100 },
+			]
+			const result = await svc.createConfigurationTemplate(
+				2,
+				'Custom',
+				false,
+				values,
+			)
+
+			expect(result.values).toEqual(values)
+		})
+
+		it('creates with firmware range', async () => {
+			const node = makeNode()
+			const nodes = new Map([[2, node]])
+			const svc = new ConfigurationTemplateService(
+				createDriverPort(),
+				createNodeStorePort(nodes),
+				createPersistencePort(),
+				createUtilsPort(),
+				createLogger(),
+				[],
+			)
+
+			const result = await svc.createConfigurationTemplate(
+				2,
+				'FW Range',
+				false,
+				[{ property: 1, endpoint: 0, value: 10 }],
+				{ min: '1.0', max: '2.0' },
+			)
+
+			expect(result.firmwareRange).toEqual({ min: '1.0', max: '2.0' })
+		})
+
+		it('throws when node not found', async () => {
+			const svc = new ConfigurationTemplateService(
+				createDriverPort(),
+				createNodeStorePort(),
+				createPersistencePort(),
+				createUtilsPort(),
+				createLogger(),
+				[],
+			)
+
+			await expect(
+				svc.createConfigurationTemplate(99, 'X'),
+			).rejects.toThrow('Node 99 not found')
+		})
+
+		it('throws when node is not ready', async () => {
+			const node = makeNode({ ready: false })
+			const nodes = new Map([[2, node]])
+			const svc = new ConfigurationTemplateService(
+				createDriverPort(),
+				createNodeStorePort(nodes),
+				createPersistencePort(),
+				createUtilsPort(),
+				createLogger(),
+				[],
+			)
+
+			await expect(
+				svc.createConfigurationTemplate(2, 'X'),
+			).rejects.toThrow('Node 2 is not ready')
+		})
+
+		it('throws when no writeable Configuration CC values', async () => {
+			const node = makeNode({ values: {} })
+			const nodes = new Map([[2, node]])
+			const svc = new ConfigurationTemplateService(
+				createDriverPort(),
+				createNodeStorePort(nodes),
+				createPersistencePort(),
+				createUtilsPort(),
+				createLogger(),
+				[],
+			)
+
+			await expect(
+				svc.createConfigurationTemplate(2, 'X'),
+			).rejects.toThrow('no writeable Configuration CC values')
+		})
+
+		it('triggers auto-apply when autoApply is true', async () => {
+			const node = makeNode()
+			const nodes = new Map([[2, node]])
+			const nodeStore = createNodeStorePort(nodes)
+			const svc = new ConfigurationTemplateService(
+				createDriverPort(),
+				nodeStore,
+				createPersistencePort(),
+				createUtilsPort(),
+				createLogger(),
+				[],
+			)
+
+			const result = await svc.createConfigurationTemplate(
+				2,
+				'Auto',
+				true,
+			)
+
+			expect(result.autoApply).toBe(true)
+		})
+	})
+
+	describe('updateConfigurationTemplate', () => {
+		it('updates name and autoApply', async () => {
+			const template = makeTemplate()
+			const persistence = createPersistencePort()
+			const svc = new ConfigurationTemplateService(
+				createDriverPort(),
+				createNodeStorePort(),
+				persistence,
+				createUtilsPort(),
+				createLogger(),
+				[template],
+			)
+
+			const result = await svc.updateConfigurationTemplate('tmpl-1', {
+				name: 'Renamed',
+				autoApply: true,
+			})
+
+			expect(result.name).toBe('Renamed')
+			expect(result.autoApply).toBe(true)
+			expect(persistence.put).toHaveBeenCalled()
+		})
+
+		it('recalculates content hash when values change', async () => {
+			const template = makeTemplate()
+			const oldHash = template.contentHash
+			const svc = new ConfigurationTemplateService(
+				createDriverPort(),
+				createNodeStorePort(),
+				createPersistencePort(),
+				createUtilsPort(),
+				createLogger(),
+				[template],
+			)
+
+			const result = await svc.updateConfigurationTemplate('tmpl-1', {
+				values: [{ property: 99, endpoint: 0, value: 999 }],
+			})
+
+			expect(result.contentHash).not.toBe(oldHash)
+		})
+
+		it('recalculates content hash when firmware range changes', async () => {
+			const template = makeTemplate()
+			const oldHash = template.contentHash
+			const svc = new ConfigurationTemplateService(
+				createDriverPort(),
+				createNodeStorePort(),
+				createPersistencePort(),
+				createUtilsPort(),
+				createLogger(),
+				[template],
+			)
+
+			const result = await svc.updateConfigurationTemplate('tmpl-1', {
+				firmwareRange: { min: '2.0' },
+			})
+
+			expect(result.contentHash).not.toBe(oldHash)
+		})
+
+		it('throws when template not found', async () => {
+			const svc = new ConfigurationTemplateService(
+				createDriverPort(),
+				createNodeStorePort(),
+				createPersistencePort(),
+				createUtilsPort(),
+				createLogger(),
+				[],
+			)
+
+			await expect(
+				svc.updateConfigurationTemplate('nonexistent', { name: 'X' }),
+			).rejects.toThrow('Template nonexistent not found')
+		})
+	})
+
+	describe('deleteConfigurationTemplate', () => {
+		it('deletes a template and persists', async () => {
+			const template = makeTemplate()
+			const persistence = createPersistencePort()
+			const svc = new ConfigurationTemplateService(
+				createDriverPort(),
+				createNodeStorePort(),
+				persistence,
+				createUtilsPort(),
+				createLogger(),
+				[template],
+			)
+
+			const result = await svc.deleteConfigurationTemplate('tmpl-1')
+
+			expect(result).toBe(true)
+			expect(svc.getConfigurationTemplates()).toEqual([])
+			expect(persistence.put).toHaveBeenCalled()
+		})
+
+		it('throws when template not found', async () => {
+			const svc = new ConfigurationTemplateService(
+				createDriverPort(),
+				createNodeStorePort(),
+				createPersistencePort(),
+				createUtilsPort(),
+				createLogger(),
+				[],
+			)
+
+			await expect(
+				svc.deleteConfigurationTemplate('nonexistent'),
+			).rejects.toThrow('Template nonexistent not found')
+		})
+
+		it('cleans up applied hashes from nodes', async () => {
+			const template = makeTemplate({ contentHash: 'hash123' })
+			const node = makeNode({ appliedTemplateContentHashes: ['hash123'] })
+			const nodes = new Map([[2, node]])
+			const nodeStore = createNodeStorePort(nodes)
+			const svc = new ConfigurationTemplateService(
+				createDriverPort(),
+				nodeStore,
+				createPersistencePort(),
+				createUtilsPort(),
+				createLogger(),
+				[template],
+			)
+
+			await svc.deleteConfigurationTemplate('tmpl-1')
+
+			expect(node.appliedTemplateContentHashes).toEqual([])
+		})
+	})
+
+	describe('applyConfigurationTemplate', () => {
+		it('applies values via writeValue and records hash', async () => {
+			const template = makeTemplate({
+				values: [
+					{ property: 1, endpoint: 0, value: 42 },
+					{ property: 2, endpoint: 0, value: 100 },
+				],
+			})
+			const node = makeNode()
+			const nodes = new Map([[2, node]])
+			const nodeStore = createNodeStorePort(nodes)
+			const loggerFake = createLogger()
+			const svc = new ConfigurationTemplateService(
+				createDriverPort(),
+				nodeStore,
+				createPersistencePort(),
+				createUtilsPort(),
+				loggerFake,
+				[template],
+			)
+
+			const result = await svc.applyConfigurationTemplate('tmpl-1', 2)
+
+			expect(result.success).toBe(2)
+			expect(result.failed).toBe(0)
+			expect(nodeStore.writeValue).toHaveBeenCalledTimes(2)
+			expect(node.appliedTemplateContentHashes).toContain('abc123')
+			expect(loggerFake.info).toHaveBeenCalled()
+		})
+
+		it('skips undefined values', async () => {
+			const template = makeTemplate({
+				values: [{ property: 1, endpoint: 0, value: undefined }],
+			})
+			const node = makeNode()
+			const nodes = new Map([[2, node]])
+			const nodeStore = createNodeStorePort(nodes)
+			const svc = new ConfigurationTemplateService(
+				createDriverPort(),
+				nodeStore,
+				createPersistencePort(),
+				createUtilsPort(),
+				createLogger(),
+				[template],
+			)
+
+			const result = await svc.applyConfigurationTemplate('tmpl-1', 2)
+
+			expect(result.success).toBe(1)
+			expect(nodeStore.writeValue).not.toHaveBeenCalled()
+		})
+
+		it('throws when template not found', async () => {
+			const svc = new ConfigurationTemplateService(
+				createDriverPort(),
+				createNodeStorePort(),
+				createPersistencePort(),
+				createUtilsPort(),
+				createLogger(),
+				[],
+			)
+
+			await expect(
+				svc.applyConfigurationTemplate('nonexistent', 2),
+			).rejects.toThrow('Template nonexistent not found')
+		})
+
+		it('throws when node not found', async () => {
+			const template = makeTemplate()
+			const svc = new ConfigurationTemplateService(
+				createDriverPort(),
+				createNodeStorePort(),
+				createPersistencePort(),
+				createUtilsPort(),
+				createLogger(),
+				[template],
+			)
+
+			await expect(
+				svc.applyConfigurationTemplate('tmpl-1', 99),
+			).rejects.toThrow('Node 99 not found')
+		})
+
+		it('throws when node not ready', async () => {
+			const template = makeTemplate()
+			const node = makeNode({ ready: false })
+			const nodes = new Map([[2, node]])
+			const svc = new ConfigurationTemplateService(
+				createDriverPort(),
+				createNodeStorePort(nodes),
+				createPersistencePort(),
+				createUtilsPort(),
+				createLogger(),
+				[template],
+			)
+
+			await expect(
+				svc.applyConfigurationTemplate('tmpl-1', 2),
+			).rejects.toThrow('Node 2 is not ready')
+		})
+
+		it('throws on device mismatch without force', async () => {
+			const template = makeTemplate({
+				deviceId: '0x0001-0x0001-0x0001',
+			})
+			const node = makeNode({
+				deviceId: '0x0086-0x0002-0x0064',
+			})
+			const nodes = new Map([[2, node]])
+			const svc = new ConfigurationTemplateService(
+				createDriverPort(),
+				createNodeStorePort(nodes),
+				createPersistencePort(),
+				createUtilsPort(),
+				createLogger(),
+				[template],
+			)
+
+			await expect(
+				svc.applyConfigurationTemplate('tmpl-1', 2),
+			).rejects.toThrow('does not match node device type')
+		})
+
+		it('allows device mismatch with force', async () => {
+			const template = makeTemplate({
+				deviceId: '0x0001-0x0001-0x0001',
+				values: [{ property: 1, endpoint: 0, value: 5 }],
+			})
+			const node = makeNode({
+				deviceId: '0x0086-0x0002-0x0064',
+			})
+			const nodes = new Map([[2, node]])
+			const svc = new ConfigurationTemplateService(
+				createDriverPort(),
+				createNodeStorePort(nodes),
+				createPersistencePort(),
+				createUtilsPort(),
+				createLogger(),
+				[template],
+			)
+
+			const result = await svc.applyConfigurationTemplate(
+				'tmpl-1',
+				2,
+				true,
+			)
+			expect(result.success).toBe(1)
+		})
+
+		it('handles write failures and dead node early exit', async () => {
+			const template = makeTemplate({
+				values: [
+					{ property: 1, endpoint: 0, value: 1 },
+					{ property: 2, endpoint: 0, value: 2 },
+					{ property: 3, endpoint: 0, value: 3 },
+				],
+			})
+			const node = makeNode({ status: 'Dead' })
+			const nodes = new Map([[2, node]])
+			const nodeStore = createNodeStorePort(nodes)
+			;(
+				nodeStore.writeValue as ReturnType<typeof vi.fn>
+			).mockResolvedValue({
+				status: SetValueStatus.Fail,
+			})
+
+			const svc = new ConfigurationTemplateService(
+				createDriverPort(),
+				nodeStore,
+				createPersistencePort(),
+				createUtilsPort(),
+				createLogger(),
+				[template],
+			)
+
+			const result = await svc.applyConfigurationTemplate('tmpl-1', 2)
+
+			expect(result.failed).toBe(3)
+			expect(result.reason).toBe('Node is dead')
+		})
+
+		it('catches exceptions from writeValue', async () => {
+			const template = makeTemplate({
+				values: [{ property: 1, endpoint: 0, value: 5 }],
+			})
+			const node = makeNode()
+			const nodes = new Map([[2, node]])
+			const nodeStore = createNodeStorePort(nodes)
+			;(
+				nodeStore.writeValue as ReturnType<typeof vi.fn>
+			).mockRejectedValue(new Error('Timeout'))
+
+			const svc = new ConfigurationTemplateService(
+				createDriverPort(),
+				nodeStore,
+				createPersistencePort(),
+				createUtilsPort(),
+				createLogger(),
+				[template],
+			)
+
+			const result = await svc.applyConfigurationTemplate('tmpl-1', 2)
+
+			expect(result.failed).toBe(1)
+			expect(result.errors[0]).toContain('Timeout')
+		})
+	})
+
+	describe('importConfigurationTemplates', () => {
+		it('imports templates and assigns new IDs', async () => {
+			const persistence = createPersistencePort()
+			const svc = new ConfigurationTemplateService(
+				createDriverPort(),
+				createNodeStorePort(),
+				persistence,
+				createUtilsPort(),
+				createLogger(),
+				[],
+			)
+
+			const imported = [makeTemplate({ id: 'old-id', contentHash: '' })]
+			const result = await svc.importConfigurationTemplates(imported)
+
+			expect(result.length).toBe(1)
+			expect(result[0].id).not.toBe('old-id')
+			expect(result[0].contentHash).toBeTruthy()
+			expect(persistence.put).toHaveBeenCalled()
+		})
+
+		it('migrates legacy minFirmwareVersion to firmwareRange', async () => {
+			const svc = new ConfigurationTemplateService(
+				createDriverPort(),
+				createNodeStorePort(),
+				createPersistencePort(),
+				createUtilsPort(),
+				createLogger(),
+				[],
+			)
+
+			const legacyTemplate = {
+				...makeTemplate(),
+				minFirmwareVersion: '1.0',
+				firmwareRange: undefined,
+			} as any
+			const result = await svc.importConfigurationTemplates([
+				legacyTemplate,
+			])
+
+			expect(result[0].firmwareRange).toEqual({ min: '1.0' })
+			expect((result[0] as any).minFirmwareVersion).toBeUndefined()
+		})
+
+		it('preserves existing contentHash if present', async () => {
+			const svc = new ConfigurationTemplateService(
+				createDriverPort(),
+				createNodeStorePort(),
+				createPersistencePort(),
+				createUtilsPort(),
+				createLogger(),
+				[],
+			)
+
+			const template = makeTemplate({ contentHash: 'existing-hash' })
+			const result = await svc.importConfigurationTemplates([template])
+
+			expect(result[0].contentHash).toBe('existing-hash')
+		})
+	})
+
+	describe('checkConfigurationTemplates', () => {
+		it('auto-applies matching templates on node ready', async () => {
+			const template = makeTemplate({
+				autoApply: true,
+				values: [{ property: 1, endpoint: 0, value: 42 }],
+			})
+			const node = makeNode({
+				appliedTemplateContentHashes: [],
+			})
+			const nodes = new Map([[2, node]])
+			const nodeStore = createNodeStorePort(nodes)
+			const loggerFake = createLogger()
+			const svc = new ConfigurationTemplateService(
+				createDriverPort(),
+				nodeStore,
+				createPersistencePort(),
+				createUtilsPort(),
+				loggerFake,
+				[template],
+			)
+
+			const zwaveNode = { id: 2 } as any
+			svc.checkConfigurationTemplates(node, zwaveNode)
+
+			// Allow async auto-apply to complete
+			await new Promise((r) => setTimeout(r, 10))
+
+			expect(nodeStore.writeValue).toHaveBeenCalled()
+		})
+
+		it('skips templates already applied (by content hash)', () => {
+			const template = makeTemplate({
+				autoApply: true,
+				contentHash: 'already-applied',
+			})
+			const node = makeNode({
+				appliedTemplateContentHashes: ['already-applied'],
+			})
+			const nodes = new Map([[2, node]])
+			const nodeStore = createNodeStorePort(nodes)
+			const svc = new ConfigurationTemplateService(
+				createDriverPort(),
+				nodeStore,
+				createPersistencePort(),
+				createUtilsPort(),
+				createLogger(),
+				[template],
+			)
+
+			const zwaveNode = { id: 2 } as any
+			svc.checkConfigurationTemplates(node, zwaveNode)
+
+			expect(nodeStore.writeValue).not.toHaveBeenCalled()
+		})
+
+		it('skips non-matching device IDs', () => {
+			const template = makeTemplate({
+				autoApply: true,
+				deviceId: 'different-device',
+			})
+			const node = makeNode()
+			const nodes = new Map([[2, node]])
+			const nodeStore = createNodeStorePort(nodes)
+			const svc = new ConfigurationTemplateService(
+				createDriverPort(),
+				nodeStore,
+				createPersistencePort(),
+				createUtilsPort(),
+				createLogger(),
+				[template],
+			)
+
+			const zwaveNode = { id: 2 } as any
+			svc.checkConfigurationTemplates(node, zwaveNode)
+
+			expect(nodeStore.writeValue).not.toHaveBeenCalled()
+		})
+
+		it('respects firmware range filtering', () => {
+			const template = makeTemplate({
+				autoApply: true,
+				firmwareRange: { min: '2.0' },
+			})
+			const node = makeNode({ firmwareVersion: '1.5.0' })
+			const nodes = new Map([[2, node]])
+			const nodeStore = createNodeStorePort(nodes)
+			const svc = new ConfigurationTemplateService(
+				createDriverPort(),
+				nodeStore,
+				createPersistencePort(),
+				createUtilsPort(),
+				createLogger(),
+				[template],
+			)
+
+			const zwaveNode = { id: 2 } as any
+			svc.checkConfigurationTemplates(node, zwaveNode)
+
+			expect(nodeStore.writeValue).not.toHaveBeenCalled()
+		})
+	})
+
+	describe('_generateContentHash (static)', () => {
+		it('produces deterministic 12-char hex hash', () => {
+			const values: ZUIConfigurationTemplateValue[] = [
+				{ property: 1, endpoint: 0, value: 42 },
+			]
+			const hash1 =
+				ConfigurationTemplateService._generateContentHash(values)
+			const hash2 =
+				ConfigurationTemplateService._generateContentHash(values)
+
+			expect(hash1).toBe(hash2)
+			expect(hash1.length).toBe(12)
+			expect(/^[0-9a-f]{12}$/.test(hash1)).toBe(true)
+		})
+
+		it('includes firmware range in hash', () => {
+			const values: ZUIConfigurationTemplateValue[] = [
+				{ property: 1, endpoint: 0, value: 42 },
+			]
+			const hash1 =
+				ConfigurationTemplateService._generateContentHash(values)
+			const hash2 = ConfigurationTemplateService._generateContentHash(
+				values,
+				{ min: '1.0' },
+			)
+
+			expect(hash1).not.toBe(hash2)
+		})
+
+		it('normalizes propertyKey null vs undefined', () => {
+			const v1: ZUIConfigurationTemplateValue[] = [
+				{ property: 1, propertyKey: null, endpoint: 0, value: 42 },
+			]
+			const v2: ZUIConfigurationTemplateValue[] = [
+				{ property: 1, propertyKey: undefined, endpoint: 0, value: 42 },
+			]
+			expect(ConfigurationTemplateService._generateContentHash(v1)).toBe(
+				ConfigurationTemplateService._generateContentHash(v2),
+			)
+		})
+	})
+
+	describe('templates accessor', () => {
+		it('returns the live template array', () => {
+			const templates = [makeTemplate()]
+			const svc = new ConfigurationTemplateService(
+				createDriverPort(),
+				createNodeStorePort(),
+				createPersistencePort(),
+				createUtilsPort(),
+				createLogger(),
+				templates,
+			)
+			expect(svc.templates).toBe(templates)
+		})
+	})
+
+	describe('getDeviceConfigurationParams', () => {
+		it('throws for invalid deviceId format', async () => {
+			const svc = new ConfigurationTemplateService(
+				createDriverPort(),
+				createNodeStorePort(),
+				createPersistencePort(),
+				createUtilsPort(),
+				createLogger(),
+				[],
+			)
+			await expect(
+				svc.getDeviceConfigurationParams('invalid'),
+			).rejects.toThrow('Invalid deviceId format')
+		})
+
+		it('throws for non-numeric components', async () => {
+			const svc = new ConfigurationTemplateService(
+				createDriverPort(),
+				createNodeStorePort(),
+				createPersistencePort(),
+				createUtilsPort(),
+				createLogger(),
+				[],
+			)
+			await expect(
+				svc.getDeviceConfigurationParams('abc-def-ghi'),
+			).rejects.toThrow('non-numeric')
+		})
+	})
+
+	describe('createConfigurationTemplate – propertyKey branches', () => {
+		it('captures propertyKey when present on CC112 value', async () => {
+			const node = makeNode({
+				values: {
+					'0-112-0-5-1': {
+						commandClass: 112,
+						writeable: true,
+						property: 5,
+						propertyKey: 1,
+						endpoint: 0,
+						value: 10,
+						label: 'Param 5 bit 1',
+						description: 'A bitmask param',
+					},
+				},
+			})
+			const nodes = new Map<number, TemplateNodeState>([[2, node]])
+			const svc = new ConfigurationTemplateService(
+				createDriverPort(),
+				createNodeStorePort(nodes),
+				createPersistencePort(),
+				createUtilsPort(),
+				createLogger(),
+				[],
+			)
+
+			const result = await svc.createConfigurationTemplate(2, 'Test')
+			expect(result.values.length).toBe(1)
+			expect(result.values[0].propertyKey).toBe(1)
+		})
+
+		it('skips non-writable CC112 values', async () => {
+			const node = makeNode({
+				values: {
+					'0-112-0-1': {
+						commandClass: 112,
+						writeable: false,
+						property: 1,
+						endpoint: 0,
+						value: 42,
+						label: 'Readonly Param',
+						description: 'Should be skipped',
+					},
+					'0-112-0-2': {
+						commandClass: 112,
+						writeable: true,
+						property: 2,
+						endpoint: 0,
+						value: 99,
+						label: 'Writable Param',
+						description: 'Should be included',
+					},
+				},
+			})
+			const nodes = new Map<number, TemplateNodeState>([[2, node]])
+			const svc = new ConfigurationTemplateService(
+				createDriverPort(),
+				createNodeStorePort(nodes),
+				createPersistencePort(),
+				createUtilsPort(),
+				createLogger(),
+				[],
+			)
+
+			const result = await svc.createConfigurationTemplate(2, 'Test')
+			expect(result.values.length).toBe(1)
+			expect(result.values[0].property).toBe(2)
+		})
+	})
+
+	describe('updateConfigurationTemplate – auto-apply on content change', () => {
+		it('triggers auto-apply when values change and autoApply is true', async () => {
+			const existingTemplate = makeTemplate({
+				autoApply: true,
+				values: [
+					{
+						property: 1,
+						propertyKey: null,
+						endpoint: 0,
+						value: 42,
+						label: 'P1',
+						description: '',
+					},
+				],
+			})
+			const originalHash = existingTemplate.contentHash
+
+			const node = makeNode()
+			const nodes = new Map<number, TemplateNodeState>([[2, node]])
+
+			// Use a driver port that returns a real controller.nodes
+			const driverPort = {
+				getDriver: () =>
+					({
+						controller: {
+							nodes: new Map<number, unknown>(),
+						},
+					}) as any,
+			}
+
+			const svc = new ConfigurationTemplateService(
+				driverPort,
+				createNodeStorePort(nodes),
+				createPersistencePort([existingTemplate]),
+				createUtilsPort(),
+				createLogger(),
+				[existingTemplate],
+			)
+
+			const updated = await svc.updateConfigurationTemplate(
+				existingTemplate.id,
+				{
+					values: [
+						{
+							property: 1,
+							propertyKey: null,
+							endpoint: 0,
+							value: 99,
+							label: 'P1',
+							description: '',
+						},
+					],
+				},
+			)
+			// Hash should change
+			expect(updated.contentHash).not.toBe(originalHash)
+		})
+	})
+
+	describe('applyConfigurationTemplate – error branch', () => {
+		it('catches writeValue exceptions and counts as failed', async () => {
+			const template = makeTemplate({
+				values: [
+					{
+						property: 1,
+						propertyKey: null,
+						endpoint: 0,
+						value: 42,
+						label: 'P1',
+						description: '',
+					},
+				],
+			})
+			const node = makeNode()
+			const nodes = new Map<number, TemplateNodeState>([[2, node]])
+			const nodeStore = createNodeStorePort(nodes)
+			nodeStore.writeValue = vi.fn(() =>
+				Promise.reject(new Error('Write failed')),
+			)
+
+			const svc = new ConfigurationTemplateService(
+				createDriverPort(),
+				nodeStore,
+				createPersistencePort([template]),
+				createUtilsPort(),
+				createLogger(),
+				[template],
+			)
+
+			const result = await svc.applyConfigurationTemplate(template.id, 2)
+			expect(result.failed).toBe(1)
+			expect(result.errors.length).toBe(1)
+			expect(result.errors[0]).toContain('Write failed')
+		})
+
+		it('records remaining values as failed when node is dead', async () => {
+			const template = makeTemplate({
+				values: [
+					{
+						property: 1,
+						propertyKey: null,
+						endpoint: 0,
+						value: 1,
+						label: 'P1',
+						description: '',
+					},
+					{
+						property: 2,
+						propertyKey: null,
+						endpoint: 0,
+						value: 2,
+						label: 'P2',
+						description: '',
+					},
+					{
+						property: 3,
+						propertyKey: null,
+						endpoint: 0,
+						value: 3,
+						label: 'P3',
+						description: '',
+					},
+				],
+			})
+			const node = makeNode({ status: 'Dead' as any })
+			const nodes = new Map<number, TemplateNodeState>([[2, node]])
+			const nodeStore = createNodeStorePort(nodes)
+			nodeStore.writeValue = vi.fn(() =>
+				Promise.resolve({
+					status: SetValueStatus.Fail,
+				}),
+			)
+
+			const svc = new ConfigurationTemplateService(
+				createDriverPort(),
+				nodeStore,
+				createPersistencePort([template]),
+				createUtilsPort(),
+				createLogger(),
+				[template],
+			)
+
+			const result = await svc.applyConfigurationTemplate(template.id, 2)
+			// First value fails, then remaining 2 are counted as failed
+			expect(result.failed).toBe(3)
+			expect(result.reason).toBe('Node is dead')
+		})
+
+		it('counts setValueFailed with message', async () => {
+			const template = makeTemplate({
+				values: [
+					{
+						property: 1,
+						propertyKey: null,
+						endpoint: 0,
+						value: 42,
+						label: 'P1',
+						description: '',
+					},
+				],
+			})
+			const node = makeNode()
+			const nodes = new Map<number, TemplateNodeState>([[2, node]])
+			const nodeStore = createNodeStorePort(nodes)
+			nodeStore.writeValue = vi.fn(() =>
+				Promise.resolve({
+					status: SetValueStatus.Fail,
+					message: 'Custom error message',
+				}),
+			)
+
+			const svc = new ConfigurationTemplateService(
+				createDriverPort(),
+				nodeStore,
+				createPersistencePort([template]),
+				createUtilsPort(),
+				createLogger(),
+				[template],
+			)
+
+			const result = await svc.applyConfigurationTemplate(template.id, 2)
+			expect(result.failed).toBe(1)
+			expect(result.errors[0]).toContain('Custom error message')
+		})
+	})
+
+	describe('checkConfigurationTemplates – partial failure', () => {
+		it('logs warning when auto-apply has partial failures', async () => {
+			const template = makeTemplate({
+				autoApply: true,
+				contentHash: 'unique-hash',
+			})
+			const node = makeNode({ appliedTemplateContentHashes: [] })
+			const nodes = new Map<number, TemplateNodeState>([[2, node]])
+			const nodeStore = createNodeStorePort(nodes)
+			// First call succeeds, second fails
+			let callCount = 0
+			nodeStore.writeValue = vi.fn(() => {
+				callCount++
+				if (callCount > 1) {
+					return Promise.resolve({
+						status: SetValueStatus.Fail,
+						message: 'Failed',
+					})
+				}
+				return Promise.resolve({ status: SetValueStatus.Success })
+			})
+
+			// add a second value
+			template.values.push({
+				property: 2,
+				propertyKey: null,
+				endpoint: 0,
+				value: 99,
+				label: 'P2',
+				description: '',
+			})
+
+			const fakeZwaveNode = { id: 2 } as any
+			const driverPort = {
+				getDriver: () =>
+					({
+						controller: {
+							nodes: {
+								get: (id: number) =>
+									id === 2 ? fakeZwaveNode : undefined,
+							},
+						},
+					}) as any,
+			}
+			const logger = createLogger()
+
+			const svc = new ConfigurationTemplateService(
+				driverPort,
+				nodeStore,
+				createPersistencePort([template]),
+				createUtilsPort(),
+				logger,
+				[template],
+			)
+
+			svc.checkConfigurationTemplates(node, fakeZwaveNode)
+			// Give async auto-apply time to complete
+			await new Promise((r) => setTimeout(r, 50))
+			// Should have logged
+			expect(nodeStore.logNode).toHaveBeenCalled()
+		})
+	})
+
+	describe('_getMatchingTemplates – firmware range filtering', () => {
+		it('excludes templates with min firmware above node firmware', () => {
+			const template = makeTemplate({
+				firmwareRange: { min: '2.0.0', max: undefined },
+			})
+			const node = makeNode({ firmwareVersion: '1.0.0' })
+			const nodes = new Map<number, TemplateNodeState>([[2, node]])
+
+			const svc = new ConfigurationTemplateService(
+				createDriverPort(),
+				createNodeStorePort(nodes),
+				createPersistencePort([template]),
+				createUtilsPort(),
+				createLogger(),
+				[template],
+			)
+
+			const fakeZwaveNode = { id: 2 } as any
+			svc.checkConfigurationTemplates(node, fakeZwaveNode)
+			// The template should not match, so no auto-apply happens
+		})
+
+		it('excludes templates with max firmware below node firmware', () => {
+			const template = makeTemplate({
+				autoApply: true,
+				firmwareRange: { min: undefined, max: '1.0.0' },
+			})
+			const node = makeNode({
+				firmwareVersion: '2.0.0',
+				appliedTemplateContentHashes: [],
+			})
+			const nodes = new Map<number, TemplateNodeState>([[2, node]])
+
+			const fakeZwaveNode = { id: 2 } as any
+
+			const svc = new ConfigurationTemplateService(
+				createDriverPort(),
+				createNodeStorePort(nodes),
+				createPersistencePort([template]),
+				createUtilsPort(),
+				createLogger(),
+				[template],
+			)
+
+			svc.checkConfigurationTemplates(node, fakeZwaveNode)
+			// Template should not be applied (firmware too high)
+		})
+
+		it('includes template when node firmware is within range', async () => {
+			const template = makeTemplate({
+				autoApply: true,
+				contentHash: 'in-range-hash',
+				firmwareRange: { min: '1.0.0', max: '3.0.0' },
+			})
+			const node = makeNode({
+				firmwareVersion: '1.5.0',
+				appliedTemplateContentHashes: [],
+			})
+			const nodes = new Map<number, TemplateNodeState>([[2, node]])
+
+			const fakeZwaveNode = { id: 2 } as any
+			const nodeStore = createNodeStorePort(nodes)
+
+			const svc = new ConfigurationTemplateService(
+				createDriverPort(),
+				nodeStore,
+				createPersistencePort([template]),
+				createUtilsPort(),
+				createLogger(),
+				[template],
+			)
+
+			svc.checkConfigurationTemplates(node, fakeZwaveNode)
+			// Give async auto-apply time to complete
+			await new Promise((r) => setTimeout(r, 50))
+			// Template should be applied (firmware in range)
+			expect(nodeStore.logNode).toHaveBeenCalled()
+		})
+
+		it('skips template when node has no firmwareVersion', () => {
+			const template = makeTemplate({
+				autoApply: true,
+				firmwareRange: { min: '1.0.0', max: undefined },
+			})
+			const node = makeNode({
+				firmwareVersion: undefined as any,
+				appliedTemplateContentHashes: [],
+			})
+			const nodes = new Map<number, TemplateNodeState>([[2, node]])
+
+			const svc = new ConfigurationTemplateService(
+				createDriverPort(),
+				createNodeStorePort(nodes),
+				createPersistencePort([template]),
+				createUtilsPort(),
+				createLogger(),
+				[template],
+			)
+
+			const fakeZwaveNode = { id: 2 } as any
+			svc.checkConfigurationTemplates(node, fakeZwaveNode)
+			// No auto-apply should happen
+		})
+	})
+
+	describe('_autoApplyToNodes – error handling', () => {
+		it('logs error when auto-apply promise rejects', async () => {
+			const template = makeTemplate({
+				autoApply: true,
+				contentHash: 'err-hash',
+			})
+			const node = makeNode({ appliedTemplateContentHashes: [] })
+			const nodes = new Map<number, TemplateNodeState>([[2, node]])
+			const nodeStore = createNodeStorePort(nodes)
+			nodeStore.writeValue = vi.fn(() =>
+				Promise.reject(new Error('Network error')),
+			)
+
+			const fakeZwaveNode = { id: 2 } as any
+			const driverPort = {
+				getDriver: () =>
+					({
+						controller: {
+							nodes: new Map([[2, fakeZwaveNode]]),
+						},
+					}) as any,
+			}
+
+			const svc = new ConfigurationTemplateService(
+				driverPort,
+				nodeStore,
+				createPersistencePort([template]),
+				createUtilsPort(),
+				createLogger(),
+				[template],
+			)
+
+			// Trigger auto-apply via update with content change
+			await svc.updateConfigurationTemplate(template.id, {
+				values: [
+					{
+						property: 1,
+						propertyKey: null,
+						endpoint: 0,
+						value: 999,
+						label: 'P1',
+						description: '',
+					},
+				],
+			})
+
+			// Wait for async apply promises to settle
+			await new Promise((r) => setTimeout(r, 100))
+			// The error should be caught and logged, not thrown
+			expect(nodeStore.logNode).toHaveBeenCalled()
+		})
+	})
+
+	describe('applyConfigurationTemplate – no storeNode yet', () => {
+		it('creates storeNode entry when none exists', async () => {
+			const template = makeTemplate()
+			const node = makeNode()
+			const nodes = new Map<number, TemplateNodeState>([[2, node]])
+			const storeNodes: Record<number, Partial<TemplateNodeState>> = {}
+			const nodeStore = createNodeStorePort(nodes, storeNodes)
+
+			const svc = new ConfigurationTemplateService(
+				createDriverPort(),
+				nodeStore,
+				createPersistencePort([template]),
+				createUtilsPort(),
+				createLogger(),
+				[template],
+			)
+
+			await svc.applyConfigurationTemplate(template.id, 2)
+			// setStoreNode should have been called to create the entry
+			expect(nodeStore.setStoreNode).toHaveBeenCalled()
+		})
+	})
+
+	describe('checkConfigurationTemplates – no driver', () => {
+		it('returns early when matching templates is empty', () => {
+			const node = makeNode({ deviceId: 'other-device' })
+			const svc = new ConfigurationTemplateService(
+				{ getDriver: () => null },
+				createNodeStorePort(),
+				createPersistencePort(),
+				createUtilsPort(),
+				createLogger(),
+				[],
+			)
+			// Should not throw even with no driver - no matching templates
+			const fakeZwaveNode = { id: 2 } as any
+			svc.checkConfigurationTemplates(node, fakeZwaveNode)
+		})
+	})
+
+	describe('deleteConfigurationTemplate – cleanup hashes', () => {
+		it('removes the deleted hash from all nodes', async () => {
+			const template = makeTemplate({ contentHash: 'del-hash' })
+			const otherTemplate = makeTemplate({
+				id: 'other-tmpl',
+				contentHash: 'other-hash',
+			})
+			const node = makeNode({
+				appliedTemplateContentHashes: ['del-hash', 'other-hash'],
+			})
+			const nodes = new Map<number, TemplateNodeState>([[2, node]])
+			const storeNodes: Record<number, Partial<TemplateNodeState>> = {
+				2: { appliedTemplateContentHashes: ['del-hash', 'other-hash'] },
+			}
+			const nodeStore = createNodeStorePort(nodes, storeNodes)
+
+			const svc = new ConfigurationTemplateService(
+				createDriverPort(),
+				nodeStore,
+				createPersistencePort([template, otherTemplate]),
+				createUtilsPort(),
+				createLogger(),
+				[template, otherTemplate],
+			)
+
+			await svc.deleteConfigurationTemplate(template.id)
+			// The deleted hash should be removed, but other-hash remains (its template still exists)
+			expect(node.appliedTemplateContentHashes).not.toContain('del-hash')
+			expect(node.appliedTemplateContentHashes).toContain('other-hash')
+		})
+	})
+
+	describe('importConfigurationTemplates – duplicate IDs', () => {
+		it('generates new IDs for imported templates with existing IDs', async () => {
+			const existing = makeTemplate({ id: 'existing-id' })
+			const imported: ZUIConfigurationTemplate = {
+				...makeTemplate({ id: 'existing-id' }),
+				name: 'Imported',
+			}
+
+			const svc = new ConfigurationTemplateService(
+				createDriverPort(),
+				createNodeStorePort(),
+				createPersistencePort([existing]),
+				createUtilsPort(),
+				createLogger(),
+				[existing],
+			)
+
+			await svc.importConfigurationTemplates([imported])
+			const templates = svc.getConfigurationTemplates()
+			expect(templates.length).toBe(2)
+			// The imported one should have a new ID
+			const importedTemplate = templates.find(
+				(t) => t.name === 'Imported',
+			)
+			expect(importedTemplate).toBeDefined()
+			expect(importedTemplate.id).not.toBe('existing-id')
+		})
+	})
+
+	describe('createConfigurationTemplate – edge cases', () => {
+		it('throws when node has no values (values=undefined)', async () => {
+			const node = makeNode({ values: undefined as any })
+			const nodes = new Map<number, TemplateNodeState>([[2, node]])
+			const svc = new ConfigurationTemplateService(
+				createDriverPort(),
+				createNodeStorePort(nodes),
+				createPersistencePort(),
+				createUtilsPort(),
+				createLogger(),
+				[],
+			)
+
+			await expect(
+				svc.createConfigurationTemplate(2, 'Test'),
+			).rejects.toThrow('no writeable Configuration CC values')
+		})
+
+		it('defaults endpoint to 0 when value.endpoint is undefined', async () => {
+			const node = makeNode({
+				values: {
+					'0-112-0-1': {
+						commandClass: 112,
+						writeable: true,
+						property: 1,
+						endpoint: undefined as any,
+						value: 42,
+						label: 'P1',
+						description: 'A param',
+					},
+				},
+			})
+			const nodes = new Map<number, TemplateNodeState>([[2, node]])
+			const svc = new ConfigurationTemplateService(
+				createDriverPort(),
+				createNodeStorePort(nodes),
+				createPersistencePort(),
+				createUtilsPort(),
+				createLogger(),
+				[],
+			)
+
+			const result = await svc.createConfigurationTemplate(2, 'Test')
+			expect(result.values[0].endpoint).toBe(0)
+		})
+
+		it('defaults deviceId when node.deviceId is falsy', async () => {
+			const node = makeNode({
+				deviceId: undefined as any,
+				values: {
+					'0-112-0-1': {
+						commandClass: 112,
+						writeable: true,
+						property: 1,
+						endpoint: 0,
+						value: 42,
+						label: 'P1',
+						description: 'A param',
+					},
+				},
+			})
+			const nodes = new Map<number, TemplateNodeState>([[2, node]])
+			const svc = new ConfigurationTemplateService(
+				createDriverPort(),
+				createNodeStorePort(nodes),
+				createPersistencePort(),
+				createUtilsPort(),
+				createLogger(),
+				[],
+			)
+
+			const result = await svc.createConfigurationTemplate(2, 'Test')
+			expect(result.deviceId).toBe('')
+		})
+	})
+
+	describe('deleteConfigurationTemplate – no hash', () => {
+		it('skips cleanup when template has no contentHash', async () => {
+			const template = makeTemplate({ contentHash: '' })
+			const node = makeNode({ appliedTemplateContentHashes: [] })
+			const nodes = new Map<number, TemplateNodeState>([[2, node]])
+			const nodeStore = createNodeStorePort(nodes)
+
+			const svc = new ConfigurationTemplateService(
+				createDriverPort(),
+				nodeStore,
+				createPersistencePort([template]),
+				createUtilsPort(),
+				createLogger(),
+				[template],
+			)
+
+			const result = await svc.deleteConfigurationTemplate(template.id)
+			expect(result).toBe(true)
+		})
+	})
+
+	describe('applyConfigurationTemplate – no appliedTemplateContentHashes', () => {
+		it('initializes appliedTemplateContentHashes when undefined', async () => {
+			const template = makeTemplate()
+			const node = makeNode({
+				appliedTemplateContentHashes: undefined as any,
+			})
+			const nodes = new Map<number, TemplateNodeState>([[2, node]])
+			const nodeStore = createNodeStorePort(nodes)
+
+			const svc = new ConfigurationTemplateService(
+				createDriverPort(),
+				nodeStore,
+				createPersistencePort([template]),
+				createUtilsPort(),
+				createLogger(),
+				[template],
+			)
+
+			await svc.applyConfigurationTemplate(template.id, 2)
+			// appliedTemplateContentHashes should now be initialized
+			expect(node.appliedTemplateContentHashes).toBeDefined()
+			expect(node.appliedTemplateContentHashes.length).toBe(1)
+		})
+	})
+
+	describe('_autoApplyToNodes – skips nodes', () => {
+		it('skips non-ready nodes', async () => {
+			const template = makeTemplate({
+				autoApply: true,
+				contentHash: 'skip-hash',
+			})
+			const node = makeNode({
+				ready: false,
+				appliedTemplateContentHashes: [],
+			})
+			const nodes = new Map<number, TemplateNodeState>([[2, node]])
+			const nodeStore = createNodeStorePort(nodes)
+
+			const driverPort = {
+				getDriver: () =>
+					({
+						controller: {
+							nodes: new Map([[2, { id: 2 }]]),
+						},
+					}) as any,
+			}
+
+			const svc = new ConfigurationTemplateService(
+				driverPort,
+				nodeStore,
+				createPersistencePort([template]),
+				createUtilsPort(),
+				createLogger(),
+				[template],
+			)
+
+			// Trigger auto-apply via update
+			await svc.updateConfigurationTemplate(template.id, {
+				values: [
+					{
+						property: 1,
+						propertyKey: null,
+						endpoint: 0,
+						value: 999,
+						label: 'P1',
+						description: '',
+					},
+				],
+			})
+
+			// Wait for async operations
+			await new Promise((r) => setTimeout(r, 50))
+			// writeValue should not be called since node is not ready
+			expect(nodeStore.writeValue).not.toHaveBeenCalled()
+		})
+
+		it('skips already-applied hashes', () => {
+			const template = makeTemplate({
+				autoApply: true,
+				contentHash: 'already-applied',
+			})
+			const node = makeNode({
+				appliedTemplateContentHashes: ['already-applied'],
+			})
+			const nodes = new Map<number, TemplateNodeState>([[2, node]])
+			const nodeStore = createNodeStorePort(nodes)
+
+			const driverPort = {
+				getDriver: () =>
+					({
+						controller: {
+							nodes: new Map([[2, { id: 2 }]]),
+						},
+					}) as any,
+			}
+
+			const svc = new ConfigurationTemplateService(
+				driverPort,
+				nodeStore,
+				createPersistencePort([template]),
+				createUtilsPort(),
+				createLogger(),
+				[template],
+			)
+
+			// Trigger auto-apply via update with name change (no content change - but autoApply set)
+			// Actually we need content change for autoApply to trigger
+			// Let's use checkConfigurationTemplates instead
+			const fakeZwaveNode = { id: 2 } as any
+			svc.checkConfigurationTemplates(node, fakeZwaveNode)
+
+			// writeValue should not be called since hash is already applied
+			expect(nodeStore.writeValue).not.toHaveBeenCalled()
+		})
+	})
+
+	describe('checkConfigurationTemplates – catch handler', () => {
+		it('logs error when applyConfigurationTemplate rejects', async () => {
+			const template = makeTemplate({
+				autoApply: true,
+				contentHash: 'check-catch-hash',
+			})
+			const node = makeNode({ appliedTemplateContentHashes: [] })
+			const nodes = new Map<number, TemplateNodeState>([[2, node]])
+			// Make getNode return undefined to trigger "not found" error
+			// inside applyConfigurationTemplate
+			const nodeStore = createNodeStorePort(nodes)
+			// Override getNode to fail for node 2 (but getNodes still works)
+			nodeStore.getNode = vi.fn(() => undefined)
+
+			const fakeZwaveNode = { id: 2 } as any
+			const driverPort = {
+				getDriver: () =>
+					({
+						controller: {
+							nodes: {
+								get: (id: number) =>
+									id === 2 ? fakeZwaveNode : undefined,
+							},
+						},
+					}) as any,
+			}
+			const logger = createLogger()
+
+			const svc = new ConfigurationTemplateService(
+				driverPort,
+				nodeStore,
+				createPersistencePort([template]),
+				createUtilsPort(),
+				logger,
+				[template],
+			)
+
+			svc.checkConfigurationTemplates(node, fakeZwaveNode)
+			// Wait for async catch handler
+			await new Promise((r) => setTimeout(r, 100))
+			// The error should be caught and logged
+			expect(nodeStore.logNode).toHaveBeenCalledWith(
+				fakeZwaveNode,
+				'error',
+				expect.stringContaining('Failed to auto-apply'),
+			)
+		})
+	})
+})

--- a/test/lib/zwave/ConfigurationTemplateService.test.ts
+++ b/test/lib/zwave/ConfigurationTemplateService.test.ts
@@ -5,6 +5,7 @@ import type {
 	ZUIConfigurationTemplateValue,
 	TemplateNodeState,
 	TemplateDriverPort,
+	TemplateConfigManagerPort,
 } from '../../../api/lib/zwave/ports.ts'
 import type { ZWaveNode } from 'zwave-js'
 import { CommandClasses } from '@zwave-js/core'
@@ -117,6 +118,16 @@ function makeTemplate(
 	}
 }
 
+function createConfigManagerPort(
+	overrides: Partial<TemplateConfigManagerPort> = {},
+): TemplateConfigManagerPort {
+	return {
+		loadDeviceIndex: vi.fn(() => Promise.resolve()),
+		lookupDevice: vi.fn(() => Promise.resolve(undefined)),
+		...overrides,
+	}
+}
+
 describe('ConfigurationTemplateService', () => {
 	beforeEach(() => {
 		vi.restoreAllMocks()
@@ -133,6 +144,7 @@ describe('ConfigurationTemplateService', () => {
 				createUtilsPort(),
 				createLogger(),
 				templates,
+				createConfigManagerPort(),
 			)
 			expect(svc.getConfigurationTemplates()).toEqual(templates)
 		})
@@ -145,6 +157,7 @@ describe('ConfigurationTemplateService', () => {
 				createUtilsPort(),
 				createLogger(),
 				[],
+				createConfigManagerPort(),
 			)
 			expect(svc.getConfigurationTemplates()).toEqual([])
 		})
@@ -162,6 +175,7 @@ describe('ConfigurationTemplateService', () => {
 				createUtilsPort(),
 				createLogger(),
 				[],
+				createConfigManagerPort(),
 			)
 
 			const result = await svc.createConfigurationTemplate(
@@ -186,6 +200,7 @@ describe('ConfigurationTemplateService', () => {
 				createUtilsPort(),
 				createLogger(),
 				[],
+				createConfigManagerPort(),
 			)
 
 			const values: ZUIConfigurationTemplateValue[] = [
@@ -211,6 +226,7 @@ describe('ConfigurationTemplateService', () => {
 				createUtilsPort(),
 				createLogger(),
 				[],
+				createConfigManagerPort(),
 			)
 
 			const result = await svc.createConfigurationTemplate(
@@ -232,6 +248,7 @@ describe('ConfigurationTemplateService', () => {
 				createUtilsPort(),
 				createLogger(),
 				[],
+				createConfigManagerPort(),
 			)
 
 			await expect(
@@ -249,6 +266,7 @@ describe('ConfigurationTemplateService', () => {
 				createUtilsPort(),
 				createLogger(),
 				[],
+				createConfigManagerPort(),
 			)
 
 			await expect(
@@ -266,6 +284,7 @@ describe('ConfigurationTemplateService', () => {
 				createUtilsPort(),
 				createLogger(),
 				[],
+				createConfigManagerPort(),
 			)
 
 			await expect(
@@ -284,6 +303,7 @@ describe('ConfigurationTemplateService', () => {
 				createUtilsPort(),
 				createLogger(),
 				[],
+				createConfigManagerPort(),
 			)
 
 			const result = await svc.createConfigurationTemplate(
@@ -307,6 +327,7 @@ describe('ConfigurationTemplateService', () => {
 				createUtilsPort(),
 				createLogger(),
 				[template],
+				createConfigManagerPort(),
 			)
 
 			const result = await svc.updateConfigurationTemplate('tmpl-1', {
@@ -329,6 +350,7 @@ describe('ConfigurationTemplateService', () => {
 				createUtilsPort(),
 				createLogger(),
 				[template],
+				createConfigManagerPort(),
 			)
 
 			const result = await svc.updateConfigurationTemplate('tmpl-1', {
@@ -348,6 +370,7 @@ describe('ConfigurationTemplateService', () => {
 				createUtilsPort(),
 				createLogger(),
 				[template],
+				createConfigManagerPort(),
 			)
 
 			const result = await svc.updateConfigurationTemplate('tmpl-1', {
@@ -365,6 +388,7 @@ describe('ConfigurationTemplateService', () => {
 				createUtilsPort(),
 				createLogger(),
 				[],
+				createConfigManagerPort(),
 			)
 
 			await expect(
@@ -384,6 +408,7 @@ describe('ConfigurationTemplateService', () => {
 				createUtilsPort(),
 				createLogger(),
 				[template],
+				createConfigManagerPort(),
 			)
 
 			const result = await svc.deleteConfigurationTemplate('tmpl-1')
@@ -401,6 +426,7 @@ describe('ConfigurationTemplateService', () => {
 				createUtilsPort(),
 				createLogger(),
 				[],
+				createConfigManagerPort(),
 			)
 
 			await expect(
@@ -420,6 +446,7 @@ describe('ConfigurationTemplateService', () => {
 				createUtilsPort(),
 				createLogger(),
 				[template],
+				createConfigManagerPort(),
 			)
 
 			await svc.deleteConfigurationTemplate('tmpl-1')
@@ -457,6 +484,7 @@ describe('ConfigurationTemplateService', () => {
 				createUtilsPort(),
 				loggerFake,
 				[template],
+				createConfigManagerPort(),
 			)
 
 			const result = await svc.applyConfigurationTemplate('tmpl-1', 2)
@@ -506,6 +534,7 @@ describe('ConfigurationTemplateService', () => {
 				createUtilsPort(),
 				createLogger(),
 				[template],
+				createConfigManagerPort(),
 			)
 
 			const result = await svc.applyConfigurationTemplate('tmpl-1', 2)
@@ -522,6 +551,7 @@ describe('ConfigurationTemplateService', () => {
 				createUtilsPort(),
 				createLogger(),
 				[],
+				createConfigManagerPort(),
 			)
 
 			await expect(
@@ -538,6 +568,7 @@ describe('ConfigurationTemplateService', () => {
 				createUtilsPort(),
 				createLogger(),
 				[template],
+				createConfigManagerPort(),
 			)
 
 			await expect(
@@ -556,6 +587,7 @@ describe('ConfigurationTemplateService', () => {
 				createUtilsPort(),
 				createLogger(),
 				[template],
+				createConfigManagerPort(),
 			)
 
 			await expect(
@@ -578,6 +610,7 @@ describe('ConfigurationTemplateService', () => {
 				createUtilsPort(),
 				createLogger(),
 				[template],
+				createConfigManagerPort(),
 			)
 
 			await expect(
@@ -601,6 +634,7 @@ describe('ConfigurationTemplateService', () => {
 				createUtilsPort(),
 				createLogger(),
 				[template],
+				createConfigManagerPort(),
 			)
 
 			const result = await svc.applyConfigurationTemplate(
@@ -657,6 +691,7 @@ describe('ConfigurationTemplateService', () => {
 				createUtilsPort(),
 				loggerFake,
 				[template],
+				createConfigManagerPort(),
 			)
 
 			const result = await svc.applyConfigurationTemplate('tmpl-1', 2)
@@ -725,6 +760,7 @@ describe('ConfigurationTemplateService', () => {
 				createUtilsPort(),
 				createLogger(),
 				[template],
+				createConfigManagerPort(),
 			)
 
 			const result = await svc.applyConfigurationTemplate('tmpl-1', 2)
@@ -751,6 +787,7 @@ describe('ConfigurationTemplateService', () => {
 				createUtilsPort(),
 				createLogger(),
 				[template],
+				createConfigManagerPort(),
 			)
 
 			const result = await svc.applyConfigurationTemplate('tmpl-1', 2)
@@ -770,6 +807,7 @@ describe('ConfigurationTemplateService', () => {
 				createUtilsPort(),
 				createLogger(),
 				[],
+				createConfigManagerPort(),
 			)
 
 			const imported = [makeTemplate({ id: 'old-id', contentHash: '' })]
@@ -789,6 +827,7 @@ describe('ConfigurationTemplateService', () => {
 				createUtilsPort(),
 				createLogger(),
 				[],
+				createConfigManagerPort(),
 			)
 
 			const legacyTemplate = {
@@ -815,6 +854,7 @@ describe('ConfigurationTemplateService', () => {
 				createUtilsPort(),
 				createLogger(),
 				[],
+				createConfigManagerPort(),
 			)
 
 			const template = makeTemplate({ contentHash: 'existing-hash' })
@@ -843,6 +883,7 @@ describe('ConfigurationTemplateService', () => {
 				createUtilsPort(),
 				loggerFake,
 				[template],
+				createConfigManagerPort(),
 			)
 
 			const zwaveNode = { id: 2 } as ZWaveNode
@@ -870,6 +911,7 @@ describe('ConfigurationTemplateService', () => {
 				createUtilsPort(),
 				createLogger(),
 				[template],
+				createConfigManagerPort(),
 			)
 
 			const zwaveNode = { id: 2 } as ZWaveNode
@@ -893,6 +935,7 @@ describe('ConfigurationTemplateService', () => {
 				createUtilsPort(),
 				createLogger(),
 				[template],
+				createConfigManagerPort(),
 			)
 
 			const zwaveNode = { id: 2 } as ZWaveNode
@@ -916,6 +959,7 @@ describe('ConfigurationTemplateService', () => {
 				createUtilsPort(),
 				createLogger(),
 				[template],
+				createConfigManagerPort(),
 			)
 
 			const zwaveNode = { id: 2 } as ZWaveNode
@@ -936,6 +980,7 @@ describe('ConfigurationTemplateService', () => {
 				createUtilsPort(),
 				createLogger(),
 				[],
+				createConfigManagerPort(),
 			)
 
 			const result1 = await svc.createConfigurationTemplate(
@@ -966,6 +1011,7 @@ describe('ConfigurationTemplateService', () => {
 				createUtilsPort(),
 				createLogger(),
 				[],
+				createConfigManagerPort(),
 			)
 
 			const values: ZUIConfigurationTemplateValue[] = [
@@ -998,6 +1044,7 @@ describe('ConfigurationTemplateService', () => {
 				createUtilsPort(),
 				createLogger(),
 				[],
+				createConfigManagerPort(),
 			)
 
 			const resultNull = await svc.createConfigurationTemplate(
@@ -1033,6 +1080,7 @@ describe('ConfigurationTemplateService', () => {
 				createUtilsPort(),
 				createLogger(),
 				[],
+				createConfigManagerPort(),
 			)
 			await expect(
 				svc.getDeviceConfigurationParams('invalid'),
@@ -1047,6 +1095,7 @@ describe('ConfigurationTemplateService', () => {
 				createUtilsPort(),
 				createLogger(),
 				[],
+				createConfigManagerPort(),
 			)
 			await expect(
 				svc.getDeviceConfigurationParams('abc-def-ghi'),
@@ -1091,17 +1140,12 @@ describe('ConfigurationTemplateService', () => {
 				paramInformation: mockParamInfo,
 			}
 
-			const configModule = await import('@zwave-js/config')
-			const loadSpy = vi
-				.spyOn(configModule.ConfigManager.prototype, 'loadDeviceIndex')
-				.mockResolvedValue(undefined)
-			const lookupSpy = vi
-				.spyOn(configModule.ConfigManager.prototype, 'lookupDevice')
-				.mockResolvedValue(
-					mockDevice as ReturnType<
-						typeof configModule.ConfigManager.prototype.lookupDevice
-					>,
-				)
+			const loadDeviceIndex = vi.fn(() => Promise.resolve())
+			const lookupDevice = vi.fn(() => Promise.resolve(mockDevice))
+			const configMgr = createConfigManagerPort({
+				loadDeviceIndex,
+				lookupDevice,
+			})
 
 			const svc = new ConfigurationTemplateService(
 				createDriverPort(),
@@ -1110,14 +1154,15 @@ describe('ConfigurationTemplateService', () => {
 				createUtilsPort(),
 				createLogger(),
 				[],
+				configMgr,
 			)
 
 			// deviceId format is "mfr-productId-productType"; lookupDevice reorders to (mfr, productType, productId)
 			const result = await svc.getDeviceConfigurationParams('134-2-100')
 
-			expect(loadSpy).toHaveBeenCalled()
+			expect(loadDeviceIndex).toHaveBeenCalled()
 
-			expect(lookupSpy).toHaveBeenCalledWith(134, 100, 2)
+			expect(lookupDevice).toHaveBeenCalledWith(134, 100, 2)
 
 			expect(result.length).toBe(2)
 
@@ -1168,16 +1213,6 @@ describe('ConfigurationTemplateService', () => {
 		})
 
 		it('returns empty array when device has no paramInformation', async () => {
-			const configModule = await import('@zwave-js/config')
-			vi.spyOn(
-				configModule.ConfigManager.prototype,
-				'loadDeviceIndex',
-			).mockResolvedValue(undefined)
-			vi.spyOn(
-				configModule.ConfigManager.prototype,
-				'lookupDevice',
-			).mockResolvedValue(undefined)
-
 			const svc = new ConfigurationTemplateService(
 				createDriverPort(),
 				createNodeStorePort(),
@@ -1185,6 +1220,7 @@ describe('ConfigurationTemplateService', () => {
 				createUtilsPort(),
 				createLogger(),
 				[],
+				createConfigManagerPort(),
 			)
 
 			const result = await svc.getDeviceConfigurationParams('134-2-100')
@@ -1216,6 +1252,7 @@ describe('ConfigurationTemplateService', () => {
 				createUtilsPort(),
 				createLogger(),
 				[],
+				createConfigManagerPort(),
 			)
 
 			const result = await svc.createConfigurationTemplate(2, 'Test')
@@ -1254,6 +1291,7 @@ describe('ConfigurationTemplateService', () => {
 				createUtilsPort(),
 				createLogger(),
 				[],
+				createConfigManagerPort(),
 			)
 
 			const result = await svc.createConfigurationTemplate(2, 'Test')
@@ -1298,6 +1336,7 @@ describe('ConfigurationTemplateService', () => {
 				createUtilsPort(),
 				createLogger(),
 				[existingTemplate],
+				createConfigManagerPort(),
 			)
 
 			const updated = await svc.updateConfigurationTemplate(
@@ -1347,6 +1386,7 @@ describe('ConfigurationTemplateService', () => {
 				createUtilsPort(),
 				createLogger(),
 				[template],
+				createConfigManagerPort(),
 			)
 
 			const result = await svc.applyConfigurationTemplate(template.id, 2)
@@ -1400,6 +1440,7 @@ describe('ConfigurationTemplateService', () => {
 				createUtilsPort(),
 				createLogger(),
 				[template],
+				createConfigManagerPort(),
 			)
 
 			const result = await svc.applyConfigurationTemplate(template.id, 2)
@@ -1437,6 +1478,7 @@ describe('ConfigurationTemplateService', () => {
 				createUtilsPort(),
 				createLogger(),
 				[template],
+				createConfigManagerPort(),
 			)
 
 			const result = await svc.applyConfigurationTemplate(template.id, 2)
@@ -1496,6 +1538,7 @@ describe('ConfigurationTemplateService', () => {
 				createUtilsPort(),
 				logger,
 				[template],
+				createConfigManagerPort(),
 			)
 
 			svc.checkConfigurationTemplates(node, fakeZwaveNode)
@@ -1536,6 +1579,7 @@ describe('ConfigurationTemplateService', () => {
 				createUtilsPort(),
 				createLogger(),
 				[template],
+				createConfigManagerPort(),
 			)
 
 			const fakeZwaveNode = { id: 2 } as ZWaveNode
@@ -1564,6 +1608,7 @@ describe('ConfigurationTemplateService', () => {
 				createUtilsPort(),
 				createLogger(),
 				[template],
+				createConfigManagerPort(),
 			)
 
 			svc.checkConfigurationTemplates(node, fakeZwaveNode)
@@ -1592,6 +1637,7 @@ describe('ConfigurationTemplateService', () => {
 				createUtilsPort(),
 				createLogger(),
 				[template],
+				createConfigManagerPort(),
 			)
 
 			svc.checkConfigurationTemplates(node, fakeZwaveNode)
@@ -1618,6 +1664,7 @@ describe('ConfigurationTemplateService', () => {
 				createUtilsPort(),
 				createLogger(),
 				[template],
+				createConfigManagerPort(),
 			)
 
 			const fakeZwaveNode = { id: 2 } as ZWaveNode
@@ -1653,6 +1700,7 @@ describe('ConfigurationTemplateService', () => {
 				createUtilsPort(),
 				createLogger(),
 				[template],
+				createConfigManagerPort(),
 			)
 
 			vi.spyOn(svc, 'applyConfigurationTemplate').mockRejectedValue(
@@ -1698,6 +1746,7 @@ describe('ConfigurationTemplateService', () => {
 				createUtilsPort(),
 				createLogger(),
 				[template],
+				createConfigManagerPort(),
 			)
 
 			await svc.applyConfigurationTemplate(template.id, 2)
@@ -1715,6 +1764,7 @@ describe('ConfigurationTemplateService', () => {
 				createUtilsPort(),
 				createLogger(),
 				[],
+				createConfigManagerPort(),
 			)
 			const fakeZwaveNode = { id: 2 } as ZWaveNode
 			svc.checkConfigurationTemplates(node, fakeZwaveNode)
@@ -1744,6 +1794,7 @@ describe('ConfigurationTemplateService', () => {
 				createUtilsPort(),
 				createLogger(),
 				[template, otherTemplate],
+				createConfigManagerPort(),
 			)
 
 			await svc.deleteConfigurationTemplate(template.id)
@@ -1767,6 +1818,7 @@ describe('ConfigurationTemplateService', () => {
 				createUtilsPort(),
 				createLogger(),
 				[existing],
+				createConfigManagerPort(),
 			)
 
 			await svc.importConfigurationTemplates([imported])
@@ -1791,6 +1843,7 @@ describe('ConfigurationTemplateService', () => {
 				createUtilsPort(),
 				createLogger(),
 				[],
+				createConfigManagerPort(),
 			)
 
 			await expect(
@@ -1820,6 +1873,7 @@ describe('ConfigurationTemplateService', () => {
 				createUtilsPort(),
 				createLogger(),
 				[],
+				createConfigManagerPort(),
 			)
 
 			const result = await svc.createConfigurationTemplate(2, 'Test')
@@ -1849,6 +1903,7 @@ describe('ConfigurationTemplateService', () => {
 				createUtilsPort(),
 				createLogger(),
 				[],
+				createConfigManagerPort(),
 			)
 
 			const result = await svc.createConfigurationTemplate(2, 'Test')
@@ -1870,6 +1925,7 @@ describe('ConfigurationTemplateService', () => {
 				createUtilsPort(),
 				createLogger(),
 				[template],
+				createConfigManagerPort(),
 			)
 
 			const result = await svc.deleteConfigurationTemplate(template.id)
@@ -1893,6 +1949,7 @@ describe('ConfigurationTemplateService', () => {
 				createUtilsPort(),
 				createLogger(),
 				[template],
+				createConfigManagerPort(),
 			)
 
 			await svc.applyConfigurationTemplate(template.id, 2)
@@ -1930,6 +1987,7 @@ describe('ConfigurationTemplateService', () => {
 				createUtilsPort(),
 				createLogger(),
 				[template],
+				createConfigManagerPort(),
 			)
 
 			await svc.updateConfigurationTemplate(template.id, {
@@ -1976,6 +2034,7 @@ describe('ConfigurationTemplateService', () => {
 				createUtilsPort(),
 				createLogger(),
 				[template],
+				createConfigManagerPort(),
 			)
 
 			const fakeZwaveNode = { id: 2 } as ZWaveNode
@@ -2017,6 +2076,7 @@ describe('ConfigurationTemplateService', () => {
 				createUtilsPort(),
 				logger,
 				[template],
+				createConfigManagerPort(),
 			)
 
 			svc.checkConfigurationTemplates(node, fakeZwaveNode)

--- a/test/lib/zwave/ConfigurationTemplateService.test.ts
+++ b/test/lib/zwave/ConfigurationTemplateService.test.ts
@@ -1,12 +1,12 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { ConfigurationTemplateService } from '../../../api/lib/zwave/ConfigurationTemplateService.ts'
+import { ConfigurationTemplateService } from '#api/lib/zwave/ConfigurationTemplateService.ts'
 import type {
 	ZUIConfigurationTemplate,
 	ZUIConfigurationTemplateValue,
 	TemplateNodeState,
 	TemplateDriverPort,
 	TemplateConfigManagerPort,
-} from '../../../api/lib/zwave/ports.ts'
+} from '#api/lib/zwave/ports.ts'
 import type { ZWaveNode } from 'zwave-js'
 import { CommandClasses } from '@zwave-js/core'
 import { SetValueStatus } from 'zwave-js'
@@ -870,6 +870,14 @@ describe('ConfigurationTemplateService', () => {
 			const nodes = new Map([[2, node]])
 			const nodeStore = createNodeStorePort(nodes)
 			const loggerFake = createLogger()
+			let resolveWrite: (() => void) | undefined
+			const valueWritten = new Promise<void>((resolve) => {
+				resolveWrite = resolve
+			})
+			nodeStore.writeValue = vi.fn(() => {
+				resolveWrite?.()
+				return Promise.resolve({ status: SetValueStatus.Success })
+			})
 			const svc = new ConfigurationTemplateService(
 				createDriverPort(),
 				nodeStore,
@@ -882,8 +890,7 @@ describe('ConfigurationTemplateService', () => {
 
 			const zwaveNode = { id: 2 } as ZWaveNode
 			svc.checkConfigurationTemplates(node, zwaveNode)
-
-			await new Promise((r) => setTimeout(r, 10))
+			await valueWritten
 
 			expect(nodeStore.writeValue).toHaveBeenCalled()
 		})
@@ -1661,6 +1668,14 @@ describe('ConfigurationTemplateService', () => {
 
 			const fakeZwaveNode = { id: 2 } as ZWaveNode
 			const nodeStore = createNodeStorePort(nodes)
+			let resolveWrite: (() => void) | undefined
+			const valueWritten = new Promise<void>((resolve) => {
+				resolveWrite = resolve
+			})
+			nodeStore.writeValue = vi.fn(() => {
+				resolveWrite?.()
+				return Promise.resolve({ status: SetValueStatus.Success })
+			})
 
 			const svc = new ConfigurationTemplateService(
 				createDriverPort(),
@@ -1673,7 +1688,7 @@ describe('ConfigurationTemplateService', () => {
 			)
 
 			svc.checkConfigurationTemplates(node, fakeZwaveNode)
-			await new Promise((r) => setTimeout(r, 50))
+			await valueWritten
 			expect(nodeStore.logNode).toHaveBeenCalled()
 		})
 
@@ -1999,7 +2014,6 @@ describe('ConfigurationTemplateService', () => {
 				],
 			})
 
-			await new Promise((r) => setTimeout(r, 50))
 			expect(nodeStore.writeValue).not.toHaveBeenCalled()
 		})
 

--- a/test/lib/zwave/ConfigurationTemplateService.test.ts
+++ b/test/lib/zwave/ConfigurationTemplateService.test.ts
@@ -925,60 +925,102 @@ describe('ConfigurationTemplateService', () => {
 		})
 	})
 
-	describe('_generateContentHash (static)', () => {
-		it('produces deterministic 12-char hex hash', () => {
-			const values: ZUIConfigurationTemplateValue[] = [
-				{ property: 1, endpoint: 0, value: 42 },
-			]
-			const hash1 =
-				ConfigurationTemplateService._generateContentHash(values)
-			const hash2 =
-				ConfigurationTemplateService._generateContentHash(values)
+	describe('contentHash via public API', () => {
+		it('produces deterministic 12-char hex hash via createConfigurationTemplate', async () => {
+			const node = makeNode()
+			const nodes = new Map([[2, node]])
+			const svc = new ConfigurationTemplateService(
+				createDriverPort(),
+				createNodeStorePort(nodes),
+				createPersistencePort(),
+				createUtilsPort(),
+				createLogger(),
+				[],
+			)
 
-			expect(hash1).toBe(hash2)
-			expect(hash1.length).toBe(12)
-			expect(/^[0-9a-f]{12}$/.test(hash1)).toBe(true)
+			const result1 = await svc.createConfigurationTemplate(
+				2,
+				'Template A',
+				false,
+				[{ property: 1, endpoint: 0, value: 42 }],
+			)
+			const result2 = await svc.createConfigurationTemplate(
+				2,
+				'Template B',
+				false,
+				[{ property: 1, endpoint: 0, value: 42 }],
+			)
+
+			expect(result1.contentHash.length).toBe(12)
+			expect(/^[0-9a-f]{12}$/.test(result1.contentHash)).toBe(true)
+			expect(result1.contentHash).toBe(result2.contentHash)
 		})
 
-		it('includes firmware range in hash', () => {
+		it('firmware range affects persisted contentHash', async () => {
+			const node = makeNode()
+			const nodes = new Map([[2, node]])
+			const svc = new ConfigurationTemplateService(
+				createDriverPort(),
+				createNodeStorePort(nodes),
+				createPersistencePort(),
+				createUtilsPort(),
+				createLogger(),
+				[],
+			)
+
 			const values: ZUIConfigurationTemplateValue[] = [
 				{ property: 1, endpoint: 0, value: 42 },
 			]
-			const hash1 =
-				ConfigurationTemplateService._generateContentHash(values)
-			const hash2 = ConfigurationTemplateService._generateContentHash(
+			const withoutFw = await svc.createConfigurationTemplate(
+				2,
+				'No FW',
+				false,
+				values,
+			)
+			const withFw = await svc.createConfigurationTemplate(
+				2,
+				'With FW',
+				false,
 				values,
 				{ min: '1.0' },
 			)
 
-			expect(hash1).not.toBe(hash2)
+			expect(withoutFw.contentHash).not.toBe(withFw.contentHash)
 		})
 
-		it('normalizes propertyKey null vs undefined', () => {
-			const v1: ZUIConfigurationTemplateValue[] = [
-				{ property: 1, propertyKey: null, endpoint: 0, value: 42 },
-			]
-			const v2: ZUIConfigurationTemplateValue[] = [
-				{ property: 1, propertyKey: undefined, endpoint: 0, value: 42 },
-			]
-			expect(ConfigurationTemplateService._generateContentHash(v1)).toBe(
-				ConfigurationTemplateService._generateContentHash(v2),
-			)
-		})
-	})
-
-	describe('templates accessor', () => {
-		it('returns the live template array', () => {
-			const templates = [makeTemplate()]
+		it('normalizes null vs undefined propertyKey to same contentHash', async () => {
+			const node = makeNode()
+			const nodes = new Map([[2, node]])
 			const svc = new ConfigurationTemplateService(
 				createDriverPort(),
-				createNodeStorePort(),
+				createNodeStorePort(nodes),
 				createPersistencePort(),
 				createUtilsPort(),
 				createLogger(),
-				templates,
+				[],
 			)
-			expect(svc.templates).toBe(templates)
+
+			const resultNull = await svc.createConfigurationTemplate(
+				2,
+				'Null Key',
+				false,
+				[{ property: 1, propertyKey: null, endpoint: 0, value: 42 }],
+			)
+			const resultUndefined = await svc.createConfigurationTemplate(
+				2,
+				'Undef Key',
+				false,
+				[
+					{
+						property: 1,
+						propertyKey: undefined,
+						endpoint: 0,
+						value: 42,
+					},
+				],
+			)
+
+			expect(resultNull.contentHash).toBe(resultUndefined.contentHash)
 		})
 	})
 

--- a/test/lib/zwave/ConfigurationTemplateService.test.ts
+++ b/test/lib/zwave/ConfigurationTemplateService.test.ts
@@ -10,6 +10,8 @@ import type {
 import type { ZWaveNode } from 'zwave-js'
 import { CommandClasses } from '@zwave-js/core'
 import { SetValueStatus } from 'zwave-js'
+import { DeviceConfig, type ParamInformation } from '@zwave-js/config'
+import { ObjectKeyMap } from '@zwave-js/shared'
 
 let idCounter = 0
 
@@ -830,20 +832,19 @@ describe('ConfigurationTemplateService', () => {
 				createConfigManagerPort(),
 			)
 
-			const legacyTemplate = {
+			const legacyTemplate: ZUIConfigurationTemplate & {
+				minFirmwareVersion?: string
+			} = {
 				...makeTemplate(),
 				minFirmwareVersion: '1.0',
 				firmwareRange: undefined,
-			} as ZUIConfigurationTemplate & { minFirmwareVersion?: string }
+			}
 			const result = await svc.importConfigurationTemplates([
 				legacyTemplate,
 			])
 
 			expect(result[0].firmwareRange).toEqual({ min: '1.0' })
-			expect(
-				(result[0] as unknown as { minFirmwareVersion?: string })
-					.minFirmwareVersion,
-			).toBeUndefined()
+			expect(legacyTemplate.minFirmwareVersion).toBeUndefined()
 		})
 
 		it('preserves existing contentHash if present', async () => {
@@ -1103,42 +1104,75 @@ describe('ConfigurationTemplateService', () => {
 		})
 
 		it('returns mapped params from ConfigManager with correct lookup ordering', async () => {
-			const mockParamInfo = new Map()
+			const mockParamInfo = new ObjectKeyMap<
+				{ parameter: number; valueBitMask?: number },
+				ParamInformation
+			>()
 			mockParamInfo.set(
 				{ parameter: 2, valueBitMask: undefined },
 				{
+					parameterNumber: 2,
+					valueBitMask: undefined,
 					label: 'Wake After Power On',
 					description: 'Wake duration',
+					valueSize: 1,
+					allowed: [],
 					readOnly: false,
+					writeOnly: undefined,
 					minValue: 0,
 					maxValue: 255,
 					defaultValue: 0,
+					recommendedValue: undefined,
 					unit: 'seconds',
 					allowManualEntry: true,
+					destructive: undefined,
 					options: [],
+					hidden: undefined,
+					purpose: undefined,
 				},
 			)
 			mockParamInfo.set(
 				{ parameter: 5, valueBitMask: 1 },
 				{
+					parameterNumber: 5,
+					valueBitMask: 1,
 					label: 'Sensor Report',
 					description: 'Bitmask param',
+					valueSize: 1,
+					allowed: [],
 					readOnly: true,
+					writeOnly: undefined,
 					minValue: 0,
 					maxValue: 3,
 					defaultValue: 1,
+					recommendedValue: undefined,
 					unit: undefined,
 					allowManualEntry: false,
+					destructive: undefined,
 					options: [
 						{ label: 'Off', value: 0 },
 						{ label: 'On', value: 1 },
 					],
+					hidden: undefined,
+					purpose: undefined,
 				},
 			)
 
-			const mockDevice = {
-				paramInformation: mockParamInfo,
-			}
+			const mockDevice = new DeviceConfig(
+				'test.json',
+				false,
+				'ACME',
+				134,
+				'Widget',
+				'Test device',
+				[{ productType: 100, productId: 2 }],
+				{ min: '0.0', max: '255.255' },
+				false,
+				undefined,
+				undefined,
+				undefined,
+				mockParamInfo,
+			)
 
 			const loadDeviceIndex = vi.fn(() => Promise.resolve())
 			const lookupDevice = vi.fn(() => Promise.resolve(mockDevice))

--- a/test/lib/zwave/ConfigurationTemplateService.test.ts
+++ b/test/lib/zwave/ConfigurationTemplateService.test.ts
@@ -136,7 +136,7 @@ describe('ConfigurationTemplateService', () => {
 		idCounter = 0
 	})
 
-	describe('getConfigurationTemplates', () => {
+	describe('listing templates', () => {
 		it('returns the initial templates', () => {
 			const templates = [makeTemplate()]
 			const svc = new ConfigurationTemplateService(
@@ -165,7 +165,7 @@ describe('ConfigurationTemplateService', () => {
 		})
 	})
 
-	describe('createConfigurationTemplate', () => {
+	describe('creating templates', () => {
 		it('creates a template from node Configuration CC values', async () => {
 			const node = makeNode()
 			const nodes = new Map([[2, node]])
@@ -294,7 +294,7 @@ describe('ConfigurationTemplateService', () => {
 			).rejects.toThrow('no writeable Configuration CC values')
 		})
 
-		it('triggers auto-apply when autoApply is true', async () => {
+		it('automatically applies a new template when enabled', async () => {
 			const node = makeNode()
 			const nodes = new Map([[2, node]])
 			const nodeStore = createNodeStorePort(nodes)
@@ -318,8 +318,8 @@ describe('ConfigurationTemplateService', () => {
 		})
 	})
 
-	describe('updateConfigurationTemplate', () => {
-		it('updates name and autoApply', async () => {
+	describe('updating templates', () => {
+		it('updates the name and automatic application setting', async () => {
 			const template = makeTemplate()
 			const persistence = createPersistencePort()
 			const svc = new ConfigurationTemplateService(
@@ -399,7 +399,7 @@ describe('ConfigurationTemplateService', () => {
 		})
 	})
 
-	describe('deleteConfigurationTemplate', () => {
+	describe('deleting templates', () => {
 		it('deletes a template and persists', async () => {
 			const template = makeTemplate()
 			const persistence = createPersistencePort()
@@ -457,8 +457,8 @@ describe('ConfigurationTemplateService', () => {
 		})
 	})
 
-	describe('applyConfigurationTemplate', () => {
-		it('applies values via writeValue with exact arguments in order and records hash', async () => {
+	describe('applying templates', () => {
+		it('writes template values and records the applied content hash', async () => {
 			const template = makeTemplate({
 				values: [
 					{
@@ -495,8 +495,7 @@ describe('ConfigurationTemplateService', () => {
 			expect(result.failed).toBe(0)
 			expect(nodeStore.writeValue).toHaveBeenCalledTimes(2)
 
-			expect(nodeStore.writeValue).toHaveBeenNthCalledWith(
-				1,
+			expect(nodeStore.writeValue).toHaveBeenCalledWith(
 				{
 					nodeId: 2,
 					commandClass: CommandClasses.Configuration,
@@ -506,8 +505,7 @@ describe('ConfigurationTemplateService', () => {
 				},
 				42,
 			)
-			expect(nodeStore.writeValue).toHaveBeenNthCalledWith(
-				2,
+			expect(nodeStore.writeValue).toHaveBeenCalledWith(
 				{
 					nodeId: 2,
 					commandClass: CommandClasses.Configuration,
@@ -647,7 +645,7 @@ describe('ConfigurationTemplateService', () => {
 			expect(result.success).toBe(1)
 		})
 
-		it('handles partial failure: asserts exact write args and records failures', async () => {
+		it('reports each failed value while continuing the application', async () => {
 			const template = makeTemplate({
 				values: [
 					{
@@ -703,8 +701,7 @@ describe('ConfigurationTemplateService', () => {
 			expect(result.errors[0]).toContain('Custom error message')
 
 			expect(nodeStore.writeValue).toHaveBeenCalledTimes(3)
-			expect(nodeStore.writeValue).toHaveBeenNthCalledWith(
-				1,
+			expect(nodeStore.writeValue).toHaveBeenCalledWith(
 				{
 					nodeId: 2,
 					commandClass: CommandClasses.Configuration,
@@ -714,8 +711,7 @@ describe('ConfigurationTemplateService', () => {
 				},
 				1,
 			)
-			expect(nodeStore.writeValue).toHaveBeenNthCalledWith(
-				2,
+			expect(nodeStore.writeValue).toHaveBeenCalledWith(
 				{
 					nodeId: 2,
 					commandClass: CommandClasses.Configuration,
@@ -725,8 +721,7 @@ describe('ConfigurationTemplateService', () => {
 				},
 				2,
 			)
-			expect(nodeStore.writeValue).toHaveBeenNthCalledWith(
-				3,
+			expect(nodeStore.writeValue).toHaveBeenCalledWith(
 				{
 					nodeId: 2,
 					commandClass: CommandClasses.Configuration,
@@ -738,7 +733,7 @@ describe('ConfigurationTemplateService', () => {
 			)
 		})
 
-		it('handles write failures and dead node early exit', async () => {
+		it('stops after the node becomes dead and reports remaining values', async () => {
 			const template = makeTemplate({
 				values: [
 					{ property: 1, endpoint: 0, value: 1 },
@@ -769,7 +764,7 @@ describe('ConfigurationTemplateService', () => {
 			expect(result.reason).toBe('Node is dead')
 		})
 
-		it('catches exceptions from writeValue', async () => {
+		it('reports exceptions from value writes', async () => {
 			const template = makeTemplate({
 				values: [{ property: 1, endpoint: 0, value: 5 }],
 			})
@@ -797,7 +792,7 @@ describe('ConfigurationTemplateService', () => {
 		})
 	})
 
-	describe('importConfigurationTemplates', () => {
+	describe('importing template collections', () => {
 		it('imports templates and assigns new IDs', async () => {
 			const persistence = createPersistencePort()
 			const svc = new ConfigurationTemplateService(
@@ -863,7 +858,7 @@ describe('ConfigurationTemplateService', () => {
 		})
 	})
 
-	describe('checkConfigurationTemplates', () => {
+	describe('automatic application when nodes become ready', () => {
 		it('auto-applies matching templates on node ready', async () => {
 			const template = makeTemplate({
 				autoApply: true,
@@ -968,7 +963,7 @@ describe('ConfigurationTemplateService', () => {
 		})
 	})
 
-	describe('contentHash via public API', () => {
+	describe('template content hashes', () => {
 		it('produces deterministic content hash for identical values', async () => {
 			const node = makeNode()
 			const nodes = new Map([[2, node]])
@@ -1032,7 +1027,7 @@ describe('ConfigurationTemplateService', () => {
 			expect(withoutFw.contentHash).not.toBe(withFw.contentHash)
 		})
 
-		it('normalizes null vs undefined propertyKey to same contentHash', async () => {
+		it('produces the same hash when a value bit mask is null or omitted', async () => {
 			const node = makeNode()
 			const nodes = new Map([[2, node]])
 			const svc = new ConfigurationTemplateService(
@@ -1069,8 +1064,8 @@ describe('ConfigurationTemplateService', () => {
 		})
 	})
 
-	describe('getDeviceConfigurationParams', () => {
-		it('throws for invalid deviceId format', async () => {
+	describe('loading device configuration parameters', () => {
+		it('rejects a malformed device identifier', async () => {
 			const svc = new ConfigurationTemplateService(
 				createDriverPort(),
 				createNodeStorePort(),
@@ -1100,7 +1095,7 @@ describe('ConfigurationTemplateService', () => {
 			).rejects.toThrow('non-numeric')
 		})
 
-		it('returns mapped params from ConfigManager with correct lookup ordering', async () => {
+		it('maps configuration parameters for a device identifier', async () => {
 			const mockParamInfo = new ObjectKeyMap<
 				{ parameter: number; valueBitMask?: number },
 				ParamInformation
@@ -1188,7 +1183,7 @@ describe('ConfigurationTemplateService', () => {
 				configMgr,
 			)
 
-			// deviceId format is "mfr-productId-productType"; lookupDevice reorders to (mfr, productType, productId)
+			// Device IDs order product ID before product type, while ConfigManager expects product type first
 			const result = await svc.getDeviceConfigurationParams('134-2-100')
 
 			expect(loadDeviceIndex).toHaveBeenCalled()
@@ -1243,7 +1238,7 @@ describe('ConfigurationTemplateService', () => {
 			})
 		})
 
-		it('returns empty array when device has no paramInformation', async () => {
+		it('returns no parameters when the device configuration has none', async () => {
 			const svc = new ConfigurationTemplateService(
 				createDriverPort(),
 				createNodeStorePort(),
@@ -1259,8 +1254,8 @@ describe('ConfigurationTemplateService', () => {
 		})
 	})
 
-	describe('createConfigurationTemplate – propertyKey branches', () => {
-		it('captures propertyKey when present on Configuration CC value', async () => {
+	describe('configuration value selection', () => {
+		it('preserves a value bit mask in the template', async () => {
 			const node = makeNode({
 				values: {
 					'0-112-0-5-1': {
@@ -1331,8 +1326,8 @@ describe('ConfigurationTemplateService', () => {
 		})
 	})
 
-	describe('updateConfigurationTemplate – auto-apply on content change', () => {
-		it('triggers auto-apply when values change and autoApply is true', async () => {
+	describe('automatic application after template updates', () => {
+		it('automatically applies an enabled template after its values change', async () => {
 			const existingTemplate = makeTemplate({
 				autoApply: true,
 				values: [
@@ -1389,8 +1384,8 @@ describe('ConfigurationTemplateService', () => {
 		})
 	})
 
-	describe('applyConfigurationTemplate – error branch', () => {
-		it('catches writeValue exceptions and counts as failed', async () => {
+	describe('failed template writes', () => {
+		it('reports rejected writes as failures', async () => {
 			const template = makeTemplate({
 				values: [
 					{
@@ -1479,7 +1474,7 @@ describe('ConfigurationTemplateService', () => {
 			expect(result.reason).toBe('Node is dead')
 		})
 
-		it('counts setValueFailed with message', async () => {
+		it('includes the write failure message', async () => {
 			const template = makeTemplate({
 				values: [
 					{
@@ -1518,8 +1513,8 @@ describe('ConfigurationTemplateService', () => {
 		})
 	})
 
-	describe('checkConfigurationTemplates – partial failure', () => {
-		it('logs warning (not info) when auto-apply has partial failures', async () => {
+	describe('partial automatic application', () => {
+		it('logs a warning with partial application totals', async () => {
 			const template = makeTemplate({
 				autoApply: true,
 				contentHash: 'unique-hash',
@@ -1561,6 +1556,13 @@ describe('ConfigurationTemplateService', () => {
 					}) as ReturnType<TemplateDriverPort['getDriver']>,
 			}
 			const logger = createLogger()
+			let resolveWarning: (() => void) | undefined
+			const warningLogged = new Promise<void>((resolve) => {
+				resolveWarning = resolve
+			})
+			nodeStore.logNode = vi.fn((_node: ZWaveNode, level: string) => {
+				if (level === 'warn') resolveWarning?.()
+			})
 
 			const svc = new ConfigurationTemplateService(
 				driverPort,
@@ -1573,7 +1575,7 @@ describe('ConfigurationTemplateService', () => {
 			)
 
 			svc.checkConfigurationTemplates(node, fakeZwaveNode)
-			await new Promise((r) => setTimeout(r, 50))
+			await warningLogged
 
 			expect(nodeStore.logNode).toHaveBeenCalledWith(
 				fakeZwaveNode,
@@ -1589,7 +1591,7 @@ describe('ConfigurationTemplateService', () => {
 		})
 	})
 
-	describe('checkConfigurationTemplates – firmware range filtering', () => {
+	describe('automatic application by firmware version', () => {
 		it('excludes templates with min firmware above node firmware', () => {
 			const template = makeTemplate({
 				autoApply: true,
@@ -1675,7 +1677,7 @@ describe('ConfigurationTemplateService', () => {
 			expect(nodeStore.logNode).toHaveBeenCalled()
 		})
 
-		it('skips template when node has no firmwareVersion', () => {
+		it('skips ranged templates when node firmware is unknown', () => {
 			const template = makeTemplate({
 				autoApply: true,
 				firmwareRange: { min: '1.0.0', max: undefined },
@@ -1703,7 +1705,7 @@ describe('ConfigurationTemplateService', () => {
 		})
 	})
 
-	describe('updateConfigurationTemplate – auto-apply error handling', () => {
+	describe('automatic application failures', () => {
 		it('logs error when auto-apply rejects', async () => {
 			const template = makeTemplate({
 				autoApply: true,
@@ -1712,6 +1714,7 @@ describe('ConfigurationTemplateService', () => {
 			const node = makeNode({ appliedTemplateContentHashes: [] })
 			const nodes = new Map<number, TemplateNodeState>([[2, node]])
 			const nodeStore = createNodeStorePort(nodes)
+			nodeStore.getNode = vi.fn(() => undefined)
 
 			const fakeZwaveNode = { id: 2 } as ZWaveNode
 			const driverPort = {
@@ -1722,6 +1725,13 @@ describe('ConfigurationTemplateService', () => {
 						},
 					}) as ReturnType<TemplateDriverPort['getDriver']>,
 			}
+			let resolveError: (() => void) | undefined
+			const errorLogged = new Promise<void>((resolve) => {
+				resolveError = resolve
+			})
+			nodeStore.logNode = vi.fn((_node: ZWaveNode, level: string) => {
+				if (level === 'error') resolveError?.()
+			})
 
 			const svc = new ConfigurationTemplateService(
 				driverPort,
@@ -1731,10 +1741,6 @@ describe('ConfigurationTemplateService', () => {
 				createLogger(),
 				[template],
 				createConfigManagerPort(),
-			)
-
-			vi.spyOn(svc, 'applyConfigurationTemplate').mockRejectedValue(
-				new Error('Network error'),
 			)
 
 			await svc.updateConfigurationTemplate(template.id, {
@@ -1750,7 +1756,7 @@ describe('ConfigurationTemplateService', () => {
 				],
 			})
 
-			await new Promise((r) => setTimeout(r, 100))
+			await errorLogged
 			const logCalls = vi.mocked(nodeStore.logNode).mock.calls
 			const errorLogs = logCalls.filter(
 				(c: unknown[]) => c[1] === 'error',
@@ -1760,8 +1766,8 @@ describe('ConfigurationTemplateService', () => {
 		})
 	})
 
-	describe('applyConfigurationTemplate – no storeNode yet', () => {
-		it('creates storeNode entry when none exists', async () => {
+	describe('persisting the first template application', () => {
+		it('persists the applied hash when no node record exists', async () => {
 			const template = makeTemplate()
 			const node = makeNode()
 			const nodes = new Map<number, TemplateNodeState>([[2, node]])
@@ -1783,24 +1789,7 @@ describe('ConfigurationTemplateService', () => {
 		})
 	})
 
-	describe('checkConfigurationTemplates – no driver', () => {
-		it('returns early when matching templates is empty', () => {
-			const node = makeNode({ deviceId: 'other-device' })
-			const svc = new ConfigurationTemplateService(
-				{ getDriver: () => null },
-				createNodeStorePort(),
-				createPersistencePort(),
-				createUtilsPort(),
-				createLogger(),
-				[],
-				createConfigManagerPort(),
-			)
-			const fakeZwaveNode = { id: 2 } as ZWaveNode
-			svc.checkConfigurationTemplates(node, fakeZwaveNode)
-		})
-	})
-
-	describe('deleteConfigurationTemplate – cleanup hashes', () => {
+	describe('deleting applied templates', () => {
 		it('removes the deleted hash from all nodes', async () => {
 			const template = makeTemplate({ contentHash: 'del-hash' })
 			const otherTemplate = makeTemplate({
@@ -1832,7 +1821,7 @@ describe('ConfigurationTemplateService', () => {
 		})
 	})
 
-	describe('importConfigurationTemplates – duplicate IDs', () => {
+	describe('importing templates', () => {
 		it('generates new IDs for imported templates with existing IDs', async () => {
 			const existing = makeTemplate({ id: 'existing-id' })
 			const imported: ZUIConfigurationTemplate = {
@@ -1861,8 +1850,8 @@ describe('ConfigurationTemplateService', () => {
 		})
 	})
 
-	describe('createConfigurationTemplate – edge cases', () => {
-		it('throws when node has no values (values=undefined)', async () => {
+	describe('creating templates from incomplete node data', () => {
+		it('rejects a node without configuration values', async () => {
 			const node = makeNode({ values: undefined })
 			const nodes = new Map<number, TemplateNodeState>([[2, node]])
 			const svc = new ConfigurationTemplateService(
@@ -1880,7 +1869,7 @@ describe('ConfigurationTemplateService', () => {
 			).rejects.toThrow('no writeable Configuration CC values')
 		})
 
-		it('defaults endpoint to 0 when value.endpoint is undefined', async () => {
+		it('uses endpoint zero when a value omits its endpoint', async () => {
 			const node = makeNode({
 				values: {
 					'0-112-0-1': {
@@ -1909,7 +1898,7 @@ describe('ConfigurationTemplateService', () => {
 			expect(result.values[0].endpoint).toBe(0)
 		})
 
-		it('defaults deviceId when node.deviceId is falsy', async () => {
+		it('uses an empty device identifier when the node has none', async () => {
 			const node = makeNode({
 				deviceId: undefined,
 				values: {
@@ -1940,30 +1929,8 @@ describe('ConfigurationTemplateService', () => {
 		})
 	})
 
-	describe('deleteConfigurationTemplate – no hash', () => {
-		it('skips cleanup when template has no contentHash', async () => {
-			const template = makeTemplate({ contentHash: '' })
-			const node = makeNode({ appliedTemplateContentHashes: [] })
-			const nodes = new Map<number, TemplateNodeState>([[2, node]])
-			const nodeStore = createNodeStorePort(nodes)
-
-			const svc = new ConfigurationTemplateService(
-				createDriverPort(),
-				nodeStore,
-				createPersistencePort([template]),
-				createUtilsPort(),
-				createLogger(),
-				[template],
-				createConfigManagerPort(),
-			)
-
-			const result = await svc.deleteConfigurationTemplate(template.id)
-			expect(result).toBe(true)
-		})
-	})
-
-	describe('applyConfigurationTemplate – no appliedTemplateContentHashes', () => {
-		it('initializes appliedTemplateContentHashes when undefined', async () => {
+	describe('recording the first applied content hash', () => {
+		it('records the applied hash for a node without prior history', async () => {
 			const template = makeTemplate()
 			const node = makeNode({
 				appliedTemplateContentHashes: undefined,
@@ -1987,7 +1954,7 @@ describe('ConfigurationTemplateService', () => {
 		})
 	})
 
-	describe('auto-apply – skips non-ready and already-applied nodes', () => {
+	describe('automatic application eligibility', () => {
 		it('skips non-ready nodes', async () => {
 			const template = makeTemplate({
 				autoApply: true,
@@ -2073,8 +2040,8 @@ describe('ConfigurationTemplateService', () => {
 		})
 	})
 
-	describe('checkConfigurationTemplates – apply rejection', () => {
-		it('logs error when applyConfigurationTemplate rejects during auto-apply', async () => {
+	describe('rejected automatic application', () => {
+		it('logs an error when automatic application rejects', async () => {
 			const template = makeTemplate({
 				autoApply: true,
 				contentHash: 'check-catch-hash',
@@ -2097,6 +2064,13 @@ describe('ConfigurationTemplateService', () => {
 					}) as ReturnType<TemplateDriverPort['getDriver']>,
 			}
 			const logger = createLogger()
+			let resolveError: (() => void) | undefined
+			const errorLogged = new Promise<void>((resolve) => {
+				resolveError = resolve
+			})
+			nodeStore.logNode = vi.fn((_node: ZWaveNode, level: string) => {
+				if (level === 'error') resolveError?.()
+			})
 
 			const svc = new ConfigurationTemplateService(
 				driverPort,
@@ -2109,7 +2083,7 @@ describe('ConfigurationTemplateService', () => {
 			)
 
 			svc.checkConfigurationTemplates(node, fakeZwaveNode)
-			await new Promise((r) => setTimeout(r, 100))
+			await errorLogged
 
 			const logCalls = vi.mocked(nodeStore.logNode).mock.calls
 			const errorLogs = logCalls.filter(

--- a/test/lib/zwave/ScheduleService.test.ts
+++ b/test/lib/zwave/ScheduleService.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { ScheduleService } from '../../../api/lib/zwave/ScheduleService.ts'
+import { ScheduleService } from '#api/lib/zwave/ScheduleService.ts'
 import { SupervisionStatus } from '@zwave-js/core'
 import {
 	ScheduleEntryLockScheduleKind,
@@ -17,7 +17,7 @@ import type {
 	ScheduleNodeStorePort,
 	ScheduleUtilsPort,
 	ScheduleNodeState,
-} from '../../../api/lib/zwave/ports.ts'
+} from '#api/lib/zwave/ports.ts'
 
 function createFakeEndpoint() {
 	return { id: 0 }

--- a/test/lib/zwave/ScheduleService.test.ts
+++ b/test/lib/zwave/ScheduleService.test.ts
@@ -1050,7 +1050,7 @@ describe('ScheduleService', () => {
 			])
 		})
 
-		it('rejects an all-users update when node has no userCodes', async () => {
+		it('emits unchanged state for an all-users update when node has no userCodes', async () => {
 			const zwaveNode = createFakeZwaveNode(true)
 			zwaveNode.commandClasses[
 				'Schedule Entry Lock'
@@ -1066,10 +1066,10 @@ describe('ScheduleService', () => {
 				createUtilsPort(),
 			)
 
-			await expect(svc.setEnabledSchedule(2, true, 0)).rejects.toThrow(
-				"Cannot read properties of undefined (reading 'available')",
-			)
-			expect(nodeStore.emitCalls).toEqual([])
+			await svc.setEnabledSchedule(2, true, 0)
+			expect(nodeStore.emitCalls).toEqual([
+				[expect.objectContaining({ id: 2 }), { userCodes: undefined }],
+			])
 		})
 	})
 })

--- a/test/lib/zwave/ScheduleService.test.ts
+++ b/test/lib/zwave/ScheduleService.test.ts
@@ -1,0 +1,909 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { ScheduleService } from '../../../api/lib/zwave/ScheduleService.ts'
+import { SupervisionStatus } from '@zwave-js/core'
+import { ScheduleEntryLockScheduleKind, UserIDStatus } from 'zwave-js'
+import type {
+	ScheduleDriverPort,
+	ScheduleNodeStorePort,
+	ScheduleUtilsPort,
+	ScheduleNodeState,
+} from '../../../api/lib/zwave/ports.ts'
+
+// ---------------------------------------------------------------------------
+// Helpers: minimal fakes for ports
+// ---------------------------------------------------------------------------
+
+function createFakeEndpoint() {
+	return { id: 0 }
+}
+
+function createFakeZwaveNode(supported = true) {
+	return {
+		id: 2,
+		getEndpoint: vi.fn(() => createFakeEndpoint()),
+		commandClasses: {
+			'Schedule Entry Lock': {
+				isSupported: vi.fn(() => supported),
+				getWeekDaySchedule: vi.fn(),
+				getYearDaySchedule: vi.fn(),
+				getDailyRepeatingSchedule: vi.fn(),
+				setWeekDaySchedule: vi.fn(),
+				setYearDaySchedule: vi.fn(),
+				setDailyRepeatingSchedule: vi.fn(),
+				setEnabled: vi.fn(),
+			},
+		},
+	}
+}
+
+function createDriverPort(
+	zwaveNode?: ReturnType<typeof createFakeZwaveNode>,
+): ScheduleDriverPort {
+	const node = zwaveNode ?? createFakeZwaveNode()
+	return {
+		getDriver: () =>
+			({
+				controller: {
+					nodes: {
+						get: vi.fn((id: number) =>
+							id === node.id ? node : undefined,
+						),
+					},
+				},
+			}) as any,
+	}
+}
+
+function createNodeStorePort(
+	initialNode?: ScheduleNodeState,
+): ScheduleNodeStorePort & { emitCalls: unknown[][] } {
+	const emitCalls: unknown[][] = []
+	const node: ScheduleNodeState = initialNode ?? {
+		id: 2,
+		schedule: undefined,
+		userCodes: undefined,
+	}
+	return {
+		getNode: vi.fn((id: number) => (id === node.id ? node : undefined)),
+		emitNodeUpdate: vi.fn((...args) => emitCalls.push(args)),
+		emitCalls,
+	}
+}
+
+function createUtilsPort(): ScheduleUtilsPort {
+	return {
+		deepEqual: (a, b) => JSON.stringify(a) === JSON.stringify(b),
+	}
+}
+
+// Stub out the CC statics so we don't need a real driver
+async function stubCCStatics(
+	overrides: Partial<{
+		supportedUsers: number
+		numWeekDaySlots: number
+		numYearDaySlots: number
+		numDailyRepeatingSlots: number
+		userIdStatuses: Record<number, number | undefined>
+		scheduleEnabled: Record<number, boolean>
+		scheduleKind: Record<number, number | undefined>
+		cachedSchedules: Record<string, unknown>
+	}> = {},
+) {
+	const {
+		supportedUsers = 2,
+		numWeekDaySlots = 1,
+		numYearDaySlots = 1,
+		numDailyRepeatingSlots = 1,
+		userIdStatuses = {},
+		scheduleEnabled = {},
+		scheduleKind = {},
+		cachedSchedules = {},
+	} = overrides
+
+	// We need to mock static methods on the CC classes
+	const { UserCodeCC, ScheduleEntryLockCC } = await import('zwave-js')
+
+	vi.spyOn(UserCodeCC, 'getSupportedUsersCached').mockReturnValue(
+		supportedUsers,
+	)
+	vi.spyOn(UserCodeCC, 'getUserIdStatusCached').mockImplementation(
+		(_driver, _ep, userId) =>
+			userIdStatuses[userId] ?? UserIDStatus.Available,
+	)
+	vi.spyOn(ScheduleEntryLockCC, 'getNumWeekDaySlotsCached').mockReturnValue(
+		numWeekDaySlots,
+	)
+	vi.spyOn(ScheduleEntryLockCC, 'getNumYearDaySlotsCached').mockReturnValue(
+		numYearDaySlots,
+	)
+	vi.spyOn(
+		ScheduleEntryLockCC,
+		'getNumDailyRepeatingSlotsCached',
+	).mockReturnValue(numDailyRepeatingSlots)
+	vi.spyOn(
+		ScheduleEntryLockCC,
+		'getUserCodeScheduleEnabledCached',
+	).mockImplementation(
+		(_driver, _ep, userId) => scheduleEnabled[userId] ?? false,
+	)
+	vi.spyOn(
+		ScheduleEntryLockCC,
+		'getUserCodeScheduleKindCached',
+	).mockImplementation(
+		(_driver, _ep, userId) => scheduleKind[userId] ?? undefined,
+	)
+	vi.spyOn(ScheduleEntryLockCC, 'getScheduleCached').mockImplementation(
+		(_driver, _ep, kind, userId, slotId) =>
+			cachedSchedules[`${kind}-${userId}-${slotId}`] ?? undefined,
+	)
+
+	return { UserCodeCC, ScheduleEntryLockCC }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('ScheduleService', () => {
+	beforeEach(() => {
+		vi.restoreAllMocks()
+	})
+
+	describe('construction and initial state', () => {
+		it('starts with lock=false and cancel=false', () => {
+			const svc = new ScheduleService(
+				createDriverPort(),
+				createNodeStorePort(),
+				createUtilsPort(),
+			)
+			expect(svc.lockGetSchedule).toBe(false)
+			expect(svc.cancelGetScheduleFlag).toBe(false)
+		})
+	})
+
+	describe('cancelGetSchedule', () => {
+		it('sets the cancel flag', () => {
+			const svc = new ScheduleService(
+				createDriverPort(),
+				createNodeStorePort(),
+				createUtilsPort(),
+			)
+			svc.cancelGetSchedule()
+			expect(svc.cancelGetScheduleFlag).toBe(true)
+		})
+	})
+
+	describe('getSchedules', () => {
+		it('throws if Schedule Entry Lock CC is not supported', async () => {
+			const zwaveNode = createFakeZwaveNode(false)
+			const svc = new ScheduleService(
+				createDriverPort(zwaveNode),
+				createNodeStorePort(),
+				createUtilsPort(),
+			)
+			await expect(svc.getSchedules(2)).rejects.toThrow(
+				'Schedule Entry Lock CC not supported on node 2',
+			)
+		})
+
+		it('throws if another request is in progress', async () => {
+			const zwaveNode = createFakeZwaveNode(true)
+			const driverPort = createDriverPort(zwaveNode)
+			const nodeStore = createNodeStorePort()
+			const svc = new ScheduleService(
+				driverPort,
+				nodeStore,
+				createUtilsPort(),
+			)
+
+			// Stub CC statics to return 0 users so the first call resolves quickly
+			await stubCCStatics({ supportedUsers: 0 })
+
+			// Start a long request
+			const p1 = svc.getSchedules(2)
+			// A second one should throw
+			await expect(svc.getSchedules(2)).rejects.toThrow(
+				'Another request is in progress',
+			)
+			await p1
+		})
+
+		it('returns undefined if node is not in store', async () => {
+			const zwaveNode = createFakeZwaveNode(true)
+			const driverPort = createDriverPort(zwaveNode)
+			const nodeStore = createNodeStorePort({
+				id: 999,
+				schedule: undefined,
+				userCodes: undefined,
+			})
+			const svc = new ScheduleService(
+				driverPort,
+				nodeStore,
+				createUtilsPort(),
+			)
+			await stubCCStatics({ supportedUsers: 0 })
+
+			const result = await svc.getSchedules(2)
+			expect(result).toBeUndefined()
+		})
+
+		it('builds schedule structure from cached data', async () => {
+			const zwaveNode = createFakeZwaveNode(true)
+			const driverPort = createDriverPort(zwaveNode)
+			const nodeStore = createNodeStorePort()
+			const svc = new ScheduleService(
+				driverPort,
+				nodeStore,
+				createUtilsPort(),
+			)
+
+			await stubCCStatics({
+				supportedUsers: 1,
+				numWeekDaySlots: 1,
+				numYearDaySlots: 1,
+				numDailyRepeatingSlots: 1,
+				userIdStatuses: { 1: 1 /* Enabled */ },
+				scheduleEnabled: { 1: true },
+				scheduleKind: {
+					1: ScheduleEntryLockScheduleKind.WeekDay,
+				},
+				cachedSchedules: {
+					[`${ScheduleEntryLockScheduleKind.WeekDay}-1-1`]: {
+						dayOfWeek: 1,
+						startHour: 8,
+						startMinute: 0,
+						stopHour: 17,
+						stopMinute: 0,
+					},
+				},
+			})
+
+			const result = await svc.getSchedules(2, { fromCache: true })
+			expect(result).toBeDefined()
+			expect(result?.weekly?.numSlots).toBe(1)
+			expect(result?.daily?.numSlots).toBe(1)
+			expect(result?.yearly?.numSlots).toBe(1)
+			// Verify lock is released
+			expect(svc.lockGetSchedule).toBe(false)
+		})
+
+		it('releases lock even if promise rejects', async () => {
+			const zwaveNode = createFakeZwaveNode(true)
+			const driverPort: ScheduleDriverPort = {
+				getDriver: () => null, // will cause NPE inside
+			}
+			const nodeStore = createNodeStorePort()
+			const svc = new ScheduleService(
+				driverPort,
+				nodeStore,
+				createUtilsPort(),
+			)
+
+			await expect(svc.getSchedules(2)).rejects.toThrow()
+			expect(svc.lockGetSchedule).toBe(false)
+			expect(svc.cancelGetScheduleFlag).toBe(false)
+		})
+	})
+
+	describe('setSchedule', () => {
+		it('throws for unsupported CC', async () => {
+			const zwaveNode = createFakeZwaveNode(false)
+			const svc = new ScheduleService(
+				createDriverPort(zwaveNode),
+				createNodeStorePort(),
+				createUtilsPort(),
+			)
+			await expect(
+				svc.setSchedule(2, 'weekly', {
+					userId: 1,
+					slotId: 1,
+					dayOfWeek: 1,
+					startHour: 8,
+					startMinute: 0,
+					stopHour: 17,
+					stopMinute: 0,
+				} as any),
+			).rejects.toThrow('Schedule Entry Lock CC not supported')
+		})
+
+		it('throws for invalid schedule type', async () => {
+			const zwaveNode = createFakeZwaveNode(true)
+			const svc = new ScheduleService(
+				createDriverPort(zwaveNode),
+				createNodeStorePort(),
+				createUtilsPort(),
+			)
+			await expect(
+				svc.setSchedule(
+					2,
+					'invalid' as any,
+					{
+						userId: 1,
+						slotId: 1,
+					} as any,
+				),
+			).rejects.toThrow('Invalid schedule type')
+		})
+
+		it('sets a weekly schedule and verifies success via readback', async () => {
+			const zwaveNode = createFakeZwaveNode(true)
+			const scheduleData = {
+				dayOfWeek: 1,
+				startHour: 8,
+				startMinute: 0,
+				stopHour: 17,
+				stopMinute: 0,
+			}
+			// setWeekDaySchedule returns undefined (no supervision)
+			zwaveNode.commandClasses[
+				'Schedule Entry Lock'
+			].setWeekDaySchedule.mockResolvedValue(undefined)
+			// readback returns matching data
+			zwaveNode.commandClasses[
+				'Schedule Entry Lock'
+			].getWeekDaySchedule.mockResolvedValue(scheduleData)
+
+			const nodeStore = createNodeStorePort({
+				id: 2,
+				schedule: {
+					daily: { numSlots: 0, slots: [] },
+					weekly: { numSlots: 1, slots: [] },
+					yearly: { numSlots: 0, slots: [] },
+				},
+				userCodes: { total: 1, available: [1], enabled: [] },
+			})
+			const svc = new ScheduleService(
+				createDriverPort(zwaveNode),
+				nodeStore,
+				createUtilsPort(),
+			)
+
+			const result = await svc.setSchedule(2, 'weekly', {
+				userId: 1,
+				slotId: 1,
+				...scheduleData,
+			} as any)
+
+			expect(result?.status).toBe(SupervisionStatus.Success)
+			expect(nodeStore.emitCalls.length).toBeGreaterThan(0)
+		})
+
+		it('handles delete (empty schedule) via readback', async () => {
+			const zwaveNode = createFakeZwaveNode(true)
+			zwaveNode.commandClasses[
+				'Schedule Entry Lock'
+			].setWeekDaySchedule.mockResolvedValue(undefined)
+			// readback returns undefined (deleted)
+			zwaveNode.commandClasses[
+				'Schedule Entry Lock'
+			].getWeekDaySchedule.mockResolvedValue(undefined)
+
+			const nodeStore = createNodeStorePort({
+				id: 2,
+				schedule: {
+					daily: { numSlots: 0, slots: [] },
+					weekly: {
+						numSlots: 1,
+						slots: [
+							{
+								userId: 1,
+								slotId: 1,
+								enabled: true,
+								dayOfWeek: 1,
+								startHour: 8,
+								startMinute: 0,
+								stopHour: 17,
+								stopMinute: 0,
+							} as any,
+						],
+					},
+					yearly: { numSlots: 0, slots: [] },
+				},
+				userCodes: { total: 1, available: [1], enabled: [1] },
+			})
+			const svc = new ScheduleService(
+				createDriverPort(zwaveNode),
+				nodeStore,
+				createUtilsPort(),
+			)
+
+			const result = await svc.setSchedule(2, 'weekly', {
+				userId: 1,
+				slotId: 1,
+			} as any)
+
+			expect(result?.status).toBe(SupervisionStatus.Success)
+		})
+
+		it('returns supervision result directly when supervised', async () => {
+			const zwaveNode = createFakeZwaveNode(true)
+			zwaveNode.commandClasses[
+				'Schedule Entry Lock'
+			].setDailyRepeatingSchedule.mockResolvedValue({
+				status: SupervisionStatus.Success,
+			})
+
+			const nodeStore = createNodeStorePort({
+				id: 2,
+				schedule: {
+					daily: { numSlots: 1, slots: [] },
+					weekly: { numSlots: 0, slots: [] },
+					yearly: { numSlots: 0, slots: [] },
+				},
+				userCodes: { total: 1, available: [1], enabled: [] },
+			})
+			const svc = new ScheduleService(
+				createDriverPort(zwaveNode),
+				nodeStore,
+				createUtilsPort(),
+			)
+
+			const result = await svc.setSchedule(2, 'daily', {
+				userId: 1,
+				slotId: 1,
+				weekday: 0,
+				startHour: 6,
+				startMinute: 30,
+				durationHour: 2,
+				durationMinute: 0,
+			} as any)
+
+			expect(result?.status).toBe(SupervisionStatus.Success)
+		})
+	})
+
+	describe('setEnabledSchedule', () => {
+		it('throws when node not found', async () => {
+			const driverPort: ScheduleDriverPort = {
+				getDriver: () =>
+					({
+						controller: {
+							nodes: { get: () => undefined },
+						},
+					}) as any,
+			}
+			const svc = new ScheduleService(
+				driverPort,
+				createNodeStorePort(),
+				createUtilsPort(),
+			)
+			await expect(svc.setEnabledSchedule(99, true, 1)).rejects.toThrow(
+				'Node not found',
+			)
+		})
+
+		it('enables a user and emits update', async () => {
+			const zwaveNode = createFakeZwaveNode(true)
+			zwaveNode.commandClasses[
+				'Schedule Entry Lock'
+			].setEnabled.mockResolvedValue(undefined)
+
+			const nodeStore = createNodeStorePort({
+				id: 2,
+				userCodes: { total: 1, available: [1], enabled: [] },
+			})
+			const svc = new ScheduleService(
+				createDriverPort(zwaveNode),
+				nodeStore,
+				createUtilsPort(),
+			)
+
+			await svc.setEnabledSchedule(2, true, 1)
+			const node = nodeStore.getNode(2)
+			expect(node?.userCodes?.enabled).toContain(1)
+		})
+
+		it('disables a user and emits update', async () => {
+			const zwaveNode = createFakeZwaveNode(true)
+			zwaveNode.commandClasses[
+				'Schedule Entry Lock'
+			].setEnabled.mockResolvedValue(undefined)
+
+			const nodeStore = createNodeStorePort({
+				id: 2,
+				userCodes: { total: 1, available: [1], enabled: [1] },
+			})
+			const svc = new ScheduleService(
+				createDriverPort(zwaveNode),
+				nodeStore,
+				createUtilsPort(),
+			)
+
+			await svc.setEnabledSchedule(2, false, 1)
+			const node = nodeStore.getNode(2)
+			expect(node?.userCodes?.enabled).not.toContain(1)
+		})
+
+		it('enables all users when userId is 0', async () => {
+			const zwaveNode = createFakeZwaveNode(true)
+			zwaveNode.commandClasses[
+				'Schedule Entry Lock'
+			].setEnabled.mockResolvedValue(undefined)
+
+			const nodeStore = createNodeStorePort({
+				id: 2,
+				userCodes: { total: 3, available: [1, 2, 3], enabled: [] },
+			})
+			const svc = new ScheduleService(
+				createDriverPort(zwaveNode),
+				nodeStore,
+				createUtilsPort(),
+			)
+
+			await svc.setEnabledSchedule(2, true, 0)
+			const node = nodeStore.getNode(2)
+			expect(node?.userCodes?.enabled).toEqual([1, 2, 3])
+		})
+
+		it('disables all users when userId is 0', async () => {
+			const zwaveNode = createFakeZwaveNode(true)
+			zwaveNode.commandClasses[
+				'Schedule Entry Lock'
+			].setEnabled.mockResolvedValue(undefined)
+
+			const nodeStore = createNodeStorePort({
+				id: 2,
+				userCodes: {
+					total: 3,
+					available: [1, 2, 3],
+					enabled: [1, 2, 3],
+				},
+			})
+			const svc = new ScheduleService(
+				createDriverPort(zwaveNode),
+				nodeStore,
+				createUtilsPort(),
+			)
+
+			await svc.setEnabledSchedule(2, false, 0)
+			const node = nodeStore.getNode(2)
+			expect(node?.userCodes?.enabled).toEqual([])
+		})
+	})
+
+	describe('_pushSchedule (static)', () => {
+		it('updates an existing slot in place', () => {
+			const arr: any[] = [
+				{ userId: 1, slotId: 1, dayOfWeek: 1, enabled: false },
+			]
+			ScheduleService._pushSchedule(
+				arr,
+				{ userId: 1, slotId: 1 },
+				{ dayOfWeek: 2 } as any,
+				true,
+			)
+			expect(arr.length).toBe(1)
+			expect(arr[0].dayOfWeek).toBe(2)
+			expect(arr[0].enabled).toBe(true)
+		})
+
+		it('removes a slot when schedule is undefined and slot exists', () => {
+			const arr: any[] = [
+				{ userId: 1, slotId: 1, dayOfWeek: 1, enabled: true },
+			]
+			ScheduleService._pushSchedule(
+				arr,
+				{ userId: 1, slotId: 1 },
+				undefined,
+				false,
+			)
+			expect(arr.length).toBe(0)
+		})
+
+		it('does nothing when schedule is undefined and slot does not exist', () => {
+			const arr: any[] = []
+			ScheduleService._pushSchedule(
+				arr,
+				{ userId: 1, slotId: 1 },
+				undefined,
+				false,
+			)
+			expect(arr.length).toBe(0)
+		})
+	})
+
+	describe('setSchedule – yearly', () => {
+		it('sets a yearly schedule via supervision', async () => {
+			const zwaveNode = createFakeZwaveNode(true)
+			zwaveNode.commandClasses[
+				'Schedule Entry Lock'
+			].setYearDaySchedule.mockResolvedValue({
+				status: SupervisionStatus.Success,
+			})
+
+			const nodeStore = createNodeStorePort({
+				id: 2,
+				schedule: {
+					daily: { numSlots: 0, slots: [] },
+					weekly: { numSlots: 0, slots: [] },
+					yearly: { numSlots: 1, slots: [] },
+				},
+				userCodes: { total: 1, available: [1], enabled: [] },
+			})
+			const svc = new ScheduleService(
+				createDriverPort(zwaveNode),
+				nodeStore,
+				createUtilsPort(),
+			)
+
+			const result = await svc.setSchedule(2, 'yearly', {
+				userId: 1,
+				slotId: 1,
+				startYear: 2025,
+				startMonth: 6,
+				startDay: 15,
+				startHour: 9,
+				startMinute: 0,
+				stopYear: 2025,
+				stopMonth: 6,
+				stopDay: 15,
+				stopHour: 18,
+				stopMinute: 0,
+			} as any)
+
+			expect(result?.status).toBe(SupervisionStatus.Success)
+		})
+	})
+
+	describe('setSchedule – readback mismatch', () => {
+		it('returns Fail when readback does not match', async () => {
+			const zwaveNode = createFakeZwaveNode(true)
+			zwaveNode.commandClasses[
+				'Schedule Entry Lock'
+			].setWeekDaySchedule.mockResolvedValue(undefined)
+			// Readback returns different data
+			zwaveNode.commandClasses[
+				'Schedule Entry Lock'
+			].getWeekDaySchedule.mockResolvedValue({
+				dayOfWeek: 99,
+			})
+
+			const nodeStore = createNodeStorePort({
+				id: 2,
+				schedule: {
+					daily: { numSlots: 0, slots: [] },
+					weekly: { numSlots: 1, slots: [] },
+					yearly: { numSlots: 0, slots: [] },
+				},
+				userCodes: { total: 1, available: [1], enabled: [] },
+			})
+			const svc = new ScheduleService(
+				createDriverPort(zwaveNode),
+				nodeStore,
+				createUtilsPort(),
+			)
+
+			const result = await svc.setSchedule(2, 'weekly', {
+				userId: 1,
+				slotId: 1,
+				dayOfWeek: 1,
+				startHour: 8,
+				startMinute: 0,
+				stopHour: 17,
+				stopMinute: 0,
+			} as any)
+
+			expect(result?.status).toBe(SupervisionStatus.Fail)
+		})
+	})
+
+	describe('getSchedules – cancellation', () => {
+		it('returns undefined when cancelled during iteration', async () => {
+			const zwaveNode = createFakeZwaveNode(true)
+			const driverPort = createDriverPort(zwaveNode)
+			const nodeStore = createNodeStorePort()
+			const svc = new ScheduleService(
+				driverPort,
+				nodeStore,
+				createUtilsPort(),
+			)
+
+			await stubCCStatics({
+				supportedUsers: 1,
+				numWeekDaySlots: 2,
+				numYearDaySlots: 0,
+				numDailyRepeatingSlots: 0,
+				userIdStatuses: { 1: 1 },
+				scheduleEnabled: { 1: true },
+				scheduleKind: {
+					1: ScheduleEntryLockScheduleKind.WeekDay,
+				},
+			})
+
+			// Get from device (not cache), mock getWeekDaySchedule to set cancel
+			zwaveNode.commandClasses[
+				'Schedule Entry Lock'
+			].getWeekDaySchedule.mockImplementation(() => {
+				svc.cancelGetSchedule()
+				return Promise.resolve({ dayOfWeek: 1 })
+			})
+
+			const result = await svc.getSchedules(2, {
+				fromCache: false,
+			})
+			expect(result).toBeUndefined()
+			// Lock is released
+			expect(svc.lockGetSchedule).toBe(false)
+		})
+	})
+
+	describe('getSchedules – returns undefined when userCodes is null', () => {
+		it('returns undefined when getSupportedUsersCached returns undefined', async () => {
+			const zwaveNode = createFakeZwaveNode(true)
+			const driverPort = createDriverPort(zwaveNode)
+			const nodeStore = createNodeStorePort()
+			const svc = new ScheduleService(
+				driverPort,
+				nodeStore,
+				createUtilsPort(),
+			)
+
+			const { UserCodeCC } = await import('zwave-js')
+			vi.spyOn(UserCodeCC, 'getSupportedUsersCached').mockReturnValue(
+				undefined as any,
+			)
+
+			const result = await svc.getSchedules(2)
+			expect(result).toBeUndefined()
+			expect(svc.lockGetSchedule).toBe(false)
+		})
+	})
+
+	describe('getSchedules – mode filtering', () => {
+		it('only fetches weekly schedules when mode is WEEKLY', async () => {
+			const zwaveNode = createFakeZwaveNode(true)
+			const driverPort = createDriverPort(zwaveNode)
+			const nodeStore = createNodeStorePort()
+			const svc = new ScheduleService(
+				driverPort,
+				nodeStore,
+				createUtilsPort(),
+			)
+
+			await stubCCStatics({
+				supportedUsers: 1,
+				numWeekDaySlots: 1,
+				numYearDaySlots: 1,
+				numDailyRepeatingSlots: 1,
+				userIdStatuses: { 1: 1 },
+				scheduleEnabled: { 1: true },
+				scheduleKind: {
+					1: ScheduleEntryLockScheduleKind.WeekDay,
+				},
+				cachedSchedules: {
+					[`${ScheduleEntryLockScheduleKind.WeekDay}-1-1`]: {
+						dayOfWeek: 1,
+						startHour: 8,
+						startMinute: 0,
+						stopHour: 17,
+						stopMinute: 0,
+					},
+				},
+			})
+
+			const result = await svc.getSchedules(2, {
+				fromCache: true,
+				mode: 'weekly' as any,
+			})
+			expect(result).toBeDefined()
+			expect(result?.weekly?.slots?.length).toBe(1)
+		})
+	})
+
+	describe('setSchedule – updates existing slot', () => {
+		it('updates an existing slot in the schedule on success', async () => {
+			const zwaveNode = createFakeZwaveNode(true)
+			const scheduleData = {
+				dayOfWeek: 3,
+				startHour: 10,
+				startMinute: 0,
+				stopHour: 18,
+				stopMinute: 0,
+			}
+			zwaveNode.commandClasses[
+				'Schedule Entry Lock'
+			].setWeekDaySchedule.mockResolvedValue({
+				status: SupervisionStatus.Success,
+			})
+
+			const nodeStore = createNodeStorePort({
+				id: 2,
+				schedule: {
+					daily: { numSlots: 0, slots: [] },
+					weekly: {
+						numSlots: 1,
+						slots: [
+							{
+								userId: 1,
+								slotId: 1,
+								dayOfWeek: 1,
+								startHour: 8,
+								startMinute: 0,
+								stopHour: 17,
+								stopMinute: 0,
+								enabled: true,
+							} as any,
+						],
+					},
+					yearly: { numSlots: 0, slots: [] },
+				},
+				userCodes: { total: 1, available: [1], enabled: [1] },
+			})
+			const svc = new ScheduleService(
+				createDriverPort(zwaveNode),
+				nodeStore,
+				createUtilsPort(),
+			)
+
+			const result = await svc.setSchedule(2, 'weekly', {
+				userId: 1,
+				slotId: 1,
+				...scheduleData,
+			} as any)
+
+			expect(result?.status).toBe(SupervisionStatus.Success)
+			// The existing slot should be updated
+			const node = nodeStore.getNode(2)
+			expect(node?.schedule?.weekly?.slots?.length).toBe(1)
+			expect((node?.schedule?.weekly?.slots?.[0] as any)?.dayOfWeek).toBe(
+				3,
+			)
+		})
+	})
+
+	describe('setSchedule – no schedule on node', () => {
+		it('returns result when node has no schedule object', async () => {
+			const zwaveNode = createFakeZwaveNode(true)
+			zwaveNode.commandClasses[
+				'Schedule Entry Lock'
+			].setWeekDaySchedule.mockResolvedValue({
+				status: SupervisionStatus.Success,
+			})
+
+			const nodeStore = createNodeStorePort({
+				id: 2,
+				schedule: undefined,
+				userCodes: undefined,
+			})
+			const svc = new ScheduleService(
+				createDriverPort(zwaveNode),
+				nodeStore,
+				createUtilsPort(),
+			)
+
+			const result = await svc.setSchedule(2, 'weekly', {
+				userId: 1,
+				slotId: 1,
+				dayOfWeek: 1,
+				startHour: 8,
+				startMinute: 0,
+				stopHour: 17,
+				stopMinute: 0,
+			} as any)
+
+			expect(result?.status).toBe(SupervisionStatus.Success)
+		})
+	})
+
+	describe('setEnabledSchedule – no userCodes', () => {
+		it('does not throw when node has no userCodes', async () => {
+			const zwaveNode = createFakeZwaveNode(true)
+			zwaveNode.commandClasses[
+				'Schedule Entry Lock'
+			].setEnabled.mockResolvedValue(undefined)
+
+			const nodeStore = createNodeStorePort({
+				id: 2,
+				userCodes: undefined,
+			})
+			const svc = new ScheduleService(
+				createDriverPort(zwaveNode),
+				nodeStore,
+				createUtilsPort(),
+			)
+
+			await svc.setEnabledSchedule(2, true, 1)
+			// Should not throw
+		})
+	})
+})

--- a/test/lib/zwave/ScheduleService.test.ts
+++ b/test/lib/zwave/ScheduleService.test.ts
@@ -864,44 +864,6 @@ describe('ScheduleService', () => {
 
 			expect(emittedNode.userCodes?.total).toBe(0)
 		})
-
-		it('populates slot counts when userCodes is null (upstream permits)', async () => {
-			const zwaveNode = createFakeZwaveNode(true)
-			const driverPort = createDriverPort(zwaveNode)
-			const nodeStore = createNodeStorePort()
-			const svc = new ScheduleService(
-				driverPort,
-				nodeStore,
-				createUtilsPort(),
-			)
-
-			const { UserCodeCC } = await import('zwave-js')
-			vi.spyOn(UserCodeCC, 'getSupportedUsersCached').mockReturnValue(
-				null as unknown as number,
-			)
-			const { ScheduleEntryLockCC } = await import('zwave-js')
-			vi.spyOn(
-				ScheduleEntryLockCC,
-				'getNumWeekDaySlotsCached',
-			).mockReturnValue(2)
-			vi.spyOn(
-				ScheduleEntryLockCC,
-				'getNumYearDaySlotsCached',
-			).mockReturnValue(1)
-			vi.spyOn(
-				ScheduleEntryLockCC,
-				'getNumDailyRepeatingSlotsCached',
-			).mockReturnValue(0)
-
-			const result = await svc.getSchedules(2)
-
-			expect(result).toBeDefined()
-			expect(result?.weekly?.numSlots).toBe(2)
-			expect(result?.yearly?.numSlots).toBe(1)
-			expect(result?.daily?.numSlots).toBe(0)
-
-			expect(nodeStore.emitCalls.length).toBe(1)
-		})
 	})
 
 	describe('getSchedules – mode filtering', () => {

--- a/test/lib/zwave/ScheduleService.test.ts
+++ b/test/lib/zwave/ScheduleService.test.ts
@@ -19,10 +19,6 @@ import type {
 	ScheduleNodeState,
 } from '../../../api/lib/zwave/ports.ts'
 
-// ---------------------------------------------------------------------------
-// Helpers: minimal fakes for ports
-// ---------------------------------------------------------------------------
-
 function createFakeEndpoint() {
 	return { id: 0 }
 }
@@ -86,7 +82,6 @@ function createUtilsPort(): ScheduleUtilsPort {
 	}
 }
 
-// Stub out the CC statics so we don't need a real driver
 async function stubCCStatics(
 	overrides: Partial<{
 		supportedUsers: number | undefined
@@ -111,7 +106,6 @@ async function stubCCStatics(
 		cachedSchedules = {},
 	} = overrides
 
-	// We need to mock static methods on the CC classes
 	const { UserCodeCC, ScheduleEntryLockCC } = await import('zwave-js')
 
 	vi.spyOn(UserCodeCC, 'getSupportedUsersCached').mockReturnValue(
@@ -151,7 +145,6 @@ async function stubCCStatics(
 	return { UserCodeCC, ScheduleEntryLockCC }
 }
 
-// Production-valid typed payloads per upstream zwave-js types
 const weeklyPayload: ScheduleEntryLockWeekDaySchedule = {
 	weekday: ScheduleEntryLockWeekday.Monday,
 	startHour: 8,
@@ -180,10 +173,6 @@ const yearlyPayload: ScheduleEntryLockYearDaySchedule = {
 	stopHour: 18,
 	stopMinute: 0,
 }
-
-// ---------------------------------------------------------------------------
-// Tests
-// ---------------------------------------------------------------------------
 
 describe('ScheduleService', () => {
 	beforeEach(() => {
@@ -237,12 +226,9 @@ describe('ScheduleService', () => {
 				createUtilsPort(),
 			)
 
-			// Stub CC statics to return 0 users so the first call resolves quickly
 			await stubCCStatics({ supportedUsers: 0 })
 
-			// Start a long request
 			const p1 = svc.getSchedules(2)
-			// A second one should throw
 			await expect(svc.getSchedules(2)).rejects.toThrow(
 				'Another request is in progress',
 			)
@@ -299,7 +285,6 @@ describe('ScheduleService', () => {
 			expect(result?.weekly?.numSlots).toBe(1)
 			expect(result?.daily?.numSlots).toBe(1)
 			expect(result?.yearly?.numSlots).toBe(1)
-			// Verify lock is released
 			expect(svc.lockGetSchedule).toBe(false)
 		})
 
@@ -362,9 +347,7 @@ describe('ScheduleService', () => {
 		it('sets a weekly schedule, calls setWeekDaySchedule, and verifies success via readback', async () => {
 			const zwaveNode = createFakeZwaveNode(true)
 			const cc = zwaveNode.commandClasses['Schedule Entry Lock']
-			// setWeekDaySchedule returns undefined (no supervision)
 			cc.setWeekDaySchedule.mockResolvedValue(undefined)
-			// readback returns matching data
 			cc.getWeekDaySchedule.mockResolvedValue(weeklyPayload)
 
 			const nodeStore = createNodeStorePort({
@@ -391,7 +374,6 @@ describe('ScheduleService', () => {
 			expect(result?.status).toBe(SupervisionStatus.Success)
 			expect(nodeStore.emitCalls.length).toBeGreaterThan(0)
 
-			// Exact upstream method used
 			expect(cc.setWeekDaySchedule).toHaveBeenCalledWith(
 				{ userId: 1, slotId: 1 },
 				weeklyPayload,
@@ -401,10 +383,8 @@ describe('ScheduleService', () => {
 				slotId: 1,
 			})
 
-			// Other mode writers NOT called
 			expect(cc.setYearDaySchedule).not.toHaveBeenCalled()
 			expect(cc.setDailyRepeatingSchedule).not.toHaveBeenCalled()
-			// Other mode readers NOT called
 			expect(cc.getYearDaySchedule).not.toHaveBeenCalled()
 			expect(cc.getDailyRepeatingSchedule).not.toHaveBeenCalled()
 		})
@@ -413,7 +393,6 @@ describe('ScheduleService', () => {
 			const zwaveNode = createFakeZwaveNode(true)
 			const cc = zwaveNode.commandClasses['Schedule Entry Lock']
 			cc.setWeekDaySchedule.mockResolvedValue(undefined)
-			// readback returns undefined (deleted)
 			cc.getWeekDaySchedule.mockResolvedValue(undefined)
 
 			const existingSlot: ScheduleEntryLockSlotId &
@@ -481,13 +460,11 @@ describe('ScheduleService', () => {
 
 			expect(result?.status).toBe(SupervisionStatus.Success)
 
-			// Exact upstream method used
 			expect(cc.setDailyRepeatingSchedule).toHaveBeenCalledWith(
 				{ userId: 1, slotId: 1 },
 				dailyPayload,
 			)
 
-			// Other mode writers/readers NOT called
 			expect(cc.setWeekDaySchedule).not.toHaveBeenCalled()
 			expect(cc.setYearDaySchedule).not.toHaveBeenCalled()
 			expect(cc.getWeekDaySchedule).not.toHaveBeenCalled()
@@ -705,13 +682,11 @@ describe('ScheduleService', () => {
 
 			expect(result?.status).toBe(SupervisionStatus.Success)
 
-			// Exact upstream method used
 			expect(cc.setYearDaySchedule).toHaveBeenCalledWith(
 				{ userId: 1, slotId: 1 },
 				yearlyPayload,
 			)
 
-			// Other mode writers/readers NOT called
 			expect(cc.setWeekDaySchedule).not.toHaveBeenCalled()
 			expect(cc.setDailyRepeatingSchedule).not.toHaveBeenCalled()
 			expect(cc.getWeekDaySchedule).not.toHaveBeenCalled()
@@ -725,7 +700,6 @@ describe('ScheduleService', () => {
 			const zwaveNode = createFakeZwaveNode(true)
 			const cc = zwaveNode.commandClasses['Schedule Entry Lock']
 			cc.setWeekDaySchedule.mockResolvedValue(undefined)
-			// Readback returns different data
 			cc.getWeekDaySchedule.mockResolvedValue({
 				weekday: ScheduleEntryLockWeekday.Saturday,
 				startHour: 0,
@@ -782,7 +756,6 @@ describe('ScheduleService', () => {
 				},
 			})
 
-			// Get from device (not cache), mock getWeekDaySchedule to set cancel
 			zwaveNode.commandClasses[
 				'Schedule Entry Lock'
 			].getWeekDaySchedule.mockImplementation(() => {
@@ -794,7 +767,6 @@ describe('ScheduleService', () => {
 				fromCache: false,
 			})
 			expect(result).toBeUndefined()
-			// Lock is released
 			expect(svc.lockGetSchedule).toBe(false)
 		})
 	})
@@ -819,17 +791,14 @@ describe('ScheduleService', () => {
 
 			const result = await svc.getSchedules(2)
 
-			// Must return node.schedule, not undefined
 			expect(result).toBeDefined()
 			expect(result?.weekly?.numSlots).toBe(3)
 			expect(result?.yearly?.numSlots).toBe(2)
 			expect(result?.daily?.numSlots).toBe(1)
-			// Slots are empty (zero user iterations)
 			expect(result?.weekly?.slots).toEqual([])
 			expect(result?.yearly?.slots).toEqual([])
 			expect(result?.daily?.slots).toEqual([])
 
-			// emitNodeUpdate must have been called exactly once
 			expect(nodeStore.emitCalls.length).toBe(1)
 			const [emittedNode, emittedProps] = nodeStore.emitCalls[0] as [
 				ScheduleNodeState,
@@ -839,10 +808,8 @@ describe('ScheduleService', () => {
 			expect(emittedProps).toHaveProperty('schedule')
 			expect(emittedProps).toHaveProperty('userCodes')
 
-			// userCodes.total should be 0 (null ?? 0)
 			expect(emittedNode.userCodes?.total).toBe(0)
 
-			// Lock is released
 			expect(svc.lockGetSchedule).toBe(false)
 		})
 
@@ -876,13 +843,11 @@ describe('ScheduleService', () => {
 
 			const result = await svc.getSchedules(2)
 
-			// Must return schedule (not undefined)
 			expect(result).toBeDefined()
 			expect(result?.weekly?.numSlots).toBe(2)
 			expect(result?.yearly?.numSlots).toBe(1)
 			expect(result?.daily?.numSlots).toBe(0)
 
-			// Node update emitted
 			expect(nodeStore.emitCalls.length).toBe(1)
 			expect(svc.lockGetSchedule).toBe(false)
 		})
@@ -973,7 +938,6 @@ describe('ScheduleService', () => {
 			} as ScheduleEntryLockSlotId & ScheduleEntryLockWeekDaySchedule)
 
 			expect(result?.status).toBe(SupervisionStatus.Success)
-			// The existing slot should be updated
 			const node = nodeStore.getNode(2)
 			expect(node?.schedule?.weekly?.slots?.length).toBe(1)
 			const slot = node?.schedule?.weekly?.slots?.[0]
@@ -1030,7 +994,6 @@ describe('ScheduleService', () => {
 			)
 
 			await svc.setEnabledSchedule(2, true, 1)
-			// Should not throw
 		})
 	})
 })

--- a/test/lib/zwave/ScheduleService.test.ts
+++ b/test/lib/zwave/ScheduleService.test.ts
@@ -179,30 +179,6 @@ describe('ScheduleService', () => {
 		vi.restoreAllMocks()
 	})
 
-	describe('construction and initial state', () => {
-		it('starts with lock=false and cancel=false', () => {
-			const svc = new ScheduleService(
-				createDriverPort(),
-				createNodeStorePort(),
-				createUtilsPort(),
-			)
-			expect(svc.lockGetSchedule).toBe(false)
-			expect(svc.cancelGetScheduleFlag).toBe(false)
-		})
-	})
-
-	describe('cancelGetSchedule', () => {
-		it('sets the cancel flag', () => {
-			const svc = new ScheduleService(
-				createDriverPort(),
-				createNodeStorePort(),
-				createUtilsPort(),
-			)
-			svc.cancelGetSchedule()
-			expect(svc.cancelGetScheduleFlag).toBe(true)
-		})
-	})
-
 	describe('getSchedules', () => {
 		it('throws if Schedule Entry Lock CC is not supported', async () => {
 			const zwaveNode = createFakeZwaveNode(false)
@@ -229,10 +205,17 @@ describe('ScheduleService', () => {
 			await stubCCStatics({ supportedUsers: 0 })
 
 			const p1 = svc.getSchedules(2)
+
+			// Consumer-observable lock state while request is in-flight
+			expect(svc.lockGetSchedule).toBe(true)
+
 			await expect(svc.getSchedules(2)).rejects.toThrow(
 				'Another request is in progress',
 			)
 			await p1
+
+			// Lock released after completion
+			expect(svc.lockGetSchedule).toBe(false)
 		})
 
 		it('returns undefined if node is not in store', async () => {
@@ -285,14 +268,11 @@ describe('ScheduleService', () => {
 			expect(result?.weekly?.numSlots).toBe(1)
 			expect(result?.daily?.numSlots).toBe(1)
 			expect(result?.yearly?.numSlots).toBe(1)
-			expect(svc.lockGetSchedule).toBe(false)
 		})
 
-		it('releases lock even if promise rejects', async () => {
+		it('allows a subsequent getSchedules call after a rejection', async () => {
 			const zwaveNode = createFakeZwaveNode(true)
-			const driverPort: ScheduleDriverPort = {
-				getDriver: () => null, // will cause NPE inside
-			}
+			const driverPort = createDriverPort(zwaveNode)
 			const nodeStore = createNodeStorePort()
 			const svc = new ScheduleService(
 				driverPort,
@@ -300,9 +280,18 @@ describe('ScheduleService', () => {
 				createUtilsPort(),
 			)
 
+			// First call: force a throw inside by returning null driver
+			const getDriverImpl = driverPort.getDriver.bind(driverPort)
+			driverPort.getDriver = () => null
+
+			await stubCCStatics({ supportedUsers: 0 })
+
 			await expect(svc.getSchedules(2)).rejects.toThrow()
-			expect(svc.lockGetSchedule).toBe(false)
-			expect(svc.cancelGetScheduleFlag).toBe(false)
+
+			// Recovery: restore driver, subsequent call succeeds (no concurrency rejection)
+			driverPort.getDriver = getDriverImpl
+			const result = await svc.getSchedules(2, { fromCache: true })
+			expect(result).toBeDefined()
 		})
 	})
 
@@ -582,72 +571,142 @@ describe('ScheduleService', () => {
 		})
 	})
 
-	describe('_pushSchedule (static)', () => {
-		it('updates an existing slot in place', () => {
-			const arr: (ScheduleEntryLockSlotId &
-				ScheduleEntryLockWeekDaySchedule & { enabled: boolean })[] = [
-				{
-					userId: 1,
-					slotId: 1,
-					weekday: ScheduleEntryLockWeekday.Monday,
-					startHour: 8,
-					startMinute: 0,
-					stopHour: 17,
-					stopMinute: 0,
-					enabled: false,
+	describe('getSchedules – slot management via cache', () => {
+		it('adds a new cached slot to the returned schedule', async () => {
+			const zwaveNode = createFakeZwaveNode(true)
+			const driverPort = createDriverPort(zwaveNode)
+			const nodeStore = createNodeStorePort()
+			const svc = new ScheduleService(
+				driverPort,
+				nodeStore,
+				createUtilsPort(),
+			)
+
+			await stubCCStatics({
+				supportedUsers: 1,
+				numWeekDaySlots: 1,
+				numYearDaySlots: 0,
+				numDailyRepeatingSlots: 0,
+				userIdStatuses: { 1: 1 },
+				scheduleEnabled: { 1: true },
+				scheduleKind: {
+					1: ScheduleEntryLockScheduleKind.WeekDay,
 				},
-			]
-			const updated: ScheduleEntryLockWeekDaySchedule = {
-				weekday: ScheduleEntryLockWeekday.Tuesday,
-				startHour: 9,
+				cachedSchedules: {
+					[`${ScheduleEntryLockScheduleKind.WeekDay}-1-1`]:
+						weeklyPayload,
+				},
+			})
+
+			const result = await svc.getSchedules(2, { fromCache: true })
+
+			expect(result?.weekly?.slots?.length).toBe(1)
+			const slot = result?.weekly?.slots?.[0]
+			expect(slot?.userId).toBe(1)
+			expect(slot?.slotId).toBe(1)
+			expect(slot?.weekday).toBe(ScheduleEntryLockWeekday.Monday)
+			expect(slot?.startHour).toBe(8)
+		})
+
+		it('replaces an existing slot with the same userId/slotId on cache refresh', async () => {
+			const zwaveNode = createFakeZwaveNode(true)
+			const driverPort = createDriverPort(zwaveNode)
+
+			const existingSlot = {
+				userId: 1,
+				slotId: 1,
+				weekday: ScheduleEntryLockWeekday.Saturday,
+				startHour: 0,
 				startMinute: 0,
-				stopHour: 18,
+				stopHour: 1,
 				stopMinute: 0,
+				enabled: true,
 			}
-			ScheduleService._pushSchedule(
-				arr,
-				{ userId: 1, slotId: 1 },
-				updated,
-				true,
-			)
-			expect(arr.length).toBe(1)
-			expect(arr[0].weekday).toBe(ScheduleEntryLockWeekday.Tuesday)
-			expect(arr[0].enabled).toBe(true)
-		})
-
-		it('removes a slot when schedule is undefined and slot exists', () => {
-			const arr: (ScheduleEntryLockSlotId &
-				ScheduleEntryLockWeekDaySchedule & { enabled: boolean })[] = [
-				{
-					userId: 1,
-					slotId: 1,
-					weekday: ScheduleEntryLockWeekday.Monday,
-					startHour: 8,
-					startMinute: 0,
-					stopHour: 17,
-					stopMinute: 0,
-					enabled: true,
+			const nodeStore = createNodeStorePort({
+				id: 2,
+				schedule: {
+					daily: { numSlots: 0, slots: [] },
+					weekly: { numSlots: 1, slots: [existingSlot] },
+					yearly: { numSlots: 0, slots: [] },
 				},
-			]
-			ScheduleService._pushSchedule(
-				arr,
-				{ userId: 1, slotId: 1 },
-				undefined,
-				false,
+				userCodes: undefined,
+			})
+			const svc = new ScheduleService(
+				driverPort,
+				nodeStore,
+				createUtilsPort(),
 			)
-			expect(arr.length).toBe(0)
+
+			await stubCCStatics({
+				supportedUsers: 1,
+				numWeekDaySlots: 1,
+				numYearDaySlots: 0,
+				numDailyRepeatingSlots: 0,
+				userIdStatuses: { 1: 1 },
+				scheduleEnabled: { 1: true },
+				scheduleKind: {
+					1: ScheduleEntryLockScheduleKind.WeekDay,
+				},
+				cachedSchedules: {
+					[`${ScheduleEntryLockScheduleKind.WeekDay}-1-1`]:
+						weeklyPayload,
+				},
+			})
+
+			const result = await svc.getSchedules(2, { fromCache: true })
+
+			expect(result?.weekly?.slots?.length).toBe(1)
+			const slot = result?.weekly?.slots?.[0]
+			expect(slot?.weekday).toBe(ScheduleEntryLockWeekday.Monday)
+			expect(slot?.startHour).toBe(8)
+			expect(slot?.stopHour).toBe(17)
 		})
 
-		it('does nothing when schedule is undefined and slot does not exist', () => {
-			const arr: (ScheduleEntryLockSlotId &
-				ScheduleEntryLockWeekDaySchedule & { enabled: boolean })[] = []
-			ScheduleService._pushSchedule(
-				arr,
-				{ userId: 1, slotId: 1 },
-				undefined,
-				false,
+		it('removes an existing slot when cache returns undefined', async () => {
+			const zwaveNode = createFakeZwaveNode(true)
+			const driverPort = createDriverPort(zwaveNode)
+
+			const existingSlot = {
+				userId: 1,
+				slotId: 1,
+				weekday: ScheduleEntryLockWeekday.Monday,
+				startHour: 8,
+				startMinute: 0,
+				stopHour: 17,
+				stopMinute: 0,
+				enabled: true,
+			}
+			const nodeStore = createNodeStorePort({
+				id: 2,
+				schedule: {
+					daily: { numSlots: 0, slots: [] },
+					weekly: { numSlots: 1, slots: [existingSlot] },
+					yearly: { numSlots: 0, slots: [] },
+				},
+				userCodes: undefined,
+			})
+			const svc = new ScheduleService(
+				driverPort,
+				nodeStore,
+				createUtilsPort(),
 			)
-			expect(arr.length).toBe(0)
+
+			await stubCCStatics({
+				supportedUsers: 1,
+				numWeekDaySlots: 1,
+				numYearDaySlots: 0,
+				numDailyRepeatingSlots: 0,
+				userIdStatuses: { 1: 1 },
+				scheduleEnabled: { 1: true },
+				scheduleKind: {
+					1: ScheduleEntryLockScheduleKind.WeekDay,
+				},
+				cachedSchedules: {},
+			})
+
+			const result = await svc.getSchedules(2, { fromCache: true })
+
+			expect(result?.weekly?.slots?.length).toBe(0)
 		})
 	})
 
@@ -760,6 +819,8 @@ describe('ScheduleService', () => {
 				'Schedule Entry Lock'
 			].getWeekDaySchedule.mockImplementation(() => {
 				svc.cancelGetSchedule()
+				// Consumer-observable: flag reflects active cancellation
+				expect(svc.cancelGetScheduleFlag).toBe(true)
 				return Promise.resolve(weeklyPayload)
 			})
 
@@ -767,7 +828,11 @@ describe('ScheduleService', () => {
 				fromCache: false,
 			})
 			expect(result).toBeUndefined()
-			expect(svc.lockGetSchedule).toBe(false)
+
+			// Recovery: subsequent call does not throw concurrency rejection
+			await stubCCStatics({ supportedUsers: 0 })
+			const result2 = await svc.getSchedules(2, { fromCache: true })
+			expect(result2).toBeDefined()
 		})
 	})
 
@@ -809,8 +874,6 @@ describe('ScheduleService', () => {
 			expect(emittedProps).toHaveProperty('userCodes')
 
 			expect(emittedNode.userCodes?.total).toBe(0)
-
-			expect(svc.lockGetSchedule).toBe(false)
 		})
 
 		it('populates slot counts when userCodes is null (upstream permits)', async () => {
@@ -849,7 +912,6 @@ describe('ScheduleService', () => {
 			expect(result?.daily?.numSlots).toBe(0)
 
 			expect(nodeStore.emitCalls.length).toBe(1)
-			expect(svc.lockGetSchedule).toBe(false)
 		})
 	})
 

--- a/test/lib/zwave/ScheduleService.test.ts
+++ b/test/lib/zwave/ScheduleService.test.ts
@@ -579,7 +579,7 @@ describe('ScheduleService', () => {
 				numWeekDaySlots: 1,
 				numYearDaySlots: 0,
 				numDailyRepeatingSlots: 0,
-				userIdStatuses: { 1: 1 },
+				userIdStatuses: { 1: UserIDStatus.Enabled },
 				scheduleEnabled: { 1: true },
 				scheduleKind: {
 					1: ScheduleEntryLockScheduleKind.WeekDay,
@@ -634,7 +634,7 @@ describe('ScheduleService', () => {
 				numWeekDaySlots: 1,
 				numYearDaySlots: 0,
 				numDailyRepeatingSlots: 0,
-				userIdStatuses: { 1: 1 },
+				userIdStatuses: { 1: UserIDStatus.Enabled },
 				scheduleEnabled: { 1: true },
 				scheduleKind: {
 					1: ScheduleEntryLockScheduleKind.WeekDay,
@@ -688,7 +688,7 @@ describe('ScheduleService', () => {
 				numWeekDaySlots: 1,
 				numYearDaySlots: 0,
 				numDailyRepeatingSlots: 0,
-				userIdStatuses: { 1: 1 },
+				userIdStatuses: { 1: UserIDStatus.Enabled },
 				scheduleEnabled: { 1: true },
 				scheduleKind: {
 					1: ScheduleEntryLockScheduleKind.WeekDay,
@@ -800,7 +800,7 @@ describe('ScheduleService', () => {
 				numWeekDaySlots: 2,
 				numYearDaySlots: 0,
 				numDailyRepeatingSlots: 0,
-				userIdStatuses: { 1: 1 },
+				userIdStatuses: { 1: UserIDStatus.Enabled },
 				scheduleEnabled: { 1: true },
 				scheduleKind: {
 					1: ScheduleEntryLockScheduleKind.WeekDay,
@@ -882,7 +882,7 @@ describe('ScheduleService', () => {
 				numWeekDaySlots: 1,
 				numYearDaySlots: 1,
 				numDailyRepeatingSlots: 1,
-				userIdStatuses: { 1: 1 },
+				userIdStatuses: { 1: UserIDStatus.Enabled },
 				scheduleEnabled: { 1: true },
 				scheduleKind: {
 					1: ScheduleEntryLockScheduleKind.WeekDay,

--- a/test/lib/zwave/ScheduleService.test.ts
+++ b/test/lib/zwave/ScheduleService.test.ts
@@ -206,16 +206,10 @@ describe('ScheduleService', () => {
 
 			const p1 = svc.getSchedules(2)
 
-			// Consumer-observable lock state while request is in-flight
-			expect(svc.lockGetSchedule).toBe(true)
-
 			await expect(svc.getSchedules(2)).rejects.toThrow(
 				'Another request is in progress',
 			)
 			await p1
-
-			// Lock released after completion
-			expect(svc.lockGetSchedule).toBe(false)
 		})
 
 		it('returns undefined if node is not in store', async () => {
@@ -252,7 +246,7 @@ describe('ScheduleService', () => {
 				numWeekDaySlots: 1,
 				numYearDaySlots: 1,
 				numDailyRepeatingSlots: 1,
-				userIdStatuses: { 1: 1 /* Enabled */ },
+				userIdStatuses: { 1: UserIDStatus.Enabled },
 				scheduleEnabled: { 1: true },
 				scheduleKind: {
 					1: ScheduleEntryLockScheduleKind.WeekDay,
@@ -280,7 +274,6 @@ describe('ScheduleService', () => {
 				createUtilsPort(),
 			)
 
-			// First call: force a throw inside by returning null driver
 			const getDriverImpl = driverPort.getDriver.bind(driverPort)
 			driverPort.getDriver = () => null
 
@@ -288,7 +281,6 @@ describe('ScheduleService', () => {
 
 			await expect(svc.getSchedules(2)).rejects.toThrow()
 
-			// Recovery: restore driver, subsequent call succeeds (no concurrency rejection)
 			driverPort.getDriver = getDriverImpl
 			const result = await svc.getSchedules(2, { fromCache: true })
 			expect(result).toBeDefined()
@@ -819,8 +811,6 @@ describe('ScheduleService', () => {
 				'Schedule Entry Lock'
 			].getWeekDaySchedule.mockImplementation(() => {
 				svc.cancelGetSchedule()
-				// Consumer-observable: flag reflects active cancellation
-				expect(svc.cancelGetScheduleFlag).toBe(true)
 				return Promise.resolve(weeklyPayload)
 			})
 
@@ -829,7 +819,6 @@ describe('ScheduleService', () => {
 			})
 			expect(result).toBeUndefined()
 
-			// Recovery: subsequent call does not throw concurrency rejection
 			await stubCCStatics({ supportedUsers: 0 })
 			const result2 = await svc.getSchedules(2, { fromCache: true })
 			expect(result2).toBeDefined()

--- a/test/lib/zwave/ScheduleService.test.ts
+++ b/test/lib/zwave/ScheduleService.test.ts
@@ -1045,6 +1045,31 @@ describe('ScheduleService', () => {
 			)
 
 			await svc.setEnabledSchedule(2, true, 1)
+			expect(nodeStore.emitCalls).toEqual([
+				[expect.objectContaining({ id: 2 }), { userCodes: undefined }],
+			])
+		})
+
+		it('rejects an all-users update when node has no userCodes', async () => {
+			const zwaveNode = createFakeZwaveNode(true)
+			zwaveNode.commandClasses[
+				'Schedule Entry Lock'
+			].setEnabled.mockResolvedValue(undefined)
+
+			const nodeStore = createNodeStorePort({
+				id: 2,
+				userCodes: undefined,
+			})
+			const svc = new ScheduleService(
+				createDriverPort(zwaveNode),
+				nodeStore,
+				createUtilsPort(),
+			)
+
+			await expect(svc.setEnabledSchedule(2, true, 0)).rejects.toThrow(
+				"Cannot read properties of undefined (reading 'available')",
+			)
+			expect(nodeStore.emitCalls).toEqual([])
 		})
 	})
 })

--- a/test/lib/zwave/ScheduleService.test.ts
+++ b/test/lib/zwave/ScheduleService.test.ts
@@ -1,7 +1,17 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { ScheduleService } from '../../../api/lib/zwave/ScheduleService.ts'
 import { SupervisionStatus } from '@zwave-js/core'
-import { ScheduleEntryLockScheduleKind, UserIDStatus } from 'zwave-js'
+import {
+	ScheduleEntryLockScheduleKind,
+	ScheduleEntryLockWeekday,
+	UserIDStatus,
+} from 'zwave-js'
+import type {
+	ScheduleEntryLockDailyRepeatingSchedule,
+	ScheduleEntryLockWeekDaySchedule,
+	ScheduleEntryLockYearDaySchedule,
+	ScheduleEntryLockSlotId,
+} from 'zwave-js'
 import type {
 	ScheduleDriverPort,
 	ScheduleNodeStorePort,
@@ -50,7 +60,7 @@ function createDriverPort(
 						),
 					},
 				},
-			}) as any,
+			}) as ReturnType<ScheduleDriverPort['getDriver']>,
 	}
 }
 
@@ -79,7 +89,7 @@ function createUtilsPort(): ScheduleUtilsPort {
 // Stub out the CC statics so we don't need a real driver
 async function stubCCStatics(
 	overrides: Partial<{
-		supportedUsers: number
+		supportedUsers: number | undefined
 		numWeekDaySlots: number
 		numYearDaySlots: number
 		numDailyRepeatingSlots: number
@@ -89,8 +99,9 @@ async function stubCCStatics(
 		cachedSchedules: Record<string, unknown>
 	}> = {},
 ) {
+	const supportedUsers =
+		'supportedUsers' in overrides ? overrides.supportedUsers : 2
 	const {
-		supportedUsers = 2,
 		numWeekDaySlots = 1,
 		numYearDaySlots = 1,
 		numDailyRepeatingSlots = 1,
@@ -138,6 +149,36 @@ async function stubCCStatics(
 	)
 
 	return { UserCodeCC, ScheduleEntryLockCC }
+}
+
+// Production-valid typed payloads per upstream zwave-js types
+const weeklyPayload: ScheduleEntryLockWeekDaySchedule = {
+	weekday: ScheduleEntryLockWeekday.Monday,
+	startHour: 8,
+	startMinute: 0,
+	stopHour: 17,
+	stopMinute: 0,
+}
+
+const dailyPayload: ScheduleEntryLockDailyRepeatingSchedule = {
+	weekdays: [ScheduleEntryLockWeekday.Sunday],
+	startHour: 6,
+	startMinute: 30,
+	durationHour: 2,
+	durationMinute: 0,
+}
+
+const yearlyPayload: ScheduleEntryLockYearDaySchedule = {
+	startYear: 2025,
+	startMonth: 6,
+	startDay: 15,
+	startHour: 9,
+	startMinute: 0,
+	stopYear: 2025,
+	stopMonth: 6,
+	stopDay: 15,
+	stopHour: 18,
+	stopMinute: 0,
 }
 
 // ---------------------------------------------------------------------------
@@ -248,13 +289,8 @@ describe('ScheduleService', () => {
 					1: ScheduleEntryLockScheduleKind.WeekDay,
 				},
 				cachedSchedules: {
-					[`${ScheduleEntryLockScheduleKind.WeekDay}-1-1`]: {
-						dayOfWeek: 1,
-						startHour: 8,
-						startMinute: 0,
-						stopHour: 17,
-						stopMinute: 0,
-					},
+					[`${ScheduleEntryLockScheduleKind.WeekDay}-1-1`]:
+						weeklyPayload,
 				},
 			})
 
@@ -297,12 +333,9 @@ describe('ScheduleService', () => {
 				svc.setSchedule(2, 'weekly', {
 					userId: 1,
 					slotId: 1,
-					dayOfWeek: 1,
-					startHour: 8,
-					startMinute: 0,
-					stopHour: 17,
-					stopMinute: 0,
-				} as any),
+					...weeklyPayload,
+				} as ScheduleEntryLockSlotId &
+					ScheduleEntryLockWeekDaySchedule),
 			).rejects.toThrow('Schedule Entry Lock CC not supported')
 		})
 
@@ -316,32 +349,23 @@ describe('ScheduleService', () => {
 			await expect(
 				svc.setSchedule(
 					2,
-					'invalid' as any,
+					'invalid' as 'daily',
 					{
 						userId: 1,
 						slotId: 1,
-					} as any,
+					} as ScheduleEntryLockSlotId &
+						ScheduleEntryLockDailyRepeatingSchedule,
 				),
 			).rejects.toThrow('Invalid schedule type')
 		})
 
-		it('sets a weekly schedule and verifies success via readback', async () => {
+		it('sets a weekly schedule, calls setWeekDaySchedule, and verifies success via readback', async () => {
 			const zwaveNode = createFakeZwaveNode(true)
-			const scheduleData = {
-				dayOfWeek: 1,
-				startHour: 8,
-				startMinute: 0,
-				stopHour: 17,
-				stopMinute: 0,
-			}
+			const cc = zwaveNode.commandClasses['Schedule Entry Lock']
 			// setWeekDaySchedule returns undefined (no supervision)
-			zwaveNode.commandClasses[
-				'Schedule Entry Lock'
-			].setWeekDaySchedule.mockResolvedValue(undefined)
+			cc.setWeekDaySchedule.mockResolvedValue(undefined)
 			// readback returns matching data
-			zwaveNode.commandClasses[
-				'Schedule Entry Lock'
-			].getWeekDaySchedule.mockResolvedValue(scheduleData)
+			cc.getWeekDaySchedule.mockResolvedValue(weeklyPayload)
 
 			const nodeStore = createNodeStorePort({
 				id: 2,
@@ -361,22 +385,44 @@ describe('ScheduleService', () => {
 			const result = await svc.setSchedule(2, 'weekly', {
 				userId: 1,
 				slotId: 1,
-				...scheduleData,
-			} as any)
+				...weeklyPayload,
+			} as ScheduleEntryLockSlotId & ScheduleEntryLockWeekDaySchedule)
 
 			expect(result?.status).toBe(SupervisionStatus.Success)
 			expect(nodeStore.emitCalls.length).toBeGreaterThan(0)
+
+			// Exact upstream method used
+			expect(cc.setWeekDaySchedule).toHaveBeenCalledWith(
+				{ userId: 1, slotId: 1 },
+				weeklyPayload,
+			)
+			expect(cc.getWeekDaySchedule).toHaveBeenCalledWith({
+				userId: 1,
+				slotId: 1,
+			})
+
+			// Other mode writers NOT called
+			expect(cc.setYearDaySchedule).not.toHaveBeenCalled()
+			expect(cc.setDailyRepeatingSchedule).not.toHaveBeenCalled()
+			// Other mode readers NOT called
+			expect(cc.getYearDaySchedule).not.toHaveBeenCalled()
+			expect(cc.getDailyRepeatingSchedule).not.toHaveBeenCalled()
 		})
 
 		it('handles delete (empty schedule) via readback', async () => {
 			const zwaveNode = createFakeZwaveNode(true)
-			zwaveNode.commandClasses[
-				'Schedule Entry Lock'
-			].setWeekDaySchedule.mockResolvedValue(undefined)
+			const cc = zwaveNode.commandClasses['Schedule Entry Lock']
+			cc.setWeekDaySchedule.mockResolvedValue(undefined)
 			// readback returns undefined (deleted)
-			zwaveNode.commandClasses[
-				'Schedule Entry Lock'
-			].getWeekDaySchedule.mockResolvedValue(undefined)
+			cc.getWeekDaySchedule.mockResolvedValue(undefined)
+
+			const existingSlot: ScheduleEntryLockSlotId &
+				ScheduleEntryLockWeekDaySchedule & { enabled: boolean } = {
+				userId: 1,
+				slotId: 1,
+				enabled: true,
+				...weeklyPayload,
+			}
 
 			const nodeStore = createNodeStorePort({
 				id: 2,
@@ -384,18 +430,7 @@ describe('ScheduleService', () => {
 					daily: { numSlots: 0, slots: [] },
 					weekly: {
 						numSlots: 1,
-						slots: [
-							{
-								userId: 1,
-								slotId: 1,
-								enabled: true,
-								dayOfWeek: 1,
-								startHour: 8,
-								startMinute: 0,
-								stopHour: 17,
-								stopMinute: 0,
-							} as any,
-						],
+						slots: [existingSlot],
 					},
 					yearly: { numSlots: 0, slots: [] },
 				},
@@ -410,16 +445,15 @@ describe('ScheduleService', () => {
 			const result = await svc.setSchedule(2, 'weekly', {
 				userId: 1,
 				slotId: 1,
-			} as any)
+			} as ScheduleEntryLockSlotId & ScheduleEntryLockWeekDaySchedule)
 
 			expect(result?.status).toBe(SupervisionStatus.Success)
 		})
 
-		it('returns supervision result directly when supervised', async () => {
+		it('returns supervision result directly when supervised (daily)', async () => {
 			const zwaveNode = createFakeZwaveNode(true)
-			zwaveNode.commandClasses[
-				'Schedule Entry Lock'
-			].setDailyRepeatingSchedule.mockResolvedValue({
+			const cc = zwaveNode.commandClasses['Schedule Entry Lock']
+			cc.setDailyRepeatingSchedule.mockResolvedValue({
 				status: SupervisionStatus.Success,
 			})
 
@@ -441,14 +475,24 @@ describe('ScheduleService', () => {
 			const result = await svc.setSchedule(2, 'daily', {
 				userId: 1,
 				slotId: 1,
-				weekday: 0,
-				startHour: 6,
-				startMinute: 30,
-				durationHour: 2,
-				durationMinute: 0,
-			} as any)
+				...dailyPayload,
+			} as ScheduleEntryLockSlotId &
+				ScheduleEntryLockDailyRepeatingSchedule)
 
 			expect(result?.status).toBe(SupervisionStatus.Success)
+
+			// Exact upstream method used
+			expect(cc.setDailyRepeatingSchedule).toHaveBeenCalledWith(
+				{ userId: 1, slotId: 1 },
+				dailyPayload,
+			)
+
+			// Other mode writers/readers NOT called
+			expect(cc.setWeekDaySchedule).not.toHaveBeenCalled()
+			expect(cc.setYearDaySchedule).not.toHaveBeenCalled()
+			expect(cc.getWeekDaySchedule).not.toHaveBeenCalled()
+			expect(cc.getYearDaySchedule).not.toHaveBeenCalled()
+			expect(cc.getDailyRepeatingSchedule).not.toHaveBeenCalled()
 		})
 	})
 
@@ -460,7 +504,7 @@ describe('ScheduleService', () => {
 						controller: {
 							nodes: { get: () => undefined },
 						},
-					}) as any,
+					}) as ReturnType<ScheduleDriverPort['getDriver']>,
 			}
 			const svc = new ScheduleService(
 				driverPort,
@@ -563,23 +607,50 @@ describe('ScheduleService', () => {
 
 	describe('_pushSchedule (static)', () => {
 		it('updates an existing slot in place', () => {
-			const arr: any[] = [
-				{ userId: 1, slotId: 1, dayOfWeek: 1, enabled: false },
+			const arr: (ScheduleEntryLockSlotId &
+				ScheduleEntryLockWeekDaySchedule & { enabled: boolean })[] = [
+				{
+					userId: 1,
+					slotId: 1,
+					weekday: ScheduleEntryLockWeekday.Monday,
+					startHour: 8,
+					startMinute: 0,
+					stopHour: 17,
+					stopMinute: 0,
+					enabled: false,
+				},
 			]
+			const updated: ScheduleEntryLockWeekDaySchedule = {
+				weekday: ScheduleEntryLockWeekday.Tuesday,
+				startHour: 9,
+				startMinute: 0,
+				stopHour: 18,
+				stopMinute: 0,
+			}
 			ScheduleService._pushSchedule(
 				arr,
 				{ userId: 1, slotId: 1 },
-				{ dayOfWeek: 2 } as any,
+				updated,
 				true,
 			)
 			expect(arr.length).toBe(1)
-			expect(arr[0].dayOfWeek).toBe(2)
+			expect(arr[0].weekday).toBe(ScheduleEntryLockWeekday.Tuesday)
 			expect(arr[0].enabled).toBe(true)
 		})
 
 		it('removes a slot when schedule is undefined and slot exists', () => {
-			const arr: any[] = [
-				{ userId: 1, slotId: 1, dayOfWeek: 1, enabled: true },
+			const arr: (ScheduleEntryLockSlotId &
+				ScheduleEntryLockWeekDaySchedule & { enabled: boolean })[] = [
+				{
+					userId: 1,
+					slotId: 1,
+					weekday: ScheduleEntryLockWeekday.Monday,
+					startHour: 8,
+					startMinute: 0,
+					stopHour: 17,
+					stopMinute: 0,
+					enabled: true,
+				},
 			]
 			ScheduleService._pushSchedule(
 				arr,
@@ -591,7 +662,8 @@ describe('ScheduleService', () => {
 		})
 
 		it('does nothing when schedule is undefined and slot does not exist', () => {
-			const arr: any[] = []
+			const arr: (ScheduleEntryLockSlotId &
+				ScheduleEntryLockWeekDaySchedule & { enabled: boolean })[] = []
 			ScheduleService._pushSchedule(
 				arr,
 				{ userId: 1, slotId: 1 },
@@ -603,11 +675,10 @@ describe('ScheduleService', () => {
 	})
 
 	describe('setSchedule – yearly', () => {
-		it('sets a yearly schedule via supervision', async () => {
+		it('sets a yearly schedule via supervision, does not call weekly/daily', async () => {
 			const zwaveNode = createFakeZwaveNode(true)
-			zwaveNode.commandClasses[
-				'Schedule Entry Lock'
-			].setYearDaySchedule.mockResolvedValue({
+			const cc = zwaveNode.commandClasses['Schedule Entry Lock']
+			cc.setYearDaySchedule.mockResolvedValue({
 				status: SupervisionStatus.Success,
 			})
 
@@ -629,34 +700,39 @@ describe('ScheduleService', () => {
 			const result = await svc.setSchedule(2, 'yearly', {
 				userId: 1,
 				slotId: 1,
-				startYear: 2025,
-				startMonth: 6,
-				startDay: 15,
-				startHour: 9,
-				startMinute: 0,
-				stopYear: 2025,
-				stopMonth: 6,
-				stopDay: 15,
-				stopHour: 18,
-				stopMinute: 0,
-			} as any)
+				...yearlyPayload,
+			} as ScheduleEntryLockSlotId & ScheduleEntryLockYearDaySchedule)
 
 			expect(result?.status).toBe(SupervisionStatus.Success)
+
+			// Exact upstream method used
+			expect(cc.setYearDaySchedule).toHaveBeenCalledWith(
+				{ userId: 1, slotId: 1 },
+				yearlyPayload,
+			)
+
+			// Other mode writers/readers NOT called
+			expect(cc.setWeekDaySchedule).not.toHaveBeenCalled()
+			expect(cc.setDailyRepeatingSchedule).not.toHaveBeenCalled()
+			expect(cc.getWeekDaySchedule).not.toHaveBeenCalled()
+			expect(cc.getDailyRepeatingSchedule).not.toHaveBeenCalled()
+			expect(cc.getYearDaySchedule).not.toHaveBeenCalled()
 		})
 	})
 
 	describe('setSchedule – readback mismatch', () => {
 		it('returns Fail when readback does not match', async () => {
 			const zwaveNode = createFakeZwaveNode(true)
-			zwaveNode.commandClasses[
-				'Schedule Entry Lock'
-			].setWeekDaySchedule.mockResolvedValue(undefined)
+			const cc = zwaveNode.commandClasses['Schedule Entry Lock']
+			cc.setWeekDaySchedule.mockResolvedValue(undefined)
 			// Readback returns different data
-			zwaveNode.commandClasses[
-				'Schedule Entry Lock'
-			].getWeekDaySchedule.mockResolvedValue({
-				dayOfWeek: 99,
-			})
+			cc.getWeekDaySchedule.mockResolvedValue({
+				weekday: ScheduleEntryLockWeekday.Saturday,
+				startHour: 0,
+				startMinute: 0,
+				stopHour: 0,
+				stopMinute: 0,
+			} satisfies ScheduleEntryLockWeekDaySchedule)
 
 			const nodeStore = createNodeStorePort({
 				id: 2,
@@ -676,12 +752,8 @@ describe('ScheduleService', () => {
 			const result = await svc.setSchedule(2, 'weekly', {
 				userId: 1,
 				slotId: 1,
-				dayOfWeek: 1,
-				startHour: 8,
-				startMinute: 0,
-				stopHour: 17,
-				stopMinute: 0,
-			} as any)
+				...weeklyPayload,
+			} as ScheduleEntryLockSlotId & ScheduleEntryLockWeekDaySchedule)
 
 			expect(result?.status).toBe(SupervisionStatus.Fail)
 		})
@@ -715,7 +787,7 @@ describe('ScheduleService', () => {
 				'Schedule Entry Lock'
 			].getWeekDaySchedule.mockImplementation(() => {
 				svc.cancelGetSchedule()
-				return Promise.resolve({ dayOfWeek: 1 })
+				return Promise.resolve(weeklyPayload)
 			})
 
 			const result = await svc.getSchedules(2, {
@@ -727,8 +799,54 @@ describe('ScheduleService', () => {
 		})
 	})
 
-	describe('getSchedules – returns undefined when userCodes is null', () => {
-		it('returns undefined when getSupportedUsersCached returns undefined', async () => {
+	describe('getSchedules – unknown userCodes', () => {
+		it('populates slot counts and emits node update when userCodes is undefined', async () => {
+			const zwaveNode = createFakeZwaveNode(true)
+			const driverPort = createDriverPort(zwaveNode)
+			const nodeStore = createNodeStorePort()
+			const svc = new ScheduleService(
+				driverPort,
+				nodeStore,
+				createUtilsPort(),
+			)
+
+			await stubCCStatics({
+				supportedUsers: undefined,
+				numWeekDaySlots: 3,
+				numYearDaySlots: 2,
+				numDailyRepeatingSlots: 1,
+			})
+
+			const result = await svc.getSchedules(2)
+
+			// Must return node.schedule, not undefined
+			expect(result).toBeDefined()
+			expect(result?.weekly?.numSlots).toBe(3)
+			expect(result?.yearly?.numSlots).toBe(2)
+			expect(result?.daily?.numSlots).toBe(1)
+			// Slots are empty (zero user iterations)
+			expect(result?.weekly?.slots).toEqual([])
+			expect(result?.yearly?.slots).toEqual([])
+			expect(result?.daily?.slots).toEqual([])
+
+			// emitNodeUpdate must have been called exactly once
+			expect(nodeStore.emitCalls.length).toBe(1)
+			const [emittedNode, emittedProps] = nodeStore.emitCalls[0] as [
+				ScheduleNodeState,
+				Record<string, unknown>,
+			]
+			expect(emittedNode.id).toBe(2)
+			expect(emittedProps).toHaveProperty('schedule')
+			expect(emittedProps).toHaveProperty('userCodes')
+
+			// userCodes.total should be 0 (null ?? 0)
+			expect(emittedNode.userCodes?.total).toBe(0)
+
+			// Lock is released
+			expect(svc.lockGetSchedule).toBe(false)
+		})
+
+		it('populates slot counts when userCodes is null (upstream permits)', async () => {
 			const zwaveNode = createFakeZwaveNode(true)
 			const driverPort = createDriverPort(zwaveNode)
 			const nodeStore = createNodeStorePort()
@@ -740,11 +858,32 @@ describe('ScheduleService', () => {
 
 			const { UserCodeCC } = await import('zwave-js')
 			vi.spyOn(UserCodeCC, 'getSupportedUsersCached').mockReturnValue(
-				undefined as any,
+				null as unknown as number,
 			)
+			const { ScheduleEntryLockCC } = await import('zwave-js')
+			vi.spyOn(
+				ScheduleEntryLockCC,
+				'getNumWeekDaySlotsCached',
+			).mockReturnValue(2)
+			vi.spyOn(
+				ScheduleEntryLockCC,
+				'getNumYearDaySlotsCached',
+			).mockReturnValue(1)
+			vi.spyOn(
+				ScheduleEntryLockCC,
+				'getNumDailyRepeatingSlotsCached',
+			).mockReturnValue(0)
 
 			const result = await svc.getSchedules(2)
-			expect(result).toBeUndefined()
+
+			// Must return schedule (not undefined)
+			expect(result).toBeDefined()
+			expect(result?.weekly?.numSlots).toBe(2)
+			expect(result?.yearly?.numSlots).toBe(1)
+			expect(result?.daily?.numSlots).toBe(0)
+
+			// Node update emitted
+			expect(nodeStore.emitCalls.length).toBe(1)
 			expect(svc.lockGetSchedule).toBe(false)
 		})
 	})
@@ -771,19 +910,14 @@ describe('ScheduleService', () => {
 					1: ScheduleEntryLockScheduleKind.WeekDay,
 				},
 				cachedSchedules: {
-					[`${ScheduleEntryLockScheduleKind.WeekDay}-1-1`]: {
-						dayOfWeek: 1,
-						startHour: 8,
-						startMinute: 0,
-						stopHour: 17,
-						stopMinute: 0,
-					},
+					[`${ScheduleEntryLockScheduleKind.WeekDay}-1-1`]:
+						weeklyPayload,
 				},
 			})
 
 			const result = await svc.getSchedules(2, {
 				fromCache: true,
-				mode: 'weekly' as any,
+				mode: 'weekly',
 			})
 			expect(result).toBeDefined()
 			expect(result?.weekly?.slots?.length).toBe(1)
@@ -793,8 +927,8 @@ describe('ScheduleService', () => {
 	describe('setSchedule – updates existing slot', () => {
 		it('updates an existing slot in the schedule on success', async () => {
 			const zwaveNode = createFakeZwaveNode(true)
-			const scheduleData = {
-				dayOfWeek: 3,
+			const updatedData: ScheduleEntryLockWeekDaySchedule = {
+				weekday: ScheduleEntryLockWeekday.Wednesday,
 				startHour: 10,
 				startMinute: 0,
 				stopHour: 18,
@@ -806,24 +940,21 @@ describe('ScheduleService', () => {
 				status: SupervisionStatus.Success,
 			})
 
+			const existingSlot: ScheduleEntryLockSlotId &
+				ScheduleEntryLockWeekDaySchedule & { enabled: boolean } = {
+				userId: 1,
+				slotId: 1,
+				enabled: true,
+				...weeklyPayload,
+			}
+
 			const nodeStore = createNodeStorePort({
 				id: 2,
 				schedule: {
 					daily: { numSlots: 0, slots: [] },
 					weekly: {
 						numSlots: 1,
-						slots: [
-							{
-								userId: 1,
-								slotId: 1,
-								dayOfWeek: 1,
-								startHour: 8,
-								startMinute: 0,
-								stopHour: 17,
-								stopMinute: 0,
-								enabled: true,
-							} as any,
-						],
+						slots: [existingSlot],
 					},
 					yearly: { numSlots: 0, slots: [] },
 				},
@@ -838,16 +969,16 @@ describe('ScheduleService', () => {
 			const result = await svc.setSchedule(2, 'weekly', {
 				userId: 1,
 				slotId: 1,
-				...scheduleData,
-			} as any)
+				...updatedData,
+			} as ScheduleEntryLockSlotId & ScheduleEntryLockWeekDaySchedule)
 
 			expect(result?.status).toBe(SupervisionStatus.Success)
 			// The existing slot should be updated
 			const node = nodeStore.getNode(2)
 			expect(node?.schedule?.weekly?.slots?.length).toBe(1)
-			expect((node?.schedule?.weekly?.slots?.[0] as any)?.dayOfWeek).toBe(
-				3,
-			)
+			const slot = node?.schedule?.weekly?.slots?.[0]
+			expect(slot).toBeDefined()
+			expect(slot?.weekday).toBe(ScheduleEntryLockWeekday.Wednesday)
 		})
 	})
 
@@ -874,12 +1005,8 @@ describe('ScheduleService', () => {
 			const result = await svc.setSchedule(2, 'weekly', {
 				userId: 1,
 				slotId: 1,
-				dayOfWeek: 1,
-				startHour: 8,
-				startMinute: 0,
-				stopHour: 17,
-				stopMinute: 0,
-			} as any)
+				...weeklyPayload,
+			} as ScheduleEntryLockSlotId & ScheduleEntryLockWeekDaySchedule)
 
 			expect(result?.status).toBe(SupervisionStatus.Success)
 		})

--- a/test/lib/zwave/ScheduleService.test.ts
+++ b/test/lib/zwave/ScheduleService.test.ts
@@ -179,7 +179,7 @@ describe('ScheduleService', () => {
 		vi.restoreAllMocks()
 	})
 
-	describe('getSchedules', () => {
+	describe('retrieving schedules', () => {
 		it('throws if Schedule Entry Lock CC is not supported', async () => {
 			const zwaveNode = createFakeZwaveNode(false)
 			const svc = new ScheduleService(
@@ -264,7 +264,7 @@ describe('ScheduleService', () => {
 			expect(result?.yearly?.numSlots).toBe(1)
 		})
 
-		it('allows a subsequent getSchedules call after a rejection', async () => {
+		it('allows another retrieval after a rejection', async () => {
 			const zwaveNode = createFakeZwaveNode(true)
 			const driverPort = createDriverPort(zwaveNode)
 			const nodeStore = createNodeStorePort()
@@ -287,7 +287,7 @@ describe('ScheduleService', () => {
 		})
 	})
 
-	describe('setSchedule', () => {
+	describe('updating schedules', () => {
 		it('throws for unsupported CC', async () => {
 			const zwaveNode = createFakeZwaveNode(false)
 			const svc = new ScheduleService(
@@ -325,7 +325,7 @@ describe('ScheduleService', () => {
 			).rejects.toThrow('Invalid schedule type')
 		})
 
-		it('sets a weekly schedule, calls setWeekDaySchedule, and verifies success via readback', async () => {
+		it('verifies an unsupervised weekly update through readback', async () => {
 			const zwaveNode = createFakeZwaveNode(true)
 			const cc = zwaveNode.commandClasses['Schedule Entry Lock']
 			cc.setWeekDaySchedule.mockResolvedValue(undefined)
@@ -370,7 +370,7 @@ describe('ScheduleService', () => {
 			expect(cc.getDailyRepeatingSchedule).not.toHaveBeenCalled()
 		})
 
-		it('handles delete (empty schedule) via readback', async () => {
+		it('removes a weekly schedule after readback confirms deletion', async () => {
 			const zwaveNode = createFakeZwaveNode(true)
 			const cc = zwaveNode.commandClasses['Schedule Entry Lock']
 			cc.setWeekDaySchedule.mockResolvedValue(undefined)
@@ -410,7 +410,7 @@ describe('ScheduleService', () => {
 			expect(result?.status).toBe(SupervisionStatus.Success)
 		})
 
-		it('returns supervision result directly when supervised (daily)', async () => {
+		it('accepts a supervised daily update without readback', async () => {
 			const zwaveNode = createFakeZwaveNode(true)
 			const cc = zwaveNode.commandClasses['Schedule Entry Lock']
 			cc.setDailyRepeatingSchedule.mockResolvedValue({
@@ -454,7 +454,7 @@ describe('ScheduleService', () => {
 		})
 	})
 
-	describe('setEnabledSchedule', () => {
+	describe('enabling schedules', () => {
 		it('throws when node not found', async () => {
 			const driverPort: ScheduleDriverPort = {
 				getDriver: () =>
@@ -516,7 +516,7 @@ describe('ScheduleService', () => {
 			expect(node?.userCodes?.enabled).not.toContain(1)
 		})
 
-		it('enables all users when userId is 0', async () => {
+		it('enables all users when no individual user is selected', async () => {
 			const zwaveNode = createFakeZwaveNode(true)
 			zwaveNode.commandClasses[
 				'Schedule Entry Lock'
@@ -537,7 +537,7 @@ describe('ScheduleService', () => {
 			expect(node?.userCodes?.enabled).toEqual([1, 2, 3])
 		})
 
-		it('disables all users when userId is 0', async () => {
+		it('disables all users when no individual user is selected', async () => {
 			const zwaveNode = createFakeZwaveNode(true)
 			zwaveNode.commandClasses[
 				'Schedule Entry Lock'
@@ -563,7 +563,7 @@ describe('ScheduleService', () => {
 		})
 	})
 
-	describe('getSchedules – slot management via cache', () => {
+	describe('refreshing cached schedules', () => {
 		it('adds a new cached slot to the returned schedule', async () => {
 			const zwaveNode = createFakeZwaveNode(true)
 			const driverPort = createDriverPort(zwaveNode)
@@ -702,8 +702,8 @@ describe('ScheduleService', () => {
 		})
 	})
 
-	describe('setSchedule – yearly', () => {
-		it('sets a yearly schedule via supervision, does not call weekly/daily', async () => {
+	describe('yearly schedules', () => {
+		it('updates only the requested yearly schedule', async () => {
 			const zwaveNode = createFakeZwaveNode(true)
 			const cc = zwaveNode.commandClasses['Schedule Entry Lock']
 			cc.setYearDaySchedule.mockResolvedValue({
@@ -746,8 +746,8 @@ describe('ScheduleService', () => {
 		})
 	})
 
-	describe('setSchedule – readback mismatch', () => {
-		it('returns Fail when readback does not match', async () => {
+	describe('schedule verification', () => {
+		it('reports failure when readback does not match', async () => {
 			const zwaveNode = createFakeZwaveNode(true)
 			const cc = zwaveNode.commandClasses['Schedule Entry Lock']
 			cc.setWeekDaySchedule.mockResolvedValue(undefined)
@@ -784,7 +784,7 @@ describe('ScheduleService', () => {
 		})
 	})
 
-	describe('getSchedules – cancellation', () => {
+	describe('schedule retrieval cancellation', () => {
 		it('returns undefined when cancelled during iteration', async () => {
 			const zwaveNode = createFakeZwaveNode(true)
 			const driverPort = createDriverPort(zwaveNode)
@@ -825,8 +825,8 @@ describe('ScheduleService', () => {
 		})
 	})
 
-	describe('getSchedules – unknown userCodes', () => {
-		it('populates slot counts and emits node update when userCodes is undefined', async () => {
+	describe('schedule retrieval without a known user count', () => {
+		it('populates schedule state when the supported user count is unknown', async () => {
 			const zwaveNode = createFakeZwaveNode(true)
 			const driverPort = createDriverPort(zwaveNode)
 			const nodeStore = createNodeStorePort()
@@ -866,8 +866,8 @@ describe('ScheduleService', () => {
 		})
 	})
 
-	describe('getSchedules – mode filtering', () => {
-		it('only fetches weekly schedules when mode is WEEKLY', async () => {
+	describe('schedule retrieval by mode', () => {
+		it('fetches only weekly schedules when requested', async () => {
 			const zwaveNode = createFakeZwaveNode(true)
 			const driverPort = createDriverPort(zwaveNode)
 			const nodeStore = createNodeStorePort()
@@ -902,7 +902,7 @@ describe('ScheduleService', () => {
 		})
 	})
 
-	describe('setSchedule – updates existing slot', () => {
+	describe('updating an existing schedule', () => {
 		it('updates an existing slot in the schedule on success', async () => {
 			const zwaveNode = createFakeZwaveNode(true)
 			const updatedData: ScheduleEntryLockWeekDaySchedule = {
@@ -959,7 +959,7 @@ describe('ScheduleService', () => {
 		})
 	})
 
-	describe('setSchedule – no schedule on node', () => {
+	describe('updating a node without cached schedules', () => {
 		it('returns result when node has no schedule object', async () => {
 			const zwaveNode = createFakeZwaveNode(true)
 			zwaveNode.commandClasses[
@@ -989,8 +989,8 @@ describe('ScheduleService', () => {
 		})
 	})
 
-	describe('setEnabledSchedule – no userCodes', () => {
-		it('does not throw when node has no userCodes', async () => {
+	describe('schedule enablement without cached user codes', () => {
+		it('emits unchanged state when a user update has no cached user codes', async () => {
 			const zwaveNode = createFakeZwaveNode(true)
 			zwaveNode.commandClasses[
 				'Schedule Entry Lock'
@@ -1012,7 +1012,7 @@ describe('ScheduleService', () => {
 			])
 		})
 
-		it('emits unchanged state for an all-users update when node has no userCodes', async () => {
+		it('emits unchanged state when a bulk update has no cached user codes', async () => {
 			const zwaveNode = createFakeZwaveNode(true)
 			zwaveNode.commandClasses[
 				'Schedule Entry Lock'


### PR DESCRIPTION
Extracts schedule and configuration-template behavior behind the `ZwaveClient` facade.

- Preserves dynamic API results, slot mutation semantics, cancellation behavior, and template identity.
- Keeps restart-driven driver swaps behind live ports.
- Review focus: write verification, missing-user-code behavior, and exact update payloads.

Part of #4722. Stacked on #4730.