### PR TITLE
refactor(zwave): extract driver lifecycle

### DIFF
--- a/api/lib/ZwaveClient.ts
+++ b/api/lib/ZwaveClient.ts
@@ -775,6 +775,20 @@ class ZwaveClient extends TypedEventEmitter<ZwaveClientEventCallbacks> {
 	 * repeated init()/hardReset() accumulate chains.
 	 */
 	private _configCheckEpoch = 0
+	/**
+	 * Monotonic token identifying the CURRENT config-update-check chain
+	 * ({@link _startScheduledConfigCheck}). Distinct from {@link _configCheckEpoch}
+	 * (a lifecycle-boundary token bumped by init/hardReset/close) because a
+	 * single driver generation can legitimately re-emit `driver ready` WITHOUT
+	 * any such boundary — an NVM restore or a controller firmware update
+	 * re-initialises the controller and fires `driver ready` again while both
+	 * the generation AND the epoch stay valid. Each ready starts a fresh chain
+	 * that bumps this token and cancels the previous one (armed timer cleared +
+	 * any in-flight check bails on the mismatch), so exactly one daily
+	 * ~24h-check chain is ever armed/in-flight regardless of how many times the
+	 * same generation becomes ready. Never reset; only ever incremented.
+	 */
+	private _configCheckChain = 0
 	private pollIntervals: Record<string, NodeJS.Timeout>
 
 	private _lockNeighborsRefresh: boolean
@@ -1436,6 +1450,17 @@ class ZwaveClient extends TypedEventEmitter<ZwaveClientEventCallbacks> {
 	 */
 	private _invalidateScheduledConfigCheck(): void {
 		this._configCheckEpoch++
+		this._clearConfigCheckTimer()
+	}
+
+	/**
+	 * Clear and forget the currently-armed daily config-update-check timer, if
+	 * any. Sole owner of the `updatesCheckTimeout` teardown so both the
+	 * lifecycle-boundary invalidation ({@link _invalidateScheduledConfigCheck})
+	 * and a fresh same-generation chain ({@link _startScheduledConfigCheck})
+	 * release the previous handle through one place and never leak it.
+	 */
+	private _clearConfigCheckTimer(): void {
 		if (this.updatesCheckTimeout) {
 			clearTimeout(this.updatesCheckTimeout)
 			this.updatesCheckTimeout = null
@@ -4343,15 +4368,13 @@ class ZwaveClient extends TypedEventEmitter<ZwaveClientEventCallbacks> {
 		this._updateControllerStatus('Driver ready')
 
 		try {
-			// this must be done only after driver is ready. Capture the current
-			// scheduling epoch so this chain is fenced against later lifecycle
-			// boundaries (init/hardReset/close/restart) that invalidate it.
-			this._scheduledConfigCheck(
-				generation,
-				this._configCheckEpoch,
-			).catch(() => {
-				/* ignore */
-			})
+			// this must be done only after driver is ready. Start a FRESH
+			// config-check chain: this cancels any chain a previous
+			// (same-generation) `driver ready` armed — an NVM restore or
+			// controller firmware update re-emits `driver ready` without a
+			// lifecycle boundary, so the generation+epoch fencing alone cannot
+			// stop a second ready from stacking a duplicate ~24h timer.
+			this._startScheduledConfigCheck(generation)
 
 			this.driver.controller
 				.on('inclusion started', this._onInclusionStarted.bind(this))
@@ -6752,6 +6775,38 @@ class ZwaveClient extends TypedEventEmitter<ZwaveClientEventCallbacks> {
 	}
 
 	/**
+	 * Start (or restart) the daily config-update-check chain for a fresh
+	 * `driver ready`, enforcing that AT MOST ONE chain is ever armed/in-flight.
+	 *
+	 * A single {@link DriverLifecycle} generation can legitimately re-emit
+	 * `driver ready` more than once with NO intervening lifecycle boundary — an
+	 * NVM restore or a controller firmware update re-initialises the controller
+	 * and fires `driver ready` again while the generation AND
+	 * {@link _configCheckEpoch} both stay valid. Without this guard each such
+	 * ready armed its own ~24h {@link updatesCheckTimeout} and the later arm
+	 * overwrote (and leaked) the earlier handle, so a live timer fired an
+	 * unwanted duplicate check and then re-armed a parallel daily chain forever.
+	 *
+	 * This clears any already-armed timer and bumps {@link _configCheckChain}
+	 * BEFORE scheduling, so both an armed timer from a previous ready AND a
+	 * still-in-flight previous check (which re-validates the chain token after
+	 * its awaited driver round-trip in {@link _scheduledConfigCheck}) are
+	 * cancelled. The fresh chain then arms exactly once. Independent of the
+	 * epoch, whose lifecycle-boundary semantics are preserved unchanged.
+	 */
+	private _startScheduledConfigCheck(generation: number): void {
+		this._clearConfigCheckTimer()
+		const chain = ++this._configCheckChain
+		this._scheduledConfigCheck(
+			generation,
+			this._configCheckEpoch,
+			chain,
+		).catch(() => {
+			/* ignore */
+		})
+	}
+
+	/**
 	 * Internal function to check for config updates automatically once a day.
 	 *
 	 * @param generation The {@link DriverLifecycle} generation active when this
@@ -6767,9 +6822,20 @@ class ZwaveClient extends TypedEventEmitter<ZwaveClientEventCallbacks> {
 	 * same generation; the epoch is bumped on every such boundary (see
 	 * {@link _invalidateScheduledConfigCheck}), so an in-flight check from before
 	 * the boundary bails here instead of re-arming a duplicate chain. The rearm
-	 * carries both tokens forward so the daily chain keeps fencing.
+	 * carries all tokens forward so the daily chain keeps fencing.
+	 * @param chain The config-check chain token ({@link _configCheckChain})
+	 * captured when this chain was started ({@link _startScheduledConfigCheck}).
+	 * Fences the case the epoch cannot: a repeated same-generation `driver ready`
+	 * (NVM restore / controller firmware) starts a new chain and bumps this
+	 * token, so a previous chain's in-flight check bails here instead of arming a
+	 * second parallel ~24h timer. The rearm carries the same token so the daily
+	 * chain keeps running until the next ready supersedes it.
 	 */
-	private async _scheduledConfigCheck(generation: number, epoch: number) {
+	private async _scheduledConfigCheck(
+		generation: number,
+		epoch: number,
+		chain: number,
+	) {
 		try {
 			await this.checkForConfigUpdates()
 		} catch (error) {
@@ -6778,11 +6844,13 @@ class ZwaveClient extends TypedEventEmitter<ZwaveClientEventCallbacks> {
 
 		// Bail if this generation was superseded while the check was in flight,
 		// the scheduling epoch was invalidated by a lifecycle boundary
-		// (init/hardReset/close/restart), or the client was closed/destroyed —
+		// (init/hardReset/close/restart), this chain was superseded by a fresh
+		// same-generation `driver ready`, or the client was closed/destroyed —
 		// do not log or rearm a stale timer.
 		if (
 			this._driverLifecycle.generation !== generation ||
 			this._configCheckEpoch !== epoch ||
+			this._configCheckChain !== chain ||
 			this.closed ||
 			this.destroyed
 		) {
@@ -6798,7 +6866,7 @@ class ZwaveClient extends TypedEventEmitter<ZwaveClientEventCallbacks> {
 
 		this.updatesCheckTimeout = setTimeout(
 			() => {
-				void this._scheduledConfigCheck(generation, epoch)
+				void this._scheduledConfigCheck(generation, epoch, chain)
 			},
 			waitMillis > 0 ? waitMillis : 1000,
 		)

--- a/api/lib/ZwaveClient.ts
+++ b/api/lib/ZwaveClient.ts
@@ -2250,7 +2250,7 @@ class ZwaveClient extends TypedEventEmitter<ZwaveClientEventCallbacks> {
 				await write()
 			} catch (error) {
 				logger.error(
-					`Error while updating store nodes: ${error.message}`,
+					`Error while updating store nodes: ${getErrorMessage(error)}`,
 					error,
 				)
 				if (throwError) {
@@ -2322,17 +2322,7 @@ class ZwaveClient extends TypedEventEmitter<ZwaveClientEventCallbacks> {
 				}
 			}
 
-			try {
-				await this._persistNodesSnapshot(persistedSnapshot, homeHex)
-			} catch (error) {
-				logger.error(
-					`Error while updating store nodes: ${getErrorMessage(error)}`,
-					error,
-				)
-				if (throwError) {
-					throw error
-				}
-			}
+			await this._persistNodesSnapshot(persistedSnapshot, homeHex)
 		}, throwError)
 	}
 

--- a/api/lib/ZwaveClient.ts
+++ b/api/lib/ZwaveClient.ts
@@ -4303,7 +4303,7 @@ class ZwaveClient extends TypedEventEmitter<ZwaveClientEventCallbacks> {
 
 		try {
 			// this must be done only after driver is ready
-			this._scheduledConfigCheck().catch(() => {
+			this._scheduledConfigCheck(generation).catch(() => {
 				/* ignore */
 			})
 
@@ -6706,14 +6706,32 @@ class ZwaveClient extends TypedEventEmitter<ZwaveClientEventCallbacks> {
 	}
 
 	/**
-	 * Internal function to check for config updates automatically once a day
+	 * Internal function to check for config updates automatically once a day.
 	 *
+	 * @param generation The {@link DriverLifecycle} generation active when this
+	 * check was scheduled. `checkForConfigUpdates()` awaits a driver round-trip,
+	 * during which a `close()`/`restart` (or a replacement driver) may supersede
+	 * this generation. We therefore re-validate the generation and the
+	 * closed/destroyed state AFTER the await, before logging or rearming, so a
+	 * stale in-flight check can never resurrect a ~24h timer that outlives the
+	 * driver or duplicates the replacement generation's own scheduled check. The
+	 * rearm carries the same token forward so the daily chain keeps fencing.
 	 */
-	private async _scheduledConfigCheck() {
+	private async _scheduledConfigCheck(generation: number) {
 		try {
 			await this.checkForConfigUpdates()
 		} catch (error) {
 			logger.warn(`Scheduled update check has failed: ${error.message}`)
+		}
+
+		// Bail if this generation was superseded while the check was in flight,
+		// or the client was closed/destroyed — do not log or rearm a stale timer.
+		if (
+			this._driverLifecycle.generation !== generation ||
+			this.closed ||
+			this.destroyed
+		) {
+			return
 		}
 
 		const nextUpdate = new Date()
@@ -6724,7 +6742,9 @@ class ZwaveClient extends TypedEventEmitter<ZwaveClientEventCallbacks> {
 		logger.info(`Next update scheduled for: ${nextUpdate}`)
 
 		this.updatesCheckTimeout = setTimeout(
-			this._scheduledConfigCheck.bind(this),
+			() => {
+				void this._scheduledConfigCheck(generation)
+			},
 			waitMillis > 0 ? waitMillis : 1000,
 		)
 	}

--- a/api/lib/ZwaveClient.ts
+++ b/api/lib/ZwaveClient.ts
@@ -747,7 +747,7 @@ class ZwaveClient extends TypedEventEmitter<ZwaveClientEventCallbacks> {
 	private statelessTimeouts: Record<string, NodeJS.Timeout>
 	private healTimeout: NodeJS.Timeout
 	private updatesCheckTimeout: NodeJS.Timeout
-	/** Invalidated on every init/hardReset/close/restart boundary to fence the daily config-check chain; the DriverLifecycle generation can't, since init/hardReset deliberately don't bump it */
+	/** Invalidated on every init/hardReset/close/restart boundary to fence the daily config-check chain that the DriverLifecycle generation can't, since init and hardReset keep the generation */
 	private _configCheckEpoch = 0
 	/** Dedupes same-generation config-check chains that `_configCheckEpoch` can't: `driver ready` re-fires without a boundary on NVM restore or controller firmware update */
 	private _configCheckChain = 0
@@ -4292,7 +4292,7 @@ class ZwaveClient extends TypedEventEmitter<ZwaveClientEventCallbacks> {
 		this._updateControllerStatus('Driver ready')
 
 		try {
-			// Only after the driver is ready; a fresh chain supersedes any prior same-generation ready
+			// Arm only after the driver is ready so a fresh chain supersedes any prior same-generation ready
 			this._startScheduledConfigCheck(generation)
 
 			this.driver.controller
@@ -6703,7 +6703,6 @@ class ZwaveClient extends TypedEventEmitter<ZwaveClientEventCallbacks> {
 		})
 	}
 
-	/** Runs the daily config-update check, then re-validates generation/epoch/chain after the awaited round-trip before logging or rearming */
 	private async _scheduledConfigCheck(
 		generation: number,
 		epoch: number,

--- a/api/lib/ZwaveClient.ts
+++ b/api/lib/ZwaveClient.ts
@@ -752,6 +752,8 @@ class ZwaveClient extends TypedEventEmitter<ZwaveClientEventCallbacks> {
 	private _configCheckEpoch = 0
 	/** Dedupes same-generation config-check chains that `_configCheckEpoch` can't: `driver ready` re-fires without a boundary on NVM restore or controller firmware update */
 	private _configCheckChain = 0
+	/** Latest-started config check allowed to publish, shared by manual and scheduled checks */
+	private _configPublicationEpoch = 0
 	private pollIntervals: Record<string, NodeJS.Timeout>
 
 	private _lockNeighborsRefresh: boolean
@@ -876,6 +878,8 @@ class ZwaveClient extends TypedEventEmitter<ZwaveClientEventCallbacks> {
 	 * Init internal vars
 	 */
 	init() {
+		this._driverLifecycle?.invalidateReady()
+
 		this.statelessTimeouts = {}
 		this.pollIntervals = {}
 
@@ -1333,7 +1337,8 @@ class ZwaveClient extends TypedEventEmitter<ZwaveClientEventCallbacks> {
 				this.destroyed = true
 				this.removeAllListeners()
 			},
-			onDriverReady: (generation) => this._onDriverReady(generation),
+			onDriverReady: (generation, readyEpoch) =>
+				this._onDriverReady(generation, readyEpoch),
 			onDriverError: (error, skipRestart) =>
 				this._onDriverError(error, skipRestart),
 			onScanComplete: () => this._onScanComplete(),
@@ -1382,6 +1387,7 @@ class ZwaveClient extends TypedEventEmitter<ZwaveClientEventCallbacks> {
 	/** Bump the epoch and clear the armed timer so any in-flight config check bails after its await instead of re-arming */
 	private _invalidateScheduledConfigCheck(): void {
 		this._configCheckEpoch++
+		this._configPublicationEpoch++
 		this._clearConfigCheckTimer()
 	}
 
@@ -2964,8 +2970,19 @@ class ZwaveClient extends TypedEventEmitter<ZwaveClientEventCallbacks> {
 	 *
 	 */
 	async checkForConfigUpdates(): Promise<string | undefined> {
+		const generation = this._driverLifecycle.generation
+		const epoch = this._configCheckEpoch
+		const publicationEpoch = ++this._configPublicationEpoch
 		const version = await this._fetchConfigUpdateVersion()
-		this._publishConfigUpdateVersion(version)
+		if (
+			this._driverLifecycle.generation === generation &&
+			this._configCheckEpoch === epoch &&
+			this._configPublicationEpoch === publicationEpoch &&
+			!this.closed &&
+			!this.destroyed
+		) {
+			this._publishConfigUpdateVersion(version)
+		}
 		return version
 	}
 
@@ -2988,10 +3005,19 @@ class ZwaveClient extends TypedEventEmitter<ZwaveClientEventCallbacks> {
 	 */
 	async installConfigUpdate(): Promise<boolean> {
 		if (this.driverReady) {
+			const generation = this._driverLifecycle.generation
+			const epoch = this._configCheckEpoch
+			const publicationEpoch = ++this._configPublicationEpoch
 			const updated = await this._driver.installConfigUpdate()
-			if (updated) {
-				this.driverInfo.newConfigVersion = undefined
-				this.sendToSocket(socketEvents.info, this.getInfo())
+			if (
+				updated &&
+				this._driverLifecycle.generation === generation &&
+				this._configCheckEpoch === epoch &&
+				this._configPublicationEpoch === publicationEpoch &&
+				!this.closed &&
+				!this.destroyed
+			) {
+				this._publishConfigUpdateVersion(undefined)
 			}
 			return updated
 		} else {
@@ -4280,7 +4306,14 @@ class ZwaveClient extends TypedEventEmitter<ZwaveClientEventCallbacks> {
 
 	// ---------- DRIVER EVENTS -------------------------------------
 
-	private async _onDriverReady(generation: number) {
+	private _isCurrentReady(generation: number, readyEpoch: number): boolean {
+		return (
+			this._driverLifecycle.generation === generation &&
+			this._driverLifecycle.readyEpoch === readyEpoch
+		)
+	}
+
+	private async _onDriverReady(generation: number, readyEpoch: number) {
 		/*
 			Now the controller interview is complete. This means we know which nodes
 			are included in the network, but they might not be ready yet.
@@ -4336,9 +4369,8 @@ class ZwaveClient extends TypedEventEmitter<ZwaveClientEventCallbacks> {
 			this._inclusionCoordinator.reinstallUserCallbacks()
 		} catch (error) {
 			// Fixes freak error in "driver ready" handler #1309
-			logger.error(error.message)
-			this.backoffRestart()
-			return
+			logger.error(getErrorMessage(error))
+			throw error
 		}
 
 		// reset retries
@@ -4353,7 +4385,7 @@ class ZwaveClient extends TypedEventEmitter<ZwaveClientEventCallbacks> {
 		await this.getStoreNodes()
 
 		// Abort if a newer generation replaced this one while the store loaded, so a late `driver ready` from an obsolete driver can't mutate the replacement's state
-		if (this._driverLifecycle.generation !== generation) {
+		if (!this._isCurrentReady(generation, readyEpoch)) {
 			return
 		}
 
@@ -4391,16 +4423,22 @@ class ZwaveClient extends TypedEventEmitter<ZwaveClientEventCallbacks> {
 
 		await this.sendInitToSockets()
 
-		if (this._driverLifecycle.generation !== generation) {
+		if (!this._isCurrentReady(generation, readyEpoch)) {
 			return
 		}
 
-		this.loadFakeNodes().catch((e) => {
-			logger.error(`Error while loading fake nodes: ${e.message}`)
+		this.loadFakeNodes(generation, readyEpoch).catch((error: unknown) => {
+			logger.error(
+				`Error while loading fake nodes: ${getErrorMessage(error)}`,
+			)
 		})
 	}
 
 	private _onDriverError(error: unknown, skipRestart = false): void {
+		if (skipRestart) {
+			this._invalidateScheduledConfigCheck()
+		}
+
 		this._error = 'Driver: ' + getErrorMessage(error)
 		this.status = ZwaveClientStatus.DRIVER_FAILED
 		this._updateControllerStatus(this._error)
@@ -6721,6 +6759,7 @@ class ZwaveClient extends TypedEventEmitter<ZwaveClientEventCallbacks> {
 		epoch: number,
 		chain: number,
 	) {
+		const publicationEpoch = ++this._configPublicationEpoch
 		let checked = false
 		let checkError: unknown
 		let version: string | undefined
@@ -6742,12 +6781,14 @@ class ZwaveClient extends TypedEventEmitter<ZwaveClientEventCallbacks> {
 			return
 		}
 
-		if (checked) {
-			this._publishConfigUpdateVersion(version)
-		} else {
-			logger.warn(
-				`Scheduled update check has failed: ${getErrorMessage(checkError)}`,
-			)
+		if (this._configPublicationEpoch === publicationEpoch) {
+			if (checked) {
+				this._publishConfigUpdateVersion(version)
+			} else {
+				logger.warn(
+					`Scheduled update check has failed: ${getErrorMessage(checkError)}`,
+				)
+			}
 		}
 
 		const nextUpdate = new Date()
@@ -6789,11 +6830,20 @@ class ZwaveClient extends TypedEventEmitter<ZwaveClientEventCallbacks> {
 	}
 
 	/** Loads fake nodes exported from UI */
-	private async loadFakeNodes() {
+	private async loadFakeNodes(generation: number, readyEpoch: number) {
 		const filePath = utils.joinPath(true, 'fakeNodes.json')
 		// load fake nodes from `fakeNodes.json` for testing
 		if (await utils.pathExists(filePath)) {
-			const fakeNodes = JSON.parse(await readFile(filePath, 'utf-8'))
+			if (!this._isCurrentReady(generation, readyEpoch)) {
+				return
+			}
+
+			const contents = await readFile(filePath, 'utf-8')
+			if (!this._isCurrentReady(generation, readyEpoch)) {
+				return
+			}
+
+			const fakeNodes = JSON.parse(contents)
 			for (const node of fakeNodes) {
 				// convert valueIds array to map
 				const values = {}

--- a/api/lib/ZwaveClient.ts
+++ b/api/lib/ZwaveClient.ts
@@ -183,9 +183,7 @@ import {
 	type SensorTypeScale,
 } from './zwave/ports.ts'
 
-// Re-exported so every existing importer of these types/const from
-// `ZwaveClient` keeps working after they moved to `./zwave/ports.ts`
-// (where extracted services can use them without importing this module).
+// Re-export to preserve the public type surface for existing ZwaveClient importers
 export { ZwaveClientStatus }
 export type { ZwaveConfig, SensorTypeScale }
 
@@ -696,18 +694,7 @@ class ZwaveClient extends TypedEventEmitter<ZwaveClientEventCallbacks> {
 
 	private _driver: Driver
 
-	/**
-	 * Owns the low-level driver lifecycle (creation/options/log transports,
-	 * connect/start, retry-backoff timers, statistics, extra log transports,
-	 * the official `@zwave-js/server` coordination and idempotent close) plus a
-	 * monotonic **generation** counter so a late `driver ready`/`error`/`all
-	 * nodes ready`/OTW callback from an obsolete driver can never mutate a
-	 * replacement generation's state. The public lifecycle methods below
-	 * (`connect`/`close`/`enableStatistics`/…) and the server accessors delegate
-	 * to it so the legacy internal/API surface is unchanged. Constructed once
-	 * (and reused across `init()`) so the generation/transports/server manager
-	 * persist across restarts.
-	 */
+	/** Reused across init() rather than reconstructed so its generation counter, log transports and adopted server manager survive restarts */
 	private _driverLifecycle: DriverLifecycle
 
 	/**
@@ -760,34 +747,9 @@ class ZwaveClient extends TypedEventEmitter<ZwaveClientEventCallbacks> {
 	private statelessTimeouts: Record<string, NodeJS.Timeout>
 	private healTimeout: NodeJS.Timeout
 	private updatesCheckTimeout: NodeJS.Timeout
-	/**
-	 * Scheduling epoch for the daily config-update check chain
-	 * ({@link _scheduledConfigCheck}). Distinct from the {@link DriverLifecycle}
-	 * generation on purpose: that generation is deliberately NOT bumped by
-	 * {@link init} or {@link hardReset} (so a post-hard-reset `driver ready`
-	 * still runs on the same generation), which means it cannot fence the
-	 * config-check chain across those boundaries. This epoch instead is
-	 * invalidated on EVERY boundary that (re)starts the driver-ready chain — see
-	 * {@link _invalidateScheduledConfigCheck}. A scheduled check captures the
-	 * epoch live and, after its awaited driver round-trip, only logs/re-arms
-	 * while the epoch is still current, so a hard reset can neither leave an
-	 * older chain's in-flight check re-arming a duplicate ~24h timer nor let
-	 * repeated init()/hardReset() accumulate chains.
-	 */
+	/** Invalidated on every init/hardReset/close/restart boundary to fence the daily config-check chain; the DriverLifecycle generation can't, since init/hardReset deliberately don't bump it */
 	private _configCheckEpoch = 0
-	/**
-	 * Monotonic token identifying the CURRENT config-update-check chain
-	 * ({@link _startScheduledConfigCheck}). Distinct from {@link _configCheckEpoch}
-	 * (a lifecycle-boundary token bumped by init/hardReset/close) because a
-	 * single driver generation can legitimately re-emit `driver ready` WITHOUT
-	 * any such boundary — an NVM restore or a controller firmware update
-	 * re-initialises the controller and fires `driver ready` again while both
-	 * the generation AND the epoch stay valid. Each ready starts a fresh chain
-	 * that bumps this token and cancels the previous one (armed timer cleared +
-	 * any in-flight check bails on the mismatch), so exactly one daily
-	 * ~24h-check chain is ever armed/in-flight regardless of how many times the
-	 * same generation becomes ready. Never reset; only ever incremented.
-	 */
+	/** Dedupes same-generation config-check chains that `_configCheckEpoch` can't: `driver ready` re-fires without a boundary on NVM restore or controller firmware update */
 	private _configCheckChain = 0
 	private pollIntervals: Record<string, NodeJS.Timeout>
 
@@ -921,12 +883,7 @@ class ZwaveClient extends TypedEventEmitter<ZwaveClientEventCallbacks> {
 		this.closed = false
 		this.driverReady = false
 
-		// init() is a config-check-chain boundary: it runs on construction, on
-		// restart() (after close()) and on hardReset() (which does NOT bump the
-		// DriverLifecycle generation). Invalidate the scheduling epoch and clear
-		// any armed daily timer here so a hard reset's re-emitted `driver ready`
-		// starts exactly one fresh chain and an older chain's in-flight check
-		// can never re-arm a duplicate/stale timer.
+		// hardReset() routes through init() without bumping the generation, so retire any older config-check chain here
 		this._invalidateScheduledConfigCheck()
 
 		this._nodes = new Map()
@@ -1320,10 +1277,7 @@ class ZwaveClient extends TypedEventEmitter<ZwaveClientEventCallbacks> {
 		}
 
 		if (this._driverLifecycle) {
-			// Reuse the existing lifecycle across restarts so its monotonic
-			// generation counter, adopted server manager and registered extra
-			// log transports persist. The host closures resolve current state,
-			// so nothing needs re-binding here.
+			// Reuse the existing lifecycle across restarts so its generation, adopted server manager and log transports persist
 		} else {
 			this._driverLifecycle = new DriverLifecycle(
 				this._buildDriverLifecycleHost(),
@@ -1337,12 +1291,7 @@ class ZwaveClient extends TypedEventEmitter<ZwaveClientEventCallbacks> {
 		this.status = ZwaveClientStatus.CLOSED
 	}
 
-	/**
-	 * Build the narrow {@link DriverLifecycleHost} port the
-	 * {@link DriverLifecycle} service uses to reach back into this client.
-	 * Every accessor resolves the CURRENT value so a driver/config swap on
-	 * restart is honoured with nothing captured at construction time.
-	 */
+	/** Accessors resolve live client state so a driver/config swap on restart is honoured with nothing captured at construction */
 	private _buildDriverLifecycleHost(): DriverLifecycleHost {
 		return {
 			getConfig: () => this.cfg,
@@ -1395,23 +1344,14 @@ class ZwaveClient extends TypedEventEmitter<ZwaveClientEventCallbacks> {
 		}
 	}
 
-	/**
-	 * Clear the per-run timers/throttles owned by this client and reset the
-	 * inclusion coordinator + firmware update service generations. Called by
-	 * the {@link DriverLifecycle} during {@link close}, after it has cleared its
-	 * own restart timer and before it destroys the server and driver. Extracted
-	 * verbatim from the middle of the old `close()` so the ordering is
-	 * unchanged.
-	 */
+	/** Runs mid-close (after DriverLifecycle clears its restart timer, before it destroys server and driver) so teardown ordering is preserved */
 	private _clearRuntimeOnClose(): void {
 		if (this.healTimeout) {
 			clearTimeout(this.healTimeout)
 			this.healTimeout = null
 		}
 
-		// close() (and, via restart(), the pre-init close) is a config-check-chain
-		// boundary. Invalidate the scheduling epoch and clear the armed daily
-		// timer so an in-flight check that settles after close cannot re-arm.
+		// Retire the config-check chain on close so an in-flight check settling afterward can't re-arm
 		this._invalidateScheduledConfigCheck()
 
 		this._inclusionCoordinator.reset()
@@ -1438,28 +1378,12 @@ class ZwaveClient extends TypedEventEmitter<ZwaveClientEventCallbacks> {
 		}
 	}
 
-	/**
-	 * Invalidate the scheduled config-update-check chain: bump the scheduling
-	 * epoch (so any in-flight {@link _scheduledConfigCheck} bails after its
-	 * awaited driver round-trip instead of logging/re-arming) and clear the
-	 * currently-armed daily timer handle. Called from every boundary that starts
-	 * or restarts the driver-ready chain — {@link init} (which covers
-	 * construction, restart() and hardReset()) and the close path
-	 * ({@link _clearRuntimeOnClose}) — so repeated init()/hardReset() can never
-	 * leave more than one live chain, and no stale handle is ever leaked.
-	 */
+	/** Bump the epoch and clear the armed timer so any in-flight config check bails after its await instead of re-arming */
 	private _invalidateScheduledConfigCheck(): void {
 		this._configCheckEpoch++
 		this._clearConfigCheckTimer()
 	}
 
-	/**
-	 * Clear and forget the currently-armed daily config-update-check timer, if
-	 * any. Sole owner of the `updatesCheckTimeout` teardown so both the
-	 * lifecycle-boundary invalidation ({@link _invalidateScheduledConfigCheck})
-	 * and a fresh same-generation chain ({@link _startScheduledConfigCheck})
-	 * release the previous handle through one place and never leak it.
-	 */
 	private _clearConfigCheckTimer(): void {
 		if (this.updatesCheckTimeout) {
 			clearTimeout(this.updatesCheckTimeout)
@@ -4368,12 +4292,7 @@ class ZwaveClient extends TypedEventEmitter<ZwaveClientEventCallbacks> {
 		this._updateControllerStatus('Driver ready')
 
 		try {
-			// this must be done only after driver is ready. Start a FRESH
-			// config-check chain: this cancels any chain a previous
-			// (same-generation) `driver ready` armed — an NVM restore or
-			// controller firmware update re-emits `driver ready` without a
-			// lifecycle boundary, so the generation+epoch fencing alone cannot
-			// stop a second ready from stacking a duplicate ~24h timer.
+			// Only after the driver is ready; a fresh chain supersedes any prior same-generation ready
 			this._startScheduledConfigCheck(generation)
 
 			this.driver.controller
@@ -4424,10 +4343,7 @@ class ZwaveClient extends TypedEventEmitter<ZwaveClientEventCallbacks> {
 		// needs home hex to be set
 		await this.getStoreNodes()
 
-		// A close()/restart() (or a newer driver) may have replaced this
-		// generation while the store was loading. Abort before touching the
-		// node registry / server so a late `driver ready` from an obsolete
-		// driver can never mutate the replacement generation's state.
+		// Abort if a newer generation replaced this one while the store loaded, so a late `driver ready` from an obsolete driver can't mutate the replacement's state
 		if (this._driverLifecycle.generation !== generation) {
 			return
 		}
@@ -6774,26 +6690,7 @@ class ZwaveClient extends TypedEventEmitter<ZwaveClientEventCallbacks> {
 		}`
 	}
 
-	/**
-	 * Start (or restart) the daily config-update-check chain for a fresh
-	 * `driver ready`, enforcing that AT MOST ONE chain is ever armed/in-flight.
-	 *
-	 * A single {@link DriverLifecycle} generation can legitimately re-emit
-	 * `driver ready` more than once with NO intervening lifecycle boundary — an
-	 * NVM restore or a controller firmware update re-initialises the controller
-	 * and fires `driver ready` again while the generation AND
-	 * {@link _configCheckEpoch} both stay valid. Without this guard each such
-	 * ready armed its own ~24h {@link updatesCheckTimeout} and the later arm
-	 * overwrote (and leaked) the earlier handle, so a live timer fired an
-	 * unwanted duplicate check and then re-armed a parallel daily chain forever.
-	 *
-	 * This clears any already-armed timer and bumps {@link _configCheckChain}
-	 * BEFORE scheduling, so both an armed timer from a previous ready AND a
-	 * still-in-flight previous check (which re-validates the chain token after
-	 * its awaited driver round-trip in {@link _scheduledConfigCheck}) are
-	 * cancelled. The fresh chain then arms exactly once. Independent of the
-	 * epoch, whose lifecycle-boundary semantics are preserved unchanged.
-	 */
+	/** Arms exactly one daily config-check chain per `driver ready`, clearing any prior armed timer and superseding an in-flight check via `_configCheckChain` */
 	private _startScheduledConfigCheck(generation: number): void {
 		this._clearConfigCheckTimer()
 		const chain = ++this._configCheckChain
@@ -6806,31 +6703,7 @@ class ZwaveClient extends TypedEventEmitter<ZwaveClientEventCallbacks> {
 		})
 	}
 
-	/**
-	 * Internal function to check for config updates automatically once a day.
-	 *
-	 * @param generation The {@link DriverLifecycle} generation active when this
-	 * check was scheduled. `checkForConfigUpdates()` awaits a driver round-trip,
-	 * during which a `close()`/`restart` (or a replacement driver) may supersede
-	 * this generation. We therefore re-validate the generation and the
-	 * closed/destroyed state AFTER the await, before logging or rearming, so a
-	 * stale in-flight check can never resurrect a ~24h timer that outlives the
-	 * driver or duplicates the replacement generation's own scheduled check.
-	 * @param epoch The config-check scheduling epoch ({@link _configCheckEpoch})
-	 * captured when this check was scheduled. The generation alone cannot fence
-	 * hardReset()/repeated-init() boundaries because those deliberately keep the
-	 * same generation; the epoch is bumped on every such boundary (see
-	 * {@link _invalidateScheduledConfigCheck}), so an in-flight check from before
-	 * the boundary bails here instead of re-arming a duplicate chain. The rearm
-	 * carries all tokens forward so the daily chain keeps fencing.
-	 * @param chain The config-check chain token ({@link _configCheckChain})
-	 * captured when this chain was started ({@link _startScheduledConfigCheck}).
-	 * Fences the case the epoch cannot: a repeated same-generation `driver ready`
-	 * (NVM restore / controller firmware) starts a new chain and bumps this
-	 * token, so a previous chain's in-flight check bails here instead of arming a
-	 * second parallel ~24h timer. The rearm carries the same token so the daily
-	 * chain keeps running until the next ready supersedes it.
-	 */
+	/** Runs the daily config-update check, then re-validates generation/epoch/chain after the awaited round-trip before logging or rearming */
 	private async _scheduledConfigCheck(
 		generation: number,
 		epoch: number,
@@ -6842,11 +6715,7 @@ class ZwaveClient extends TypedEventEmitter<ZwaveClientEventCallbacks> {
 			logger.warn(`Scheduled update check has failed: ${error.message}`)
 		}
 
-		// Bail if this generation was superseded while the check was in flight,
-		// the scheduling epoch was invalidated by a lifecycle boundary
-		// (init/hardReset/close/restart), this chain was superseded by a fresh
-		// same-generation `driver ready`, or the client was closed/destroyed —
-		// do not log or rearm a stale timer.
+		// Re-check every token after the in-flight check: a lifecycle boundary or newer chain during the await means bail instead of rearming a stale timer
 		if (
 			this._driverLifecycle.generation !== generation ||
 			this._configCheckEpoch !== epoch ||

--- a/api/lib/ZwaveClient.ts
+++ b/api/lib/ZwaveClient.ts
@@ -760,6 +760,21 @@ class ZwaveClient extends TypedEventEmitter<ZwaveClientEventCallbacks> {
 	private statelessTimeouts: Record<string, NodeJS.Timeout>
 	private healTimeout: NodeJS.Timeout
 	private updatesCheckTimeout: NodeJS.Timeout
+	/**
+	 * Scheduling epoch for the daily config-update check chain
+	 * ({@link _scheduledConfigCheck}). Distinct from the {@link DriverLifecycle}
+	 * generation on purpose: that generation is deliberately NOT bumped by
+	 * {@link init} or {@link hardReset} (so a post-hard-reset `driver ready`
+	 * still runs on the same generation), which means it cannot fence the
+	 * config-check chain across those boundaries. This epoch instead is
+	 * invalidated on EVERY boundary that (re)starts the driver-ready chain — see
+	 * {@link _invalidateScheduledConfigCheck}. A scheduled check captures the
+	 * epoch live and, after its awaited driver round-trip, only logs/re-arms
+	 * while the epoch is still current, so a hard reset can neither leave an
+	 * older chain's in-flight check re-arming a duplicate ~24h timer nor let
+	 * repeated init()/hardReset() accumulate chains.
+	 */
+	private _configCheckEpoch = 0
 	private pollIntervals: Record<string, NodeJS.Timeout>
 
 	private _lockNeighborsRefresh: boolean
@@ -891,6 +906,14 @@ class ZwaveClient extends TypedEventEmitter<ZwaveClientEventCallbacks> {
 
 		this.closed = false
 		this.driverReady = false
+
+		// init() is a config-check-chain boundary: it runs on construction, on
+		// restart() (after close()) and on hardReset() (which does NOT bump the
+		// DriverLifecycle generation). Invalidate the scheduling epoch and clear
+		// any armed daily timer here so a hard reset's re-emitted `driver ready`
+		// starts exactly one fresh chain and an older chain's in-flight check
+		// can never re-arm a duplicate/stale timer.
+		this._invalidateScheduledConfigCheck()
 
 		this._nodes = new Map()
 		this._virtualNodes = new Map()
@@ -1372,10 +1395,10 @@ class ZwaveClient extends TypedEventEmitter<ZwaveClientEventCallbacks> {
 			this.healTimeout = null
 		}
 
-		if (this.updatesCheckTimeout) {
-			clearTimeout(this.updatesCheckTimeout)
-			this.updatesCheckTimeout = null
-		}
+		// close() (and, via restart(), the pre-init close) is a config-check-chain
+		// boundary. Invalidate the scheduling epoch and clear the armed daily
+		// timer so an in-flight check that settles after close cannot re-arm.
+		this._invalidateScheduledConfigCheck()
 
 		this._inclusionCoordinator.reset()
 
@@ -1398,6 +1421,24 @@ class ZwaveClient extends TypedEventEmitter<ZwaveClientEventCallbacks> {
 		for (const [key, entry] of this.throttledFunctions) {
 			clearTimeout(entry.timeout)
 			this.throttledFunctions.delete(key)
+		}
+	}
+
+	/**
+	 * Invalidate the scheduled config-update-check chain: bump the scheduling
+	 * epoch (so any in-flight {@link _scheduledConfigCheck} bails after its
+	 * awaited driver round-trip instead of logging/re-arming) and clear the
+	 * currently-armed daily timer handle. Called from every boundary that starts
+	 * or restarts the driver-ready chain — {@link init} (which covers
+	 * construction, restart() and hardReset()) and the close path
+	 * ({@link _clearRuntimeOnClose}) — so repeated init()/hardReset() can never
+	 * leave more than one live chain, and no stale handle is ever leaked.
+	 */
+	private _invalidateScheduledConfigCheck(): void {
+		this._configCheckEpoch++
+		if (this.updatesCheckTimeout) {
+			clearTimeout(this.updatesCheckTimeout)
+			this.updatesCheckTimeout = null
 		}
 	}
 
@@ -4302,8 +4343,13 @@ class ZwaveClient extends TypedEventEmitter<ZwaveClientEventCallbacks> {
 		this._updateControllerStatus('Driver ready')
 
 		try {
-			// this must be done only after driver is ready
-			this._scheduledConfigCheck(generation).catch(() => {
+			// this must be done only after driver is ready. Capture the current
+			// scheduling epoch so this chain is fenced against later lifecycle
+			// boundaries (init/hardReset/close/restart) that invalidate it.
+			this._scheduledConfigCheck(
+				generation,
+				this._configCheckEpoch,
+			).catch(() => {
 				/* ignore */
 			})
 
@@ -6714,10 +6760,16 @@ class ZwaveClient extends TypedEventEmitter<ZwaveClientEventCallbacks> {
 	 * this generation. We therefore re-validate the generation and the
 	 * closed/destroyed state AFTER the await, before logging or rearming, so a
 	 * stale in-flight check can never resurrect a ~24h timer that outlives the
-	 * driver or duplicates the replacement generation's own scheduled check. The
-	 * rearm carries the same token forward so the daily chain keeps fencing.
+	 * driver or duplicates the replacement generation's own scheduled check.
+	 * @param epoch The config-check scheduling epoch ({@link _configCheckEpoch})
+	 * captured when this check was scheduled. The generation alone cannot fence
+	 * hardReset()/repeated-init() boundaries because those deliberately keep the
+	 * same generation; the epoch is bumped on every such boundary (see
+	 * {@link _invalidateScheduledConfigCheck}), so an in-flight check from before
+	 * the boundary bails here instead of re-arming a duplicate chain. The rearm
+	 * carries both tokens forward so the daily chain keeps fencing.
 	 */
-	private async _scheduledConfigCheck(generation: number) {
+	private async _scheduledConfigCheck(generation: number, epoch: number) {
 		try {
 			await this.checkForConfigUpdates()
 		} catch (error) {
@@ -6725,9 +6777,12 @@ class ZwaveClient extends TypedEventEmitter<ZwaveClientEventCallbacks> {
 		}
 
 		// Bail if this generation was superseded while the check was in flight,
-		// or the client was closed/destroyed — do not log or rearm a stale timer.
+		// the scheduling epoch was invalidated by a lifecycle boundary
+		// (init/hardReset/close/restart), or the client was closed/destroyed —
+		// do not log or rearm a stale timer.
 		if (
 			this._driverLifecycle.generation !== generation ||
+			this._configCheckEpoch !== epoch ||
 			this.closed ||
 			this.destroyed
 		) {
@@ -6743,7 +6798,7 @@ class ZwaveClient extends TypedEventEmitter<ZwaveClientEventCallbacks> {
 
 		this.updatesCheckTimeout = setTimeout(
 			() => {
-				void this._scheduledConfigCheck(generation)
+				void this._scheduledConfigCheck(generation, epoch)
 			},
 			waitMillis > 0 ? waitMillis : 1000,
 		)

--- a/api/lib/ZwaveClient.ts
+++ b/api/lib/ZwaveClient.ts
@@ -4400,6 +4400,9 @@ class ZwaveClient extends TypedEventEmitter<ZwaveClientEventCallbacks> {
 
 		this.driverReady = true
 
+		// A repeated ready event can follow an NVM restore with a different home ID
+		this._firmwareUpdateService.resetGeneration()
+
 		this._inclusionCoordinator.syncFromDriver()
 
 		logger.info('Z-Wave driver is ready')

--- a/api/lib/ZwaveClient.ts
+++ b/api/lib/ZwaveClient.ts
@@ -2964,14 +2964,22 @@ class ZwaveClient extends TypedEventEmitter<ZwaveClientEventCallbacks> {
 	 *
 	 */
 	async checkForConfigUpdates(): Promise<string | undefined> {
+		const version = await this._fetchConfigUpdateVersion()
+		this._publishConfigUpdateVersion(version)
+		return version
+	}
+
+	private async _fetchConfigUpdateVersion(): Promise<string | undefined> {
 		if (this.driverReady) {
-			this.driverInfo.newConfigVersion =
-				await this._driver.checkForConfigUpdates()
-			this.sendToSocket(socketEvents.info, this.getInfo())
-			return this.driverInfo.newConfigVersion
+			return this._driver.checkForConfigUpdates()
 		} else {
 			throw new DriverNotReadyError()
 		}
+	}
+
+	private _publishConfigUpdateVersion(version: string | undefined): void {
+		this.driverInfo.newConfigVersion = version
+		this.sendToSocket(socketEvents.info, this.getInfo())
 	}
 
 	/**
@@ -6713,13 +6721,17 @@ class ZwaveClient extends TypedEventEmitter<ZwaveClientEventCallbacks> {
 		epoch: number,
 		chain: number,
 	) {
+		let checked = false
+		let checkError: unknown
+		let version: string | undefined
 		try {
-			await this.checkForConfigUpdates()
+			version = await this._fetchConfigUpdateVersion()
+			checked = true
 		} catch (error) {
-			logger.warn(`Scheduled update check has failed: ${error.message}`)
+			checkError = error
 		}
 
-		// Re-check every token after the in-flight check: a lifecycle boundary or newer chain during the await means bail instead of rearming a stale timer
+		// Fence publication and rescheduling after the in-flight fetch so an older ready event cannot overwrite its replacement
 		if (
 			this._driverLifecycle.generation !== generation ||
 			this._configCheckEpoch !== epoch ||
@@ -6728,6 +6740,14 @@ class ZwaveClient extends TypedEventEmitter<ZwaveClientEventCallbacks> {
 			this.destroyed
 		) {
 			return
+		}
+
+		if (checked) {
+			this._publishConfigUpdateVersion(version)
+		} else {
+			logger.warn(
+				`Scheduled update check has failed: ${getErrorMessage(checkError)}`,
+			)
 		}
 
 		const nextUpdate = new Date()

--- a/api/lib/ZwaveClient.ts
+++ b/api/lib/ZwaveClient.ts
@@ -696,7 +696,7 @@ class ZwaveClient extends TypedEventEmitter<ZwaveClientEventCallbacks> {
 	private _driver: Driver
 
 	/** Reused across init() rather than reconstructed so its generation counter, log transports and adopted server manager survive restarts */
-	private _driverLifecycle: DriverLifecycle
+	private _driverLifecycle!: DriverLifecycle
 
 	/**
 	 * The narrow {@link ZwaveServerHost} port the server manager uses to reach
@@ -1149,8 +1149,8 @@ class ZwaveClient extends TypedEventEmitter<ZwaveClientEventCallbacks> {
 					staged.map(({ nodeId }) => nodeId),
 				)
 				const snapshot: NodesStoreRecord = {}
-				for (const key of Object.keys(this.storeNodes)) {
-					snapshot[key] = this.storeNodes[key]
+				for (const [key, node] of Object.entries(this.storeNodes)) {
+					snapshot[Number(key)] = node
 				}
 				for (const entry of staged) {
 					const existing = snapshot[entry.nodeId]

--- a/api/lib/ZwaveClient.ts
+++ b/api/lib/ZwaveClient.ts
@@ -92,11 +92,11 @@ import type {
 	JoinNetworkResult,
 	VirtualNode,
 	VirtualValueID,
+	Driver,
 } from 'zwave-js'
 import {
 	OTWFirmwareUpdateStatus,
 	ControllerStatus,
-	Driver,
 	ExclusionStrategy,
 	FirmwareUpdateStatus,
 	guessFirmwareFileFormat,
@@ -132,9 +132,8 @@ import * as LogManager from './logger.ts'
 import * as utils from './utils.ts'
 
 import { serverVersion, type ZwavejsServer } from '@zwave-js/server'
-import ZwaveServerManager, {
-	type ZwaveServerHost,
-} from '../hass/ZwaveServerManager.ts'
+import type ZwaveServerManager from '../hass/ZwaveServerManager.ts'
+import { type ZwaveServerHost } from '../hass/ZwaveServerManager.ts'
 import type { Server as SocketServer } from 'socket.io'
 import { TypedEventEmitter } from './EventEmitter.ts'
 import type { GatewayValue } from './Gateway.ts'
@@ -176,6 +175,19 @@ import { GroupService, GroupServiceGeneration } from './zwave/GroupService.ts'
 import { AssociationService } from './zwave/AssociationService.ts'
 import { FirmwareUpdateService } from './zwave/FirmwareUpdateService.ts'
 import { InclusionCoordinator } from './zwave/InclusionCoordinator.ts'
+import { DriverLifecycle } from './zwave/DriverLifecycle.ts'
+import type { DriverLifecycleHost } from './zwave/DriverLifecycle.ts'
+import {
+	ZwaveClientStatus,
+	type ZwaveConfig,
+	type SensorTypeScale,
+} from './zwave/ports.ts'
+
+// Re-exported so every existing importer of these types/const from
+// `ZwaveClient` keeps working after they moved to `./zwave/ports.ts`
+// (where extracted services can use them without importing this module).
+export { ZwaveClientStatus }
+export type { ZwaveConfig, SensorTypeScale }
 
 export type { HassDevice } from '../hass/types.ts'
 export { ZUIScheduleEntryLockMode }
@@ -392,14 +404,6 @@ const observedCCProps: {
 			})
 		},
 	},
-}
-
-export type SensorTypeScale = {
-	key: string | number
-	sensor: string
-	label: string
-	unit?: string
-	description?: string
 }
 
 export type AllowedApis = (typeof allowedApis)[number]
@@ -626,58 +630,6 @@ export type NodeEvent = {
 	time: Date
 }
 
-export type ZwaveConfig = {
-	enabled?: boolean
-	allowBootloaderOnly?: boolean
-	port?: string
-	networkKey?: string
-	securityKeys?: utils.DeepPartial<{
-		S2_Unauthenticated: string
-		S2_Authenticated: string
-		S2_AccessControl: string
-		S0_Legacy: string
-	}>
-	securityKeysLongRange?: utils.DeepPartial<{
-		S2_Authenticated: string
-		S2_AccessControl: string
-	}>
-	serverEnabled?: boolean
-	enableSoftReset?: boolean
-	disableWatchdog?: boolean
-	deviceConfigPriorityDir?: string
-	serverPort?: number
-	serverHost?: string
-	logEnabled?: boolean
-	maxFiles?: number
-	logLevel?: LogManager.LogLevel
-	commandsTimeout?: number
-	sendToSleepTimeout?: number
-	responseTimeout?: number
-	enableStatistics?: boolean
-	disableOptimisticValueUpdate?: boolean
-	disclaimerVersion?: number
-	options?: ZWaveOptions
-	// healNetwork?: boolean
-	healHour?: number
-	logToFile?: boolean
-	nodeFilter?: string[]
-	scales?: SensorTypeScale[]
-	serverServiceDiscoveryDisabled?: boolean
-	maxNodeEventsQueueSize?: number
-	higherReportsTimeout?: boolean
-	disableControllerRecovery?: boolean
-	disableAutomaticFirmwareUpdateChecks?: boolean
-	rf?: {
-		region?: RFRegion
-		maxLongRangePowerlevel?: number | 'auto'
-		autoPowerlevels?: boolean
-		txPower?: {
-			powerlevel: number | 'auto'
-			measured0dBm?: number
-		}
-	}
-}
-
 export type ZUIDriverInfo = {
 	uptime?: number
 	lastUpdate?: number
@@ -693,17 +645,6 @@ export type ZUIDriverInfo = {
 	controllerId?: number
 	newConfigVersion?: string | undefined
 }
-
-export const ZwaveClientStatus = {
-	CONNECTED: 'connected',
-	BOOTLOADER_READY: 'bootloader ready',
-	DRIVER_READY: 'driver ready',
-	SCAN_DONE: 'scan done',
-	DRIVER_FAILED: 'driver failed',
-	CLOSED: 'closed',
-} as const
-export type ZwaveClientStatus =
-	(typeof ZwaveClientStatus)[keyof typeof ZwaveClientStatus]
 
 export const EventSource = {
 	DRIVER: 'driver',
@@ -756,16 +697,18 @@ class ZwaveClient extends TypedEventEmitter<ZwaveClientEventCallbacks> {
 	private _driver: Driver
 
 	/**
-	 * Owns the `@zwave-js/server` lifecycle; the `server` accessor below
-	 * delegates to it.
-	 *
-	 * Optional because in production the `AppRuntime`-owned
-	 * `HomeAssistantManager` constructs the manager (via {@link buildServerHost})
-	 * and adopts it through {@link adoptServerManager} before the driver
-	 * connects, while a directly-constructed client (standalone/tests) lazily
-	 * builds its own fallback on first access to {@link zwaveServer}.
+	 * Owns the low-level driver lifecycle (creation/options/log transports,
+	 * connect/start, retry-backoff timers, statistics, extra log transports,
+	 * the official `@zwave-js/server` coordination and idempotent close) plus a
+	 * monotonic **generation** counter so a late `driver ready`/`error`/`all
+	 * nodes ready`/OTW callback from an obsolete driver can never mutate a
+	 * replacement generation's state. The public lifecycle methods below
+	 * (`connect`/`close`/`enableStatistics`/…) and the server accessors delegate
+	 * to it so the legacy internal/API surface is unchanged. Constructed once
+	 * (and reused across `init()`) so the generation/transports/server manager
+	 * persist across restarts.
 	 */
-	private _serverManager?: ZwaveServerManager
+	private _driverLifecycle: DriverLifecycle
 
 	/**
 	 * The narrow {@link ZwaveServerHost} port the server manager uses to reach
@@ -792,7 +735,7 @@ class ZwaveClient extends TypedEventEmitter<ZwaveClientEventCallbacks> {
 	 * all drive the manager the coordinator owns. Idempotent per generation.
 	 */
 	public adoptServerManager(manager: ZwaveServerManager): void {
-		this._serverManager = manager
+		this._driverLifecycle.adoptServerManager(manager)
 	}
 
 	/**
@@ -803,20 +746,15 @@ class ZwaveClient extends TypedEventEmitter<ZwaveClientEventCallbacks> {
 	 * `HomeAssistantManager` can resolve the current manager across restarts.
 	 */
 	public get zwaveServer(): ZwaveServerManager {
-		if (!this._serverManager) {
-			this._serverManager = new ZwaveServerManager(this.buildServerHost())
-		}
-		return this._serverManager
+		return this._driverLifecycle.zwaveServer
 	}
 
 	private get server(): ZwavejsServer | null {
-		return this._serverManager?.server ?? null
+		return this._driverLifecycle.server
 	}
 
 	private set server(value: ZwavejsServer | null) {
-		// Route through the lazy accessor so a directly-constructed client that
-		// assigns `server` before any create() still has a manager to hold it
-		this.zwaveServer.server = value
+		this._driverLifecycle.server = value
 	}
 
 	private statelessTimeouts: Record<string, NodeJS.Timeout>
@@ -838,12 +776,7 @@ class ZwaveClient extends TypedEventEmitter<ZwaveClientEventCallbacks> {
 
 	private nvmEvent: string
 
-	private backoffRetry = 0
-	private restartTimeout: NodeJS.Timeout
-
 	private driverFunctionCache: utils.Snippet[] = []
-
-	private _extraLogTransports: Array<{ transport: any; level?: string }> = []
 
 	// Foreach valueId, we store a callback function to be called when the value changes
 	private valuesObservers: Record<string, ValueIdObserver> = {}
@@ -1336,7 +1269,7 @@ class ZwaveClient extends TypedEventEmitter<ZwaveClientEventCallbacks> {
 				inclusionConfigPort,
 				inclusionQRPort,
 				logger,
-				() => this._serverManager,
+				() => this._driverLifecycle.serverManager,
 				(event: string) => {
 					this.nvmEvent = event
 				},
@@ -1349,11 +1282,123 @@ class ZwaveClient extends TypedEventEmitter<ZwaveClientEventCallbacks> {
 			)
 		}
 
+		if (this._driverLifecycle) {
+			// Reuse the existing lifecycle across restarts so its monotonic
+			// generation counter, adopted server manager and registered extra
+			// log transports persist. The host closures resolve current state,
+			// so nothing needs re-binding here.
+		} else {
+			this._driverLifecycle = new DriverLifecycle(
+				this._buildDriverLifecycleHost(),
+			)
+		}
+
 		this._devices = {}
 		this.driverInfo = {}
 		this.healTimeout = null
 
 		this.status = ZwaveClientStatus.CLOSED
+	}
+
+	/**
+	 * Build the narrow {@link DriverLifecycleHost} port the
+	 * {@link DriverLifecycle} service uses to reach back into this client.
+	 * Every accessor resolves the CURRENT value so a driver/config swap on
+	 * restart is honoured with nothing captured at construction time.
+	 */
+	private _buildDriverLifecycleHost(): DriverLifecycleHost {
+		return {
+			getConfig: () => this.cfg,
+			getDriver: () => this._driver,
+			setDriver: (driver) => {
+				this._driver = driver
+			},
+			isDriverReady: () => this.driverReady,
+			isDriverReadyRaw: () => this._driverReady,
+			isClosed: () => this.closed,
+			setClosed: (closed) => {
+				this.closed = closed
+			},
+			isDestroyed: () => this.destroyed,
+			setStatus: (status) => {
+				this.status = status
+			},
+			setDriverReady: (ready) => {
+				this.driverReady = ready
+			},
+			hasConnectedClients: async () =>
+				(await this.socket.fetchSockets()).length > 0,
+			emitDebug: (message) => {
+				this.socket.to('debug').emit(socketEvents.debug, message)
+			},
+			getInclusionUserCallbacks: () =>
+				this._inclusionCoordinator.getUserCallbacks(),
+			installUserCallbacks: () => this.setUserCallbacks(),
+			persistConfig: async () => {
+				const settings = jsonStore.get(store.settings)
+				settings.zwave = this.cfg
+				await jsonStore.put(store.settings, settings)
+			},
+			restart: () => this.restart(),
+			buildServerHost: () => this.buildServerHost(),
+			clearRuntimeOnClose: () => this._clearRuntimeOnClose(),
+			finalizeClose: () => {
+				this.destroyed = true
+				this.removeAllListeners()
+			},
+			onDriverReady: (generation) => this._onDriverReady(generation),
+			onDriverError: (error, skipRestart) =>
+				this._onDriverError(error as ZWaveError, skipRestart),
+			onScanComplete: () => this._onScanComplete(),
+			onBootLoaderReady: () => this._onBootLoaderReady(),
+			onOTWFirmwareUpdateProgress: (progress) =>
+				this._onOTWFirmwareUpdateProgress(progress),
+			onOTWFirmwareUpdateFinished: (result) =>
+				this._onOTWFirmwareUpdateFinished(result),
+		}
+	}
+
+	/**
+	 * Clear the per-run timers/throttles owned by this client and reset the
+	 * inclusion coordinator + firmware update service generations. Called by
+	 * the {@link DriverLifecycle} during {@link close}, after it has cleared its
+	 * own restart timer and before it destroys the server and driver. Extracted
+	 * verbatim from the middle of the old `close()` so the ordering is
+	 * unchanged.
+	 */
+	private _clearRuntimeOnClose(): void {
+		if (this.healTimeout) {
+			clearTimeout(this.healTimeout)
+			this.healTimeout = null
+		}
+
+		if (this.updatesCheckTimeout) {
+			clearTimeout(this.updatesCheckTimeout)
+			this.updatesCheckTimeout = null
+		}
+
+		this._inclusionCoordinator.reset()
+
+		this._firmwareUpdateService.resetGeneration()
+
+		if (this.statelessTimeouts) {
+			for (const k in this.statelessTimeouts) {
+				clearTimeout(this.statelessTimeouts[k])
+				delete this.statelessTimeouts[k]
+			}
+		}
+
+		if (this.pollIntervals) {
+			for (const k in this.pollIntervals) {
+				clearTimeout(this.pollIntervals[k])
+				delete this.pollIntervals[k]
+			}
+		}
+
+		for (const [key, entry] of this.throttledFunctions) {
+			clearTimeout(entry.timeout)
+			this.throttledFunctions.delete(key)
+		}
 	}
 
 	/**
@@ -1371,16 +1416,7 @@ class ZwaveClient extends TypedEventEmitter<ZwaveClientEventCallbacks> {
 	 * If the driver is already running, the transport is applied immediately.
 	 */
 	addExtraLogTransport(transport: any, level?: string): void {
-		this._extraLogTransports.push({ transport, level })
-		if (this._driver && this._driverReady) {
-			const config: any = {
-				transports: [transport],
-			}
-			if (level) {
-				config.level = level
-			}
-			this._driver.updateLogConfig(config)
-		}
+		this._driverLifecycle.addExtraLogTransport(transport, level)
 	}
 
 	/**
@@ -1388,39 +1424,11 @@ class ZwaveClient extends TypedEventEmitter<ZwaveClientEventCallbacks> {
 	 * If the driver is running, the transport is detached immediately.
 	 */
 	removeExtraLogTransport(transport: any): void {
-		const idx = this._extraLogTransports.findIndex(
-			(e) => e.transport === transport,
-		)
-		if (idx !== -1) {
-			this._extraLogTransports.splice(idx, 1)
-		}
-		if (this._driver && this._driverReady) {
-			this._driver.updateLogConfig({
-				transports: [],
-			})
-		}
+		this._driverLifecycle.removeExtraLogTransport(transport)
 	}
 
 	backoffRestart(): void {
-		// fix edge case where client is half closed and restart is called
-		if (this.checkIfDestroyed()) {
-			return
-		}
-
-		const timeout = Math.min(2 ** this.backoffRetry * 1000, 15000)
-		this.backoffRetry++
-
-		logger.info(
-			`Restarting client in ${timeout / 1000} seconds, retry ${
-				this.backoffRetry
-			}`,
-		)
-
-		this.restartTimeout = setTimeout(() => {
-			this.restart().catch((error) => {
-				logger.error(`Error while restarting driver: ${error.message}`)
-			})
-		}, timeout)
+		this._driverLifecycle.backoffRestart()
 	}
 
 	/**
@@ -1428,17 +1436,7 @@ class ZwaveClient extends TypedEventEmitter<ZwaveClientEventCallbacks> {
 	 * @returns True if client is destroyed
 	 */
 	checkIfDestroyed() {
-		if (this.destroyed) {
-			logger.debug(
-				`Client listening on '${this.cfg.port}' is destroyed, closing`,
-			)
-			this.close(true).catch((error) => {
-				logger.error(`Error while closing driver: ${error.message}`)
-			})
-			return true
-		}
-
-		return false
+		return this._driverLifecycle.checkIfDestroyed()
 	}
 
 	/**
@@ -1678,63 +1676,7 @@ class ZwaveClient extends TypedEventEmitter<ZwaveClientEventCallbacks> {
 	 * Method used to close client connection, use this before destroy
 	 */
 	async close(keepListeners = false) {
-		this.status = ZwaveClientStatus.CLOSED
-		this.closed = true
-		this.driverReady = false
-
-		if (this.restartTimeout) {
-			clearTimeout(this.restartTimeout)
-			this.restartTimeout = null
-		}
-
-		if (this.healTimeout) {
-			clearTimeout(this.healTimeout)
-			this.healTimeout = null
-		}
-
-		if (this.updatesCheckTimeout) {
-			clearTimeout(this.updatesCheckTimeout)
-			this.updatesCheckTimeout = null
-		}
-
-		this._inclusionCoordinator.reset()
-
-		this._firmwareUpdateService.resetGeneration()
-
-		if (this.statelessTimeouts) {
-			for (const k in this.statelessTimeouts) {
-				clearTimeout(this.statelessTimeouts[k])
-				delete this.statelessTimeouts[k]
-			}
-		}
-
-		if (this.pollIntervals) {
-			for (const k in this.pollIntervals) {
-				clearTimeout(this.pollIntervals[k])
-				delete this.pollIntervals[k]
-			}
-		}
-
-		for (const [key, entry] of this.throttledFunctions) {
-			clearTimeout(entry.timeout)
-			this.throttledFunctions.delete(key)
-		}
-
-		if (this._serverManager) {
-			await this._serverManager.destroy()
-		}
-
-		if (this._driver) {
-			await this._driver.destroy()
-			this._driver = null
-		}
-
-		if (!keepListeners) {
-			this.destroyed = true
-			this.removeAllListeners()
-		}
-
-		logger.info('Client closed')
+		await this._driverLifecycle.close(keepListeners)
 	}
 
 	getStatus() {
@@ -2040,294 +1982,7 @@ class ZwaveClient extends TypedEventEmitter<ZwaveClientEventCallbacks> {
 	 * Method used to start Z-Wave connection using configuration `port`
 	 */
 	async connect() {
-		// When ZWAVE_PORT env var is set, force enable and override port
-		if (process.env.ZWAVE_PORT) {
-			this.cfg.enabled = true
-			this.cfg.port = process.env.ZWAVE_PORT
-		}
-
-		if (this.cfg.enabled === false) {
-			logger.info('Z-Wave driver DISABLED')
-			return
-		}
-
-		if (this.driverReady) {
-			logger.info(`Driver already connected to ${this.cfg.port}`)
-			return
-		}
-
-		// this could happen when the driver fails the connect and a reconnect timeout triggers
-		if (this.closed || this.checkIfDestroyed()) {
-			return
-		}
-
-		if (!this.cfg?.port) {
-			logger.warn('Z-Wave driver not inited, no port configured')
-			return
-		}
-
-		let shouldUpdateSettings = false
-
-		// extend options with hidden `options`
-		const zwaveOptions: PartialZWaveOptions = {
-			bootloaderMode: this.cfg.allowBootloaderOnly ? 'allow' : 'recover',
-			storage: {
-				cacheDir: storeDir,
-				deviceConfigPriorityDir:
-					this.cfg.deviceConfigPriorityDir || deviceConfigPriorityDir,
-			},
-			// https://zwave-js.github.io/node-zwave-js/#/api/driver?id=logconfig
-			logConfig: utils.buildLogConfig(this.cfg, logsDir),
-			emitValueUpdateAfterSetValue: true,
-			apiKeys: {
-				firmwareUpdateService:
-					'421e29797c3c2926f84efc737352d6190354b3b526a6dce6633674dd33a8a4f964c794f5',
-			},
-			timeouts: {
-				report: this.cfg.higherReportsTimeout ? 10000 : undefined,
-				sendToSleep: this.cfg.sendToSleepTimeout,
-				response: this.cfg.responseTimeout,
-			},
-			features: {
-				unresponsiveControllerRecovery: this.cfg
-					.disableControllerRecovery
-					? false
-					: true,
-				watchdog: this.cfg.disableWatchdog ? false : true,
-			},
-			userAgent: {
-				[utils.pkgJson.name]: utils.pkgJson.version,
-			},
-			disableOptimisticValueUpdate: this.cfg.disableOptimisticValueUpdate,
-		}
-
-		// when no env is specified copy config db to store dir
-		// fixes issues with pkg (and no more need to set this env on docker)
-		if (!process.env.ZWAVEJS_EXTERNAL_CONFIG) {
-			zwaveOptions.storage.deviceConfigExternalDir = configDbDir
-		}
-
-		if (this.cfg.rf) {
-			const { region, txPower, maxLongRangePowerlevel } = this.cfg.rf
-
-			let { autoPowerlevels } = this.cfg.rf
-			zwaveOptions.rf = {}
-
-			if (typeof region === 'number') {
-				zwaveOptions.rf.region = region
-			}
-
-			if (
-				autoPowerlevels === undefined &&
-				typeof maxLongRangePowerlevel !== 'number' &&
-				typeof txPower?.powerlevel !== 'number'
-			) {
-				// if autoPowerlevels is undefined and maxLongRangePowerlevel is not a number (likely '' or undefined), assume autoPowerlevels is true
-				autoPowerlevels = true
-				this.cfg.rf.autoPowerlevels = true
-				shouldUpdateSettings = true
-			}
-
-			if (autoPowerlevels) {
-				zwaveOptions.rf.maxLongRangePowerlevel = 'auto'
-				zwaveOptions.rf.txPower ??= {}
-				zwaveOptions.rf.txPower.powerlevel = 'auto'
-			}
-
-			if (
-				!autoPowerlevels &&
-				(maxLongRangePowerlevel === 'auto' ||
-					typeof maxLongRangePowerlevel === 'number')
-			) {
-				zwaveOptions.rf.maxLongRangePowerlevel = maxLongRangePowerlevel
-			}
-
-			if (txPower) {
-				if (
-					!autoPowerlevels &&
-					(txPower.powerlevel === 'auto' ||
-						typeof txPower.powerlevel === 'number')
-				) {
-					zwaveOptions.rf.txPower ??= {}
-					zwaveOptions.rf.txPower.powerlevel = txPower.powerlevel
-				}
-
-				if (typeof txPower.measured0dBm === 'number') {
-					zwaveOptions.rf.txPower ??= {}
-					zwaveOptions.rf.txPower.measured0dBm = txPower.measured0dBm
-				}
-			}
-		}
-
-		// @ts-expect-error this is defined when running in a pkg bundle
-		if (process.pkg) {
-			// Ensure Z-Wave JS is looking for the configuration files in the right place
-			// when running inside a pkg bundle
-			zwaveOptions.host ??= {}
-			zwaveOptions.host.fs = new PkgFsBindings()
-		}
-
-		// ensure deviceConfigPriorityDir exists to prevent warnings #2374
-		// lgtm [js/path-injection]
-		await utils.ensureDir(zwaveOptions.storage.deviceConfigPriorityDir)
-
-		// when not set let zwavejs handle this based on the environment
-		if (typeof this.cfg.enableSoftReset === 'boolean') {
-			zwaveOptions.features.softReset = this.cfg.enableSoftReset
-		}
-
-		// when server is not enabled, disable the user callbacks set/remove
-		// so it can be used through MQTT
-		if (!this.cfg.serverEnabled) {
-			zwaveOptions.inclusionUserCallbacks =
-				this._inclusionCoordinator.getUserCallbacks()
-		}
-
-		if (this.cfg.scales) {
-			const preferences = utils.buildPreferences(this.cfg)
-			if (preferences) {
-				zwaveOptions.preferences = preferences
-			}
-		}
-
-		Object.assign(zwaveOptions, this.cfg.options)
-
-		let s0Key: string
-
-		// back compatibility
-		if (this.cfg.networkKey) {
-			s0Key = this.cfg.networkKey
-			delete this.cfg.networkKey
-		}
-
-		this.cfg.securityKeys = this.cfg.securityKeys || {}
-
-		// update settings to fix compatibility
-		if (s0Key && !this.cfg.securityKeys.S0_Legacy) {
-			this.cfg.securityKeys.S0_Legacy = s0Key
-			shouldUpdateSettings = true
-		}
-
-		utils.parseSecurityKeys(this.cfg, zwaveOptions)
-
-		// Apply driver-only external settings (storage, presets, logFilename, forceConsole).
-		// These are not in ZwaveConfig/settings.json, so they must be applied directly to driver options.
-		applyExternalDriverSettings(zwaveOptions)
-
-		const logTransport = new JSONTransport()
-		logTransport.format = createDefaultTransportFormat(true, false)
-
-		zwaveOptions.logConfig.transports = [
-			logTransport,
-			...this._extraLogTransports.map((e) => e.transport),
-		]
-
-		// If any extra transport requires a more verbose log level, apply it.
-		// Use the most verbose (highest priority) level among all extra transports.
-		const extraLevel = this._extraLogTransports
-			.map((e) => e.level)
-			.filter(Boolean)
-			.reduce<string | undefined>((best, level) => {
-				if (!best) return level
-				return LOG_LEVEL_ORDER.indexOf(level) >
-					LOG_LEVEL_ORDER.indexOf(best)
-					? level
-					: best
-			}, undefined)
-		if (extraLevel) {
-			const currentLevel = zwaveOptions.logConfig.level
-			const currentIdx =
-				typeof currentLevel === 'string'
-					? LOG_LEVEL_ORDER.indexOf(currentLevel)
-					: -1
-			const extraIdx = LOG_LEVEL_ORDER.indexOf(extraLevel)
-			if (extraIdx > currentIdx) {
-				zwaveOptions.logConfig.level = extraLevel
-			}
-		}
-
-		logTransport.stream.on('data', (data) => {
-			this.socket
-				.to('debug')
-				.emit(socketEvents.debug, data.message.toString())
-		})
-
-		try {
-			if (shouldUpdateSettings) {
-				const settings = jsonStore.get(store.settings)
-				settings.zwave = this.cfg
-				await jsonStore.put(store.settings, settings)
-			}
-			// init driver here because if connect fails the driver is destroyed
-			// this could throw so include in the try/catch
-			this._driver = new Driver(this.cfg.port, zwaveOptions)
-			this._driver.on('error', this._onDriverError.bind(this))
-			this._driver.on('driver ready', this._onDriverReady.bind(this))
-			this._driver.on('all nodes ready', this._onScanComplete.bind(this))
-			this._driver.on(
-				'bootloader ready',
-				this._onBootLoaderReady.bind(this),
-			)
-			this._driver.on(
-				'firmware update progress',
-				this._onOTWFirmwareUpdateProgress.bind(this),
-			)
-			this._driver.on(
-				'firmware update finished',
-				this._onOTWFirmwareUpdateFinished.bind(this),
-			)
-
-			logger.info(`Connecting to ${this.cfg.port}`)
-
-			// setup user callbacks only if there are connected clients
-			const hasConnectedClients =
-				(await this.socket.fetchSockets()).length > 0
-
-			if (hasConnectedClients) {
-				this.setUserCallbacks()
-			}
-
-			await this._driver.start()
-
-			if (this.checkIfDestroyed()) {
-				return
-			}
-
-			if (this.cfg.serverEnabled) {
-				this._createServer()
-			}
-
-			if (this.cfg.enableStatistics) {
-				this.enableStatistics()
-			}
-
-			this.status = ZwaveClientStatus.CONNECTED
-		} catch (error) {
-			// destroy diver instance when it fails
-			if (this._driver) {
-				this._driver.destroy().catch((err) => {
-					logger.error(
-						`Error while destroying driver ${err.message}`,
-						error,
-					)
-				})
-			}
-
-			if (this.checkIfDestroyed()) {
-				return
-			}
-
-			this._onDriverError(error, true)
-
-			if (error.code !== ZWaveErrorCodes.Driver_InvalidOptions) {
-				this.backoffRestart()
-			} else {
-				logger.error(
-					`Invalid options for driver: ${error.message}`,
-					error,
-				)
-			}
-		}
+		await this._driverLifecycle.connect()
 	}
 
 	private logNode(
@@ -3225,19 +2880,7 @@ class ZwaveClient extends TypedEventEmitter<ZwaveClientEventCallbacks> {
 	 *
 	 */
 	enableStatistics() {
-		if (this._driver) {
-			this._driver.enableStatistics({
-				applicationName:
-					utils.pkgJson.name +
-					(this.cfg.serverEnabled ? ' / zwave-js-server' : ''),
-				applicationVersion: utils.pkgJson.version,
-			})
-			logger.info('Zwavejs usage statistics ENABLED')
-		}
-
-		logger.warn(
-			'Zwavejs driver is not ready yet, statistics will be enabled on driver initialization',
-		)
+		this._driverLifecycle.enableStatistics()
 	}
 
 	/**
@@ -3245,14 +2888,7 @@ class ZwaveClient extends TypedEventEmitter<ZwaveClientEventCallbacks> {
 	 *
 	 */
 	disableStatistics() {
-		if (this._driver) {
-			this._driver.disableStatistics()
-			logger.info('Zwavejs usage statistics DISABLED')
-		}
-
-		logger.warn(
-			'Zwavejs driver is not ready yet, statistics will be disabled on driver initialization',
-		)
+		this._driverLifecycle.disableStatistics()
 	}
 
 	getInfo() {
@@ -4645,7 +4281,7 @@ class ZwaveClient extends TypedEventEmitter<ZwaveClientEventCallbacks> {
 
 	// ---------- DRIVER EVENTS -------------------------------------
 
-	private async _onDriverReady() {
+	private async _onDriverReady(generation: number) {
 		/*
 			Now the controller interview is complete. This means we know which nodes
 			are included in the network, but they might not be ready yet.
@@ -4709,7 +4345,7 @@ class ZwaveClient extends TypedEventEmitter<ZwaveClientEventCallbacks> {
 		}
 
 		// reset retries
-		this.backoffRetry = 0
+		this._driverLifecycle.resetBackoff()
 
 		this.driverInfo.homeid = this._driver.controller.homeId
 		const homeHex = '0x' + this.driverInfo?.homeid?.toString(16)
@@ -4718,6 +4354,14 @@ class ZwaveClient extends TypedEventEmitter<ZwaveClientEventCallbacks> {
 
 		// needs home hex to be set
 		await this.getStoreNodes()
+
+		// A close()/restart() (or a newer driver) may have replaced this
+		// generation while the store was loading. Abort before touching the
+		// node registry / server so a late `driver ready` from an obsolete
+		// driver can never mutate the replacement generation's state.
+		if (this._driverLifecycle.generation !== generation) {
+			return
+		}
 
 		// Create broadcast nodes and recreate virtual nodes for groups
 		this._createBroadcastNodes()
@@ -4752,6 +4396,10 @@ class ZwaveClient extends TypedEventEmitter<ZwaveClientEventCallbacks> {
 		logger.info(`Scanning network with homeid: ${homeHex}`)
 
 		await this.sendInitToSockets()
+
+		if (this._driverLifecycle.generation !== generation) {
+			return
+		}
 
 		this.loadFakeNodes().catch((e) => {
 			logger.error(`Error while loading fake nodes: ${e.message}`)

--- a/api/lib/ZwaveClient.ts
+++ b/api/lib/ZwaveClient.ts
@@ -754,6 +754,9 @@ class ZwaveClient extends TypedEventEmitter<ZwaveClientEventCallbacks> {
 	private _configCheckChain = 0
 	/** Latest-started config check allowed to publish, shared by manual and scheduled checks */
 	private _configPublicationEpoch = 0
+	/** Changes at both boundaries of an install so checks overlapping it cannot publish a sampled pre-install version */
+	private _configInstallEpoch = 0
+	private _activeConfigInstall: number | null = null
 	private pollIntervals: Record<string, NodeJS.Timeout>
 
 	private _lockNeighborsRefresh: boolean
@@ -1388,6 +1391,8 @@ class ZwaveClient extends TypedEventEmitter<ZwaveClientEventCallbacks> {
 	private _invalidateScheduledConfigCheck(): void {
 		this._configCheckEpoch++
 		this._configPublicationEpoch++
+		this._configInstallEpoch++
+		this._activeConfigInstall = null
 		this._clearConfigCheckTimer()
 	}
 
@@ -2310,12 +2315,26 @@ class ZwaveClient extends TypedEventEmitter<ZwaveClientEventCallbacks> {
 				}
 			}
 
-			await this._persistNodesSnapshot(persistedSnapshot, homeHex)
+			try {
+				await this._persistNodesSnapshot(persistedSnapshot, homeHex)
+			} catch (error) {
+				logger.error(
+					`Error while updating store nodes: ${getErrorMessage(error)}`,
+					error,
+				)
+				if (throwError) {
+					throw error
+				}
+			}
 		}, throwError)
 	}
 
 	async updateStoreNodes(throwError = true) {
-		await this._updateStoreNodesSnapshot(this.storeNodes, throwError)
+		await this._updateStoreNodesSnapshot(
+			this.storeNodes,
+			throwError,
+			this.homeHex,
+		)
 	}
 
 	/**
@@ -2973,13 +2992,15 @@ class ZwaveClient extends TypedEventEmitter<ZwaveClientEventCallbacks> {
 		const generation = this._driverLifecycle.generation
 		const epoch = this._configCheckEpoch
 		const publicationEpoch = ++this._configPublicationEpoch
+		const installEpoch = this._configInstallEpoch
 		const version = await this._fetchConfigUpdateVersion()
 		if (
-			this._driverLifecycle.generation === generation &&
-			this._configCheckEpoch === epoch &&
-			this._configPublicationEpoch === publicationEpoch &&
-			!this.closed &&
-			!this.destroyed
+			this._isCurrentConfigPublication(
+				generation,
+				epoch,
+				publicationEpoch,
+				installEpoch,
+			)
 		) {
 			this._publishConfigUpdateVersion(version)
 		}
@@ -2999,6 +3020,23 @@ class ZwaveClient extends TypedEventEmitter<ZwaveClientEventCallbacks> {
 		this.sendToSocket(socketEvents.info, this.getInfo())
 	}
 
+	private _isCurrentConfigPublication(
+		generation: number,
+		epoch: number,
+		publicationEpoch: number,
+		installEpoch: number,
+	): boolean {
+		return (
+			this._driverLifecycle.generation === generation &&
+			this._configCheckEpoch === epoch &&
+			this._configPublicationEpoch === publicationEpoch &&
+			this._configInstallEpoch === installEpoch &&
+			this._activeConfigInstall === null &&
+			!this.closed &&
+			!this.destroyed
+		)
+	}
+
 	/**
 	 * Checks for configs updates and installs them
 	 *
@@ -3007,19 +3045,31 @@ class ZwaveClient extends TypedEventEmitter<ZwaveClientEventCallbacks> {
 		if (this.driverReady) {
 			const generation = this._driverLifecycle.generation
 			const epoch = this._configCheckEpoch
-			const publicationEpoch = ++this._configPublicationEpoch
-			const updated = await this._driver.installConfigUpdate()
-			if (
-				updated &&
-				this._driverLifecycle.generation === generation &&
-				this._configCheckEpoch === epoch &&
-				this._configPublicationEpoch === publicationEpoch &&
-				!this.closed &&
-				!this.destroyed
-			) {
-				this._publishConfigUpdateVersion(undefined)
+			const install = ++this._configInstallEpoch
+			this._activeConfigInstall = install
+			this._configPublicationEpoch++
+			let updated = false
+			try {
+				updated = await this._driver.installConfigUpdate()
+				return updated
+			} finally {
+				if (this._activeConfigInstall === install) {
+					this._activeConfigInstall = null
+					const installEpoch = ++this._configInstallEpoch
+					const publicationEpoch = ++this._configPublicationEpoch
+					if (
+						updated &&
+						this._isCurrentConfigPublication(
+							generation,
+							epoch,
+							publicationEpoch,
+							installEpoch,
+						)
+					) {
+						this._publishConfigUpdateVersion(undefined)
+					}
+				}
 			}
-			return updated
 		} else {
 			throw new DriverNotReadyError()
 		}
@@ -6760,6 +6810,7 @@ class ZwaveClient extends TypedEventEmitter<ZwaveClientEventCallbacks> {
 		chain: number,
 	) {
 		const publicationEpoch = ++this._configPublicationEpoch
+		const installEpoch = this._configInstallEpoch
 		let checked = false
 		let checkError: unknown
 		let version: string | undefined
@@ -6781,7 +6832,14 @@ class ZwaveClient extends TypedEventEmitter<ZwaveClientEventCallbacks> {
 			return
 		}
 
-		if (this._configPublicationEpoch === publicationEpoch) {
+		if (
+			this._isCurrentConfigPublication(
+				generation,
+				epoch,
+				publicationEpoch,
+				installEpoch,
+			)
+		) {
 			if (checked) {
 				this._publishConfigUpdateVersion(version)
 			} else {

--- a/api/lib/ZwaveClient.ts
+++ b/api/lib/ZwaveClient.ts
@@ -697,6 +697,7 @@ class ZwaveClient extends TypedEventEmitter<ZwaveClientEventCallbacks> {
 
 	/** Reused across init() rather than reconstructed so its generation counter, log transports and adopted server manager survive restarts */
 	private _driverLifecycle!: DriverLifecycle
+	private _controllerListenersInstalledOn: Driver['controller'] | undefined
 
 	/**
 	 * The narrow {@link ZwaveServerHost} port the server manager uses to reach
@@ -4403,33 +4404,51 @@ class ZwaveClient extends TypedEventEmitter<ZwaveClientEventCallbacks> {
 			// Arm only after the driver is ready so a fresh chain supersedes any prior same-generation ready
 			this._startScheduledConfigCheck(generation)
 
-			this.driver.controller
-				.on('inclusion started', this._onInclusionStarted.bind(this))
-				.on('exclusion started', this._onExclusionStarted.bind(this))
-				.on('inclusion stopped', this._onInclusionStopped.bind(this))
-				.on('exclusion stopped', this._onExclusionStopped.bind(this))
-				.on(
-					'inclusion state changed',
-					this._onInclusionStateChanged.bind(this),
-				)
-				.on('inclusion failed', this._onInclusionFailed.bind(this))
-				.on('exclusion failed', this._onExclusionFailed.bind(this))
-				.on('node found', this._onNodeFound.bind(this))
-				.on('node added', this._onNodeAdded.bind(this))
-				.on('node removed', this._onNodeRemoved.bind(this))
-				.on(
-					'rebuild routes progress',
-					this._onRebuildRoutesProgress.bind(this),
-				)
-				.on('rebuild routes done', this._onRebuildRoutesDone.bind(this))
-				.on(
-					'statistics updated',
-					this._onControllerStatisticsUpdated.bind(this),
-				)
-				.on(
-					'status changed',
-					this._onControllerStatusChanged.bind(this),
-				)
+			const controller = this.driver.controller
+			if (this._controllerListenersInstalledOn !== controller) {
+				this._controllerListenersInstalledOn = controller
+					.on(
+						'inclusion started',
+						this._onInclusionStarted.bind(this),
+					)
+					.on(
+						'exclusion started',
+						this._onExclusionStarted.bind(this),
+					)
+					.on(
+						'inclusion stopped',
+						this._onInclusionStopped.bind(this),
+					)
+					.on(
+						'exclusion stopped',
+						this._onExclusionStopped.bind(this),
+					)
+					.on(
+						'inclusion state changed',
+						this._onInclusionStateChanged.bind(this),
+					)
+					.on('inclusion failed', this._onInclusionFailed.bind(this))
+					.on('exclusion failed', this._onExclusionFailed.bind(this))
+					.on('node found', this._onNodeFound.bind(this))
+					.on('node added', this._onNodeAdded.bind(this))
+					.on('node removed', this._onNodeRemoved.bind(this))
+					.on(
+						'rebuild routes progress',
+						this._onRebuildRoutesProgress.bind(this),
+					)
+					.on(
+						'rebuild routes done',
+						this._onRebuildRoutesDone.bind(this),
+					)
+					.on(
+						'statistics updated',
+						this._onControllerStatisticsUpdated.bind(this),
+					)
+					.on(
+						'status changed',
+						this._onControllerStatusChanged.bind(this),
+					)
+			}
 
 			// Re-register callbacks because the coordinator survives driver replacement
 			this._inclusionCoordinator.reinstallUserCallbacks()
@@ -4438,9 +4457,6 @@ class ZwaveClient extends TypedEventEmitter<ZwaveClientEventCallbacks> {
 			logger.error(getErrorMessage(error))
 			throw error
 		}
-
-		// reset retries
-		this._driverLifecycle.resetBackoff()
 
 		this.driverInfo.homeid = this._driver.controller.homeId
 		const homeHex = '0x' + this.driverInfo?.homeid?.toString(16)

--- a/api/lib/ZwaveClient.ts
+++ b/api/lib/ZwaveClient.ts
@@ -20,6 +20,7 @@ import {
 	SecurityClass,
 	SupervisionStatus,
 	ZWaveErrorCodes,
+	isZWaveError,
 	Protocols,
 	tryUnzipFirmwareFile,
 	extractFirmware,
@@ -68,7 +69,6 @@ import type {
 	ValueID,
 	ValueMetadata,
 	ValueType,
-	ZWaveError,
 	ZWaveNode,
 	ZWaveNodeEvents,
 	ZWaveNodeFirmwareUpdateFinishedCallback,
@@ -130,6 +130,7 @@ import store from '../config/store.ts'
 import jsonStore from './jsonStore.ts'
 import * as LogManager from './logger.ts'
 import * as utils from './utils.ts'
+import { getErrorMessage } from './errors.ts'
 
 import { serverVersion, type ZwavejsServer } from '@zwave-js/server'
 import type ZwaveServerManager from '../hass/ZwaveServerManager.ts'
@@ -1334,7 +1335,7 @@ class ZwaveClient extends TypedEventEmitter<ZwaveClientEventCallbacks> {
 			},
 			onDriverReady: (generation) => this._onDriverReady(generation),
 			onDriverError: (error, skipRestart) =>
-				this._onDriverError(error as ZWaveError, skipRestart),
+				this._onDriverError(error, skipRestart),
 			onScanComplete: () => this._onScanComplete(),
 			onBootLoaderReady: () => this._onBootLoaderReady(),
 			onOTWFirmwareUpdateProgress: (progress) =>
@@ -4391,13 +4392,17 @@ class ZwaveClient extends TypedEventEmitter<ZwaveClientEventCallbacks> {
 		})
 	}
 
-	private _onDriverError(error: ZWaveError, skipRestart = false): void {
-		this._error = 'Driver: ' + error.message
+	private _onDriverError(error: unknown, skipRestart = false): void {
+		this._error = 'Driver: ' + getErrorMessage(error)
 		this.status = ZwaveClientStatus.DRIVER_FAILED
 		this._updateControllerStatus(this._error)
 		this.emit('event', EventSource.DRIVER, 'driver error', error)
 
-		if (!skipRestart && error.code === ZWaveErrorCodes.Driver_Failed) {
+		if (
+			!skipRestart &&
+			isZWaveError(error) &&
+			error.code === ZWaveErrorCodes.Driver_Failed
+		) {
 			// this cannot be recovered by zwave-js, requires a manual restart
 			this.driverReady = false
 			this.backoffRestart()

--- a/api/lib/ZwaveClient.ts
+++ b/api/lib/ZwaveClient.ts
@@ -757,6 +757,7 @@ class ZwaveClient extends TypedEventEmitter<ZwaveClientEventCallbacks> {
 	/** Changes at both boundaries of an install so checks overlapping it cannot publish a sampled pre-install version */
 	private _configInstallEpoch = 0
 	private _activeConfigInstall: number | null = null
+	private _configInstallPromise: Promise<boolean> | null = null
 	private pollIntervals: Record<string, NodeJS.Timeout>
 
 	private _lockNeighborsRefresh: boolean
@@ -882,6 +883,7 @@ class ZwaveClient extends TypedEventEmitter<ZwaveClientEventCallbacks> {
 	 */
 	init() {
 		this._driverLifecycle?.invalidateReady()
+		this._clearRuntimeTimers()
 
 		this.statelessTimeouts = {}
 		this.pollIntervals = {}
@@ -1355,10 +1357,7 @@ class ZwaveClient extends TypedEventEmitter<ZwaveClientEventCallbacks> {
 
 	/** Runs mid-close (after DriverLifecycle clears its restart timer, before it destroys server and driver) so teardown ordering is preserved */
 	private _clearRuntimeOnClose(): void {
-		if (this.healTimeout) {
-			clearTimeout(this.healTimeout)
-			this.healTimeout = null
-		}
+		this._clearRuntimeTimers()
 
 		// Retire the config-check chain on close so an in-flight check settling afterward can't re-arm
 		this._invalidateScheduledConfigCheck()
@@ -1366,6 +1365,13 @@ class ZwaveClient extends TypedEventEmitter<ZwaveClientEventCallbacks> {
 		this._inclusionCoordinator.reset()
 
 		this._firmwareUpdateService.resetGeneration()
+	}
+
+	private _clearRuntimeTimers(): void {
+		if (this.healTimeout) {
+			clearTimeout(this.healTimeout)
+			this.healTimeout = null
+		}
 
 		if (this.statelessTimeouts) {
 			for (const k in this.statelessTimeouts) {
@@ -1393,6 +1399,7 @@ class ZwaveClient extends TypedEventEmitter<ZwaveClientEventCallbacks> {
 		this._configPublicationEpoch++
 		this._configInstallEpoch++
 		this._activeConfigInstall = null
+		this._configInstallPromise = null
 		this._clearConfigCheckTimer()
 	}
 
@@ -3042,36 +3049,52 @@ class ZwaveClient extends TypedEventEmitter<ZwaveClientEventCallbacks> {
 	 *
 	 */
 	async installConfigUpdate(): Promise<boolean> {
-		if (this.driverReady) {
-			const generation = this._driverLifecycle.generation
-			const epoch = this._configCheckEpoch
-			const install = ++this._configInstallEpoch
-			this._activeConfigInstall = install
-			this._configPublicationEpoch++
-			let updated = false
-			try {
-				updated = await this._driver.installConfigUpdate()
-				return updated
-			} finally {
-				if (this._activeConfigInstall === install) {
-					this._activeConfigInstall = null
-					const installEpoch = ++this._configInstallEpoch
-					const publicationEpoch = ++this._configPublicationEpoch
-					if (
-						updated &&
-						this._isCurrentConfigPublication(
-							generation,
-							epoch,
-							publicationEpoch,
-							installEpoch,
-						)
-					) {
-						this._publishConfigUpdateVersion(undefined)
-					}
+		if (!this.driverReady) {
+			throw new DriverNotReadyError()
+		}
+
+		if (this._configInstallPromise) {
+			return this._configInstallPromise
+		}
+
+		const operation = this._installConfigUpdate()
+		this._configInstallPromise = operation
+		try {
+			return await operation
+		} finally {
+			if (this._configInstallPromise === operation) {
+				this._configInstallPromise = null
+			}
+		}
+	}
+
+	private async _installConfigUpdate(): Promise<boolean> {
+		const generation = this._driverLifecycle.generation
+		const epoch = this._configCheckEpoch
+		const install = ++this._configInstallEpoch
+		this._activeConfigInstall = install
+		this._configPublicationEpoch++
+		let updated = false
+		try {
+			updated = await this._driver.installConfigUpdate()
+			return updated
+		} finally {
+			if (this._activeConfigInstall === install) {
+				this._activeConfigInstall = null
+				const installEpoch = ++this._configInstallEpoch
+				const publicationEpoch = ++this._configPublicationEpoch
+				if (
+					updated &&
+					this._isCurrentConfigPublication(
+						generation,
+						epoch,
+						publicationEpoch,
+						installEpoch,
+					)
+				) {
+					this._publishConfigUpdateVersion(undefined)
 				}
 			}
-		} else {
-			throw new DriverNotReadyError()
 		}
 	}
 
@@ -4485,8 +4508,13 @@ class ZwaveClient extends TypedEventEmitter<ZwaveClientEventCallbacks> {
 	}
 
 	private _onDriverError(error: unknown, skipRestart = false): void {
-		if (skipRestart) {
+		const driverFailed =
+			isZWaveError(error) && error.code === ZWaveErrorCodes.Driver_Failed
+		if (skipRestart || driverFailed) {
 			this._invalidateScheduledConfigCheck()
+		}
+		if (driverFailed) {
+			this._firmwareUpdateService.resetGeneration()
 		}
 
 		this._error = 'Driver: ' + getErrorMessage(error)
@@ -4494,11 +4522,7 @@ class ZwaveClient extends TypedEventEmitter<ZwaveClientEventCallbacks> {
 		this._updateControllerStatus(this._error)
 		this.emit('event', EventSource.DRIVER, 'driver error', error)
 
-		if (
-			!skipRestart &&
-			isZWaveError(error) &&
-			error.code === ZWaveErrorCodes.Driver_Failed
-		) {
+		if (!skipRestart && driverFailed) {
 			// this cannot be recovered by zwave-js, requires a manual restart
 			this.driverReady = false
 			this.backoffRestart()

--- a/api/lib/utils.ts
+++ b/api/lib/utils.ts
@@ -9,6 +9,7 @@ import { mkdir, access, readdir, readlink, realpath } from 'node:fs/promises'
 import { fileURLToPath } from 'node:url'
 import tripleBeam from 'triple-beam'
 import { MAX_NODES_LR } from '@zwave-js/core'
+import type { LogConfig } from '@zwave-js/core'
 import type { BytesView } from '@zwave-js/shared'
 import { hasErrorCode } from './errors.ts'
 
@@ -701,6 +702,34 @@ export function buildLogConfig(
 		filename: joinPath(logsDir, 'zwavejs_%DATE%.log'),
 		forceConsole: isDocker() ? !config.logToFile : false,
 	}
+}
+
+/**
+ * Resolves a zwave-js `LogConfig` level to its level name.
+ *
+ * `buildLogConfig` stores the level as an npm numeric rank, while the driver's
+ * runtime log transports track levels by name, so the numeric form has to be
+ * resolved back to a name. Returns `undefined` for an omitted or unrecognised
+ * level so callers can fall back to a documented default.
+ */
+export function logLevelName(
+	level: LogConfig['level'] | undefined,
+): string | undefined {
+	if (typeof level === 'string') return level
+	if (typeof level === 'number') {
+		for (const [name, rank] of Object.entries(loglevels)) {
+			if (rank === level) return name
+		}
+	}
+	return undefined
+}
+
+/**
+ * Verbosity rank of a log level name on the same npm scale `buildLogConfig`
+ * encodes, or -1 when the name is unknown, so the most verbose level wins.
+ */
+export function logLevelRank(level: string): number {
+	return level in loglevels ? loglevels[level] : -1
 }
 
 /**

--- a/api/lib/zwave/DriverLifecycle.ts
+++ b/api/lib/zwave/DriverLifecycle.ts
@@ -1,0 +1,757 @@
+/**
+ * DriverLifecycle
+ * ----------------
+ * Owns the low-level lifecycle of a single `zwave-js` {@link Driver} instance
+ * on behalf of `ZwaveClient`:
+ *
+ *  - driver creation, option building, log-transport injection and binding of
+ *    the driver event handlers ({@link connect});
+ *  - the official `@zwave-js/server` (`ZwavejsServer`) coordination
+ *    (create / start-if-needed / destroy / adopt) through {@link ZwaveServerManager};
+ *  - retry/backoff restart timing ({@link backoffRestart});
+ *  - usage-statistics enable/disable and extra log transports;
+ *  - idempotent teardown ({@link close}) that destroys the server BEFORE the
+ *    driver and clears every timer it owns;
+ *  - a monotonic **generation** counter so a late `driver ready` / `error` /
+ *    `all nodes ready` / OTW callback from an obsolete driver can never mutate
+ *    a replacement generation's state (the same pattern the other extracted
+ *    services use).
+ *
+ * Everything the service needs from `ZwaveClient` — the current config, the
+ * driver field, status/ready/closed/destroyed state, node restoration, socket
+ * IO and the driver-event handler bodies (which do node-registry work retained
+ * in `ZwaveClient`) — is reached through the narrow {@link DriverLifecycleHost}
+ * port. The service therefore never imports `ZwaveClient` and cannot create an
+ * import cycle. Every accessor resolves the CURRENT value, so a driver swap on
+ * restart is honoured with nothing captured at construction time.
+ */
+
+import { Driver } from 'zwave-js'
+import type {
+	OTWFirmwareUpdateProgress,
+	OTWFirmwareUpdateResult,
+	PartialZWaveOptions,
+} from 'zwave-js'
+import { ZWaveErrorCodes, isZWaveError } from '@zwave-js/core'
+import { createDefaultTransportFormat } from '@zwave-js/core/bindings/log/node'
+import { JSONTransport } from '@zwave-js/log-transport-json'
+import type { ZwavejsServer } from '@zwave-js/server'
+
+import * as LogManager from '../logger.ts'
+import * as utils from '../utils.ts'
+import { applyExternalDriverSettings } from '../externalSettings.ts'
+import { configDbDir, logsDir, storeDir } from '../../config/app.ts'
+import { PkgFsBindings } from '../PkgFsBindings.ts'
+import { deviceConfigPriorityDir } from '../Constants.ts'
+import ZwaveServerManager, {
+	type ZwaveServerHost,
+} from '../../hass/ZwaveServerManager.ts'
+import {
+	ZwaveClientStatus,
+	type ZwaveConfig,
+	type InclusionUserCallbacks,
+} from './ports.ts'
+
+const logger = LogManager.module('Z-Wave')
+
+/**
+ * Log levels ordered from least to most verbose. Used to pick the most
+ * verbose level requested by any registered extra log transport.
+ */
+const LOG_LEVEL_ORDER = ['error', 'warn', 'info', 'verbose', 'debug', 'silly']
+
+/**
+ * Narrow port back into `ZwaveClient`. Every method resolves the CURRENT
+ * client state so the lifecycle keeps working across driver/config swaps
+ * without capturing anything at construction time.
+ */
+export interface DriverLifecycleHost {
+	/** The current Z-Wave configuration (`ZwaveClient.cfg`). */
+	getConfig(): ZwaveConfig
+	/** The current driver instance (`ZwaveClient._driver`), if any. */
+	getDriver(): Driver | null
+	/** Store the driver instance back on the client (compatibility field). */
+	setDriver(driver: Driver | null): void
+	/** `ZwaveClient.driverReady` getter (driver && ready && !closed). */
+	isDriverReady(): boolean
+	/** The raw `ZwaveClient._driverReady` field (no closed/driver checks). */
+	isDriverReadyRaw(): boolean
+	/** `ZwaveClient.closed`. */
+	isClosed(): boolean
+	/** Set `ZwaveClient.closed`. */
+	setClosed(closed: boolean): void
+	/** `ZwaveClient.destroyed`. */
+	isDestroyed(): boolean
+	/** Set `ZwaveClient.status`. */
+	setStatus(status: ZwaveClientStatus): void
+	/** Set `ZwaveClient.driverReady` (fires `driverStatus` when it changes). */
+	setDriverReady(ready: boolean): void
+	/** True when at least one socket client is connected. */
+	hasConnectedClients(): Promise<boolean>
+	/** Forward a driver log line to the `debug` socket room. */
+	emitDebug(message: string): void
+	/** The inclusion user callbacks to attach when no server is enabled. */
+	getInclusionUserCallbacks(): InclusionUserCallbacks
+	/** Install the inclusion user callbacks on the current driver. */
+	installUserCallbacks(): void
+	/** Persist the current config to settings.json (startup migrations). */
+	persistConfig(): Promise<void>
+	/** Re-run the full client init/connect (used by the backoff timer). */
+	restart(): Promise<void>
+	/** Build the {@link ZwaveServerHost} for a standalone fallback manager. */
+	buildServerHost(): ZwaveServerHost
+	/**
+	 * Clear the runtime timers/throttles that live on `ZwaveClient` and reset
+	 * the inclusion coordinator + firmware update service generations. Run
+	 * during {@link close} after the lifecycle's own timers are cleared and
+	 * before the server/driver are destroyed.
+	 */
+	clearRuntimeOnClose(): void
+	/**
+	 * Finalise a non-`keepListeners` close: mark the client destroyed and
+	 * remove all its event listeners.
+	 */
+	finalizeClose(): void
+	/** Driver `driver ready` handler body (node restoration lives here). */
+	onDriverReady(generation: number): Promise<void>
+	/** Driver `error` handler body. */
+	onDriverError(error: unknown, skipRestart: boolean): void
+	/** Driver `all nodes ready` handler body. */
+	onScanComplete(): void
+	/** Driver `bootloader ready` handler body. */
+	onBootLoaderReady(): void
+	/** Driver `firmware update progress` (OTW) handler body. */
+	onOTWFirmwareUpdateProgress(progress: OTWFirmwareUpdateProgress): void
+	/** Driver `firmware update finished` (OTW) handler body. */
+	onOTWFirmwareUpdateFinished(result: OTWFirmwareUpdateResult): void
+}
+
+export class DriverLifecycle {
+	private readonly host: DriverLifecycleHost
+
+	/**
+	 * Monotonically increasing generation counter. Bumped when a new driver
+	 * starts connecting AND when the client is closed, so any in-flight async
+	 * work from an obsolete driver detects the mismatch and aborts instead of
+	 * mutating the replacement generation. NEVER reset by `init()`.
+	 */
+	private _generation = 0
+
+	private _backoffRetry = 0
+	private _restartTimeout: NodeJS.Timeout | null = null
+
+	private _extraLogTransports: Array<{ transport: any; level?: string }> = []
+
+	private _serverManager?: ZwaveServerManager
+
+	constructor(host: DriverLifecycleHost) {
+		this.host = host
+	}
+
+	/** The current generation token (see {@link _generation}). */
+	get generation(): number {
+		return this._generation
+	}
+
+	// -----------------------------------------------------------------------
+	// @zwave-js/server coordination
+	// -----------------------------------------------------------------------
+
+	/**
+	 * The lifecycle-managed `@zwave-js/server` subsystem. In production this is
+	 * the HA-owned manager adopted via {@link adoptServerManager}; a
+	 * directly-constructed client lazily builds a standalone fallback here on
+	 * first access so its server lifecycle keeps working with no coordinator.
+	 */
+	get zwaveServer(): ZwaveServerManager {
+		if (!this._serverManager) {
+			this._serverManager = new ZwaveServerManager(
+				this.host.buildServerHost(),
+			)
+		}
+		return this._serverManager
+	}
+
+	/** The adopted/lazily-built server manager, or `undefined` if none yet. */
+	get serverManager(): ZwaveServerManager | undefined {
+		return this._serverManager
+	}
+
+	get server(): ZwavejsServer | null {
+		return this._serverManager?.server ?? null
+	}
+
+	set server(value: ZwavejsServer | null) {
+		// Route through the lazy accessor so a directly-constructed client
+		// (standalone / tests) that assigns `server` before any create() still
+		// has a manager to hold it.
+		this.zwaveServer.server = value
+	}
+
+	/**
+	 * Adopt the HA-owned server manager. Called by `HomeAssistantManager` once,
+	 * before the driver connects, so `create()/startIfNeeded()/destroy()` all
+	 * drive the manager the coordinator owns.
+	 */
+	adoptServerManager(manager: ZwaveServerManager): void {
+		this._serverManager = manager
+	}
+
+	/**
+	 * Construct (but do not yet start) the server. Called from {@link connect}
+	 * right after the driver is created (and only when `serverEnabled`), so the
+	 * server always exists BEFORE the driver becomes ready.
+	 */
+	createServer(): void {
+		this.zwaveServer.create()
+	}
+
+	// -----------------------------------------------------------------------
+	// Statistics
+	// -----------------------------------------------------------------------
+
+	enableStatistics(): void {
+		const driver = this.host.getDriver()
+		const cfg = this.host.getConfig()
+		if (driver) {
+			driver.enableStatistics({
+				applicationName:
+					utils.pkgJson.name +
+					(cfg.serverEnabled ? ' / zwave-js-server' : ''),
+				applicationVersion: utils.pkgJson.version,
+			})
+			logger.info('Zwavejs usage statistics ENABLED')
+		}
+
+		logger.warn(
+			'Zwavejs driver is not ready yet, statistics will be enabled on driver initialization',
+		)
+	}
+
+	disableStatistics(): void {
+		const driver = this.host.getDriver()
+		if (driver) {
+			driver.disableStatistics()
+			logger.info('Zwavejs usage statistics DISABLED')
+		}
+
+		logger.warn(
+			'Zwavejs driver is not ready yet, statistics will be disabled on driver initialization',
+		)
+	}
+
+	// -----------------------------------------------------------------------
+	// Extra log transports (persist across driver restarts)
+	// -----------------------------------------------------------------------
+
+	/**
+	 * Register an extra log transport that persists across driver restarts.
+	 * If the driver is already running, the transport is applied immediately.
+	 */
+	addExtraLogTransport(transport: any, level?: string): void {
+		this._extraLogTransports.push({ transport, level })
+		const driver = this.host.getDriver()
+		if (driver && this.host.isDriverReadyRaw()) {
+			const config: any = {
+				transports: [transport],
+			}
+			if (level) {
+				config.level = level
+			}
+			driver.updateLogConfig(config)
+		}
+	}
+
+	/**
+	 * Remove a previously registered extra log transport.
+	 * If the driver is running, the transport is detached immediately.
+	 */
+	removeExtraLogTransport(transport: any): void {
+		const idx = this._extraLogTransports.findIndex(
+			(e) => e.transport === transport,
+		)
+		if (idx !== -1) {
+			this._extraLogTransports.splice(idx, 1)
+		}
+		const driver = this.host.getDriver()
+		if (driver && this.host.isDriverReadyRaw()) {
+			driver.updateLogConfig({
+				transports: [],
+			})
+		}
+	}
+
+	// -----------------------------------------------------------------------
+	// Restart / destroyed helpers
+	// -----------------------------------------------------------------------
+
+	/** Reset the exponential backoff counter (called on `driver ready`). */
+	resetBackoff(): void {
+		this._backoffRetry = 0
+	}
+
+	backoffRestart(): void {
+		// fix edge case where client is half closed and restart is called
+		if (this.checkIfDestroyed()) {
+			return
+		}
+
+		const timeout = Math.min(2 ** this._backoffRetry * 1000, 15000)
+		this._backoffRetry++
+
+		logger.info(
+			`Restarting client in ${timeout / 1000} seconds, retry ${
+				this._backoffRetry
+			}`,
+		)
+
+		this._restartTimeout = setTimeout(() => {
+			this.host.restart().catch((error: Error) => {
+				logger.error(`Error while restarting driver: ${error.message}`)
+			})
+		}, timeout)
+	}
+
+	/**
+	 * Checks if the client is destroyed and if so closes it.
+	 * @returns True if the client is destroyed
+	 */
+	checkIfDestroyed(): boolean {
+		if (this.host.isDestroyed()) {
+			logger.debug(
+				`Client listening on '${this.host.getConfig().port}' is destroyed, closing`,
+			)
+			this.close(true).catch((error: Error) => {
+				logger.error(`Error while closing driver: ${error.message}`)
+			})
+			return true
+		}
+
+		return false
+	}
+
+	// -----------------------------------------------------------------------
+	// connect / close
+	// -----------------------------------------------------------------------
+
+	async connect(): Promise<void> {
+		const cfg = this.host.getConfig()
+
+		// When ZWAVE_PORT env var is set, force enable and override port
+		if (process.env.ZWAVE_PORT) {
+			cfg.enabled = true
+			cfg.port = process.env.ZWAVE_PORT
+		}
+
+		if (cfg.enabled === false) {
+			logger.info('Z-Wave driver DISABLED')
+			return
+		}
+
+		if (this.host.isDriverReady()) {
+			logger.info(`Driver already connected to ${cfg.port}`)
+			return
+		}
+
+		// this could happen when the driver fails the connect and a reconnect timeout triggers
+		if (this.host.isClosed() || this.checkIfDestroyed()) {
+			return
+		}
+
+		if (!cfg?.port) {
+			logger.warn('Z-Wave driver not inited, no port configured')
+			return
+		}
+
+		// Commit to a new driver generation. Any obsolete driver's late async
+		// callbacks now detect the bump and abort.
+		const generation = ++this._generation
+		const port = cfg.port
+
+		let shouldUpdateSettings = false
+
+		const priorityDir =
+			cfg.deviceConfigPriorityDir || deviceConfigPriorityDir
+
+		// extend options with hidden `options`
+		const storage: NonNullable<PartialZWaveOptions['storage']> = {
+			cacheDir: storeDir,
+			deviceConfigPriorityDir: priorityDir,
+		}
+		const logConfig = utils.buildLogConfig(cfg, logsDir)
+		const features: NonNullable<PartialZWaveOptions['features']> = {
+			unresponsiveControllerRecovery: cfg.disableControllerRecovery
+				? false
+				: true,
+			watchdog: cfg.disableWatchdog ? false : true,
+		}
+		const zwaveOptions: PartialZWaveOptions = {
+			bootloaderMode: cfg.allowBootloaderOnly ? 'allow' : 'recover',
+			storage,
+			// https://zwave-js.github.io/node-zwave-js/#/api/driver?id=logconfig
+			logConfig,
+			emitValueUpdateAfterSetValue: true,
+			apiKeys: {
+				firmwareUpdateService:
+					'421e29797c3c2926f84efc737352d6190354b3b526a6dce6633674dd33a8a4f964c794f5',
+			},
+			timeouts: {
+				report: cfg.higherReportsTimeout ? 10000 : undefined,
+				sendToSleep: cfg.sendToSleepTimeout,
+				response: cfg.responseTimeout,
+			},
+			features,
+			userAgent: {
+				[utils.pkgJson.name]: utils.pkgJson.version,
+			},
+			disableOptimisticValueUpdate: cfg.disableOptimisticValueUpdate,
+		}
+
+		// when no env is specified copy config db to store dir
+		// fixes issues with pkg (and no more need to set this env on docker)
+		if (!process.env.ZWAVEJS_EXTERNAL_CONFIG) {
+			storage.deviceConfigExternalDir = configDbDir
+		}
+
+		if (cfg.rf) {
+			const { region, txPower, maxLongRangePowerlevel } = cfg.rf
+
+			let { autoPowerlevels } = cfg.rf
+			const rf: NonNullable<PartialZWaveOptions['rf']> = {}
+			zwaveOptions.rf = rf
+
+			if (typeof region === 'number') {
+				rf.region = region
+			}
+
+			if (
+				autoPowerlevels === undefined &&
+				typeof maxLongRangePowerlevel !== 'number' &&
+				typeof txPower?.powerlevel !== 'number'
+			) {
+				// if autoPowerlevels is undefined and maxLongRangePowerlevel is not a number (likely '' or undefined), assume autoPowerlevels is true
+				autoPowerlevels = true
+				cfg.rf.autoPowerlevels = true
+				shouldUpdateSettings = true
+			}
+
+			if (autoPowerlevels) {
+				rf.maxLongRangePowerlevel = 'auto'
+				rf.txPower ??= {}
+				rf.txPower.powerlevel = 'auto'
+			}
+
+			if (
+				!autoPowerlevels &&
+				(maxLongRangePowerlevel === 'auto' ||
+					typeof maxLongRangePowerlevel === 'number')
+			) {
+				rf.maxLongRangePowerlevel = maxLongRangePowerlevel
+			}
+
+			if (txPower) {
+				if (
+					!autoPowerlevels &&
+					(txPower.powerlevel === 'auto' ||
+						typeof txPower.powerlevel === 'number')
+				) {
+					rf.txPower ??= {}
+					rf.txPower.powerlevel = txPower.powerlevel
+				}
+
+				if (typeof txPower.measured0dBm === 'number') {
+					rf.txPower ??= {}
+					rf.txPower.measured0dBm = txPower.measured0dBm
+				}
+			}
+		}
+
+		if ((process as NodeJS.Process & { pkg?: unknown }).pkg) {
+			// Ensure Z-Wave JS is looking for the configuration files in the right place
+			// when running inside a pkg bundle
+			zwaveOptions.host ??= {}
+			zwaveOptions.host.fs = new PkgFsBindings()
+		}
+
+		// ensure deviceConfigPriorityDir exists to prevent warnings #2374
+		// lgtm [js/path-injection]
+		await utils.ensureDir(priorityDir)
+
+		if (this._generation !== generation) {
+			return
+		}
+
+		// when not set let zwavejs handle this based on the environment
+		if (typeof cfg.enableSoftReset === 'boolean') {
+			features.softReset = cfg.enableSoftReset
+		}
+
+		// when server is not enabled, disable the user callbacks set/remove
+		// so it can be used through MQTT
+		if (!cfg.serverEnabled) {
+			zwaveOptions.inclusionUserCallbacks =
+				this.host.getInclusionUserCallbacks()
+		}
+
+		if (cfg.scales) {
+			const preferences = utils.buildPreferences(cfg)
+			if (preferences) {
+				zwaveOptions.preferences = preferences
+			}
+		}
+
+		Object.assign(zwaveOptions, cfg.options)
+
+		let s0Key: string | undefined
+
+		// back compatibility
+		if (cfg.networkKey) {
+			s0Key = cfg.networkKey
+			delete cfg.networkKey
+		}
+
+		cfg.securityKeys = cfg.securityKeys || {}
+
+		// update settings to fix compatibility
+		if (s0Key && !cfg.securityKeys.S0_Legacy) {
+			cfg.securityKeys.S0_Legacy = s0Key
+			shouldUpdateSettings = true
+		}
+
+		utils.parseSecurityKeys(cfg, zwaveOptions)
+
+		// Apply driver-only external settings (storage, presets, logFilename, forceConsole).
+		// These are not in ZwaveConfig/settings.json, so they must be applied directly to driver options.
+		applyExternalDriverSettings(zwaveOptions)
+
+		const logTransport = new JSONTransport()
+		logTransport.format = createDefaultTransportFormat(true, false)
+
+		if (logConfig) {
+			logConfig.transports = [
+				logTransport,
+				...this._extraLogTransports.map((e) => e.transport),
+			]
+
+			// If any extra transport requires a more verbose log level, apply it.
+			// Use the most verbose (highest priority) level among all extra transports.
+			const extraLevel = this._extraLogTransports
+				.map((e) => e.level)
+				.filter((level): level is string => Boolean(level))
+				.reduce<string | undefined>((best, level) => {
+					if (!best) return level
+					return LOG_LEVEL_ORDER.indexOf(level) >
+						LOG_LEVEL_ORDER.indexOf(best)
+						? level
+						: best
+				}, undefined)
+			if (extraLevel) {
+				const currentLevel = logConfig.level
+				const currentIdx =
+					typeof currentLevel === 'string'
+						? LOG_LEVEL_ORDER.indexOf(currentLevel)
+						: -1
+				const extraIdx = LOG_LEVEL_ORDER.indexOf(extraLevel)
+				if (extraIdx > currentIdx) {
+					logConfig.level = extraLevel
+				}
+			}
+		}
+
+		logTransport.stream.on('data', (data: any) => {
+			this.host.emitDebug(data.message.toString())
+		})
+
+		try {
+			if (shouldUpdateSettings) {
+				await this.host.persistConfig()
+				if (this._generation !== generation) {
+					return
+				}
+			}
+			// init driver here because if connect fails the driver is destroyed
+			// this could throw so include in the try/catch
+			const driver = new Driver(port, zwaveOptions)
+			this.host.setDriver(driver)
+			driver.on('error', (error) =>
+				this.dispatchDriverError(generation, error),
+			)
+			driver.on('driver ready', () =>
+				this.dispatchDriverReady(generation),
+			)
+			driver.on('all nodes ready', () =>
+				this.dispatchScanComplete(generation),
+			)
+			driver.on('bootloader ready', () =>
+				this.dispatchBootLoaderReady(generation),
+			)
+			driver.on('firmware update progress', (progress) =>
+				this.dispatchOTWFirmwareUpdateProgress(generation, progress),
+			)
+			driver.on('firmware update finished', (result) =>
+				this.dispatchOTWFirmwareUpdateFinished(generation, result),
+			)
+
+			logger.info(`Connecting to ${port}`)
+
+			// setup user callbacks only if there are connected clients
+			const hasConnectedClients = await this.host.hasConnectedClients()
+
+			if (this._generation !== generation) {
+				return
+			}
+
+			if (hasConnectedClients) {
+				this.host.installUserCallbacks()
+			}
+
+			await driver.start()
+
+			if (this._generation !== generation) {
+				return
+			}
+
+			if (this.checkIfDestroyed()) {
+				return
+			}
+
+			if (cfg.serverEnabled) {
+				this.createServer()
+			}
+
+			if (cfg.enableStatistics) {
+				this.enableStatistics()
+			}
+
+			this.host.setStatus(ZwaveClientStatus.CONNECTED)
+		} catch (error) {
+			// destroy diver instance when it fails
+			const driver = this.host.getDriver()
+			if (driver) {
+				driver.destroy().catch((err: Error) => {
+					logger.error(
+						`Error while destroying driver ${err.message}`,
+						error,
+					)
+				})
+			}
+
+			if (this._generation !== generation) {
+				return
+			}
+
+			if (this.checkIfDestroyed()) {
+				return
+			}
+
+			this.host.onDriverError(error, true)
+
+			if (
+				!isZWaveError(error) ||
+				error.code !== ZWaveErrorCodes.Driver_InvalidOptions
+			) {
+				this.backoffRestart()
+			} else {
+				logger.error(
+					`Invalid options for driver: ${error.message}`,
+					error,
+				)
+			}
+		}
+	}
+
+	/**
+	 * Close the client connection. Destroys the server BEFORE the driver and
+	 * clears every timer the lifecycle owns. Idempotent and safe to retry.
+	 */
+	async close(keepListeners = false): Promise<void> {
+		// Invalidate any in-flight generation so a driver that becomes ready or
+		// errors after this point cannot mutate replacement state.
+		this._generation++
+
+		this.host.setStatus(ZwaveClientStatus.CLOSED)
+		this.host.setClosed(true)
+		this.host.setDriverReady(false)
+
+		if (this._restartTimeout) {
+			clearTimeout(this._restartTimeout)
+			this._restartTimeout = null
+		}
+
+		// Clears heal/updates/stateless/poll/throttle timers on ZwaveClient and
+		// resets the inclusion coordinator + firmware update service.
+		this.host.clearRuntimeOnClose()
+
+		if (this._serverManager) {
+			await this._serverManager.destroy()
+		}
+
+		const driver = this.host.getDriver()
+		if (driver) {
+			await driver.destroy()
+			this.host.setDriver(null)
+		}
+
+		if (!keepListeners) {
+			this.host.finalizeClose()
+		}
+
+		logger.info('Client closed')
+	}
+
+	// -----------------------------------------------------------------------
+	// Generation-guarded driver-event dispatch
+	//
+	// The handler bodies (which touch ZwaveClient node/controller state) stay
+	// in ZwaveClient behind the host port; the dispatch here drops any event
+	// coming from an obsolete driver generation.
+	// -----------------------------------------------------------------------
+
+	private dispatchDriverReady(generation: number): void {
+		if (this._generation !== generation) {
+			return
+		}
+		void this.host.onDriverReady(generation)
+	}
+
+	private dispatchDriverError(generation: number, error: Error): void {
+		if (this._generation !== generation) {
+			return
+		}
+		this.host.onDriverError(error, false)
+	}
+
+	private dispatchScanComplete(generation: number): void {
+		if (this._generation !== generation) {
+			return
+		}
+		this.host.onScanComplete()
+	}
+
+	private dispatchBootLoaderReady(generation: number): void {
+		if (this._generation !== generation) {
+			return
+		}
+		this.host.onBootLoaderReady()
+	}
+
+	private dispatchOTWFirmwareUpdateProgress(
+		generation: number,
+		progress: OTWFirmwareUpdateProgress,
+	): void {
+		if (this._generation !== generation) {
+			return
+		}
+		this.host.onOTWFirmwareUpdateProgress(progress)
+	}
+
+	private dispatchOTWFirmwareUpdateFinished(
+		generation: number,
+		result: OTWFirmwareUpdateResult,
+	): void {
+		if (this._generation !== generation) {
+			return
+		}
+		this.host.onOTWFirmwareUpdateFinished(result)
+	}
+}

--- a/api/lib/zwave/DriverLifecycle.ts
+++ b/api/lib/zwave/DriverLifecycle.ts
@@ -17,6 +17,7 @@ import type Transport from 'winston-transport'
 
 import * as LogManager from '../logger.ts'
 import * as utils from '../utils.ts'
+import { getErrorMessage, toError } from '../errors.ts'
 import { applyExternalDriverSettings } from '../externalSettings.ts'
 import { configDbDir, logsDir, storeDir } from '../../config/app.ts'
 import { PkgFsBindings } from '../PkgFsBindings.ts'
@@ -273,8 +274,10 @@ export class DriverLifecycle {
 			if (this._generation !== generation) {
 				return
 			}
-			this.host.restart().catch((error: Error) => {
-				logger.error(`Error while restarting driver: ${error.message}`)
+			this.host.restart().catch((error: unknown) => {
+				logger.error(
+					`Error while restarting driver: ${getErrorMessage(error)}`,
+				)
 			})
 		}, timeout)
 	}
@@ -284,8 +287,10 @@ export class DriverLifecycle {
 			logger.debug(
 				`Client listening on '${this.host.getConfig().port}' is destroyed, closing`,
 			)
-			this.close(true).catch((error: Error) => {
-				logger.error(`Error while closing driver: ${error.message}`)
+			this.close(true).catch((error: unknown) => {
+				logger.error(
+					`Error while closing driver: ${getErrorMessage(error)}`,
+				)
 			})
 			return true
 		}
@@ -647,7 +652,7 @@ export class DriverLifecycle {
 			await driver.destroy()
 		} catch (err) {
 			logger.error(
-				`Error while destroying driver ${(err as Error).message}`,
+				`Error while destroying driver ${getErrorMessage(err)}`,
 				cause,
 			)
 			// Keep this instance as owner so a later close/retry can destroy it again instead of stranding the port it may still hold
@@ -699,7 +704,13 @@ export class DriverLifecycle {
 		if (this._generation !== generation) {
 			return
 		}
-		void this.host.onDriverReady(generation)
+		void this.host.onDriverReady(generation).catch((error: unknown) => {
+			if (this._generation !== generation) {
+				return
+			}
+			this.host.onDriverError(toError(error), true)
+			this.backoffRestart()
+		})
 	}
 
 	private dispatchDriverError(generation: number, error: Error): void {

--- a/api/lib/zwave/DriverLifecycle.ts
+++ b/api/lib/zwave/DriverLifecycle.ts
@@ -17,7 +17,7 @@ import type Transport from 'winston-transport'
 
 import * as LogManager from '../logger.ts'
 import * as utils from '../utils.ts'
-import { getErrorMessage, toError } from '../errors.ts'
+import { getErrorMessage } from '../errors.ts'
 import { applyExternalDriverSettings } from '../externalSettings.ts'
 import { configDbDir, logsDir, storeDir } from '../../config/app.ts'
 import { PkgFsBindings } from '../PkgFsBindings.ts'
@@ -824,7 +824,9 @@ export class DriverLifecycle {
 		this._completedReadyEpoch = -1
 		this._pendingScan = undefined
 		this.host.setDriverReady(false)
-		this.host.onDriverError(toError(error), true)
+		const readyError =
+			error instanceof Error ? error : new Error(getErrorMessage(error))
+		this.host.onDriverError(readyError, true)
 		this.backoffRestart()
 	}
 

--- a/api/lib/zwave/DriverLifecycle.ts
+++ b/api/lib/zwave/DriverLifecycle.ts
@@ -708,6 +708,7 @@ export class DriverLifecycle {
 			if (this._generation !== generation) {
 				return
 			}
+			this.host.setDriverReady(false)
 			this.host.onDriverError(toError(error), true)
 			this.backoffRestart()
 		})

--- a/api/lib/zwave/DriverLifecycle.ts
+++ b/api/lib/zwave/DriverLifecycle.ts
@@ -102,6 +102,9 @@ export class DriverLifecycle {
 	/** Generation `_activeConnect` belongs to, so a duplicate connect coalesces only while this still equals `_generation` */
 	private _activeConnectGeneration = 0
 
+	/** Shares one terminal destroy attempt across overlapping close and stale-start cleanup */
+	private readonly _driverDestructions = new WeakMap<Driver, Promise<void>>()
+
 	private _extraLogTransports: Array<{
 		transport: Transport
 		level?: string
@@ -681,7 +684,7 @@ export class DriverLifecycle {
 		cause?: unknown,
 	): Promise<void> {
 		try {
-			await driver.destroy()
+			await this.destroyDriver(driver)
 		} catch (err) {
 			logger.error(
 				`Error while destroying driver ${getErrorMessage(err)}`,
@@ -696,6 +699,17 @@ export class DriverLifecycle {
 		if (this.host.getDriver() === driver) {
 			this.host.setDriver(null)
 		}
+	}
+
+	private destroyDriver(driver: Driver): Promise<void> {
+		const activeDestruction = this._driverDestructions.get(driver)
+		if (activeDestruction) {
+			return activeDestruction
+		}
+
+		const destruction = Promise.resolve().then(() => driver.destroy())
+		this._driverDestructions.set(driver, destruction)
+		return destruction
 	}
 
 	/** Idempotent and safe to retry */
@@ -727,7 +741,7 @@ export class DriverLifecycle {
 		let destroyError: unknown
 		if (driver) {
 			try {
-				await driver.destroy()
+				await this.destroyDriver(driver)
 			} catch (error) {
 				// zwave-js memoizes an unsettled destroy promise after failure, so this instance cannot be retried safely
 				if (this.host.getDriver() === driver) {

--- a/api/lib/zwave/DriverLifecycle.ts
+++ b/api/lib/zwave/DriverLifecycle.ts
@@ -90,6 +90,8 @@ export class DriverLifecycle {
 
 	/** Separately fences repeated ready events and init() calls that keep the same driver generation */
 	private _readyEpoch = 0
+	private _completedReadyEpoch = -1
+	private _pendingScan: { generation: number; readyEpoch: number } | undefined
 
 	private _backoffRetry = 0
 	private _restartTimeout: NodeJS.Timeout | null = null
@@ -135,6 +137,8 @@ export class DriverLifecycle {
 
 	invalidateReady(): void {
 		this._readyEpoch++
+		this._completedReadyEpoch = -1
+		this._pendingScan = undefined
 	}
 
 	/** Lazily builds a standalone fallback manager on first access so a directly-constructed client's server lifecycle works with no coordinator to adopt one */
@@ -522,9 +526,12 @@ export class DriverLifecycle {
 
 		Object.assign(zwaveOptions, cfg.options)
 
-		// Clone logConfig before the enrichment below: `Object.assign(cfg.options)` above can alias it onto the persisted `cfg.options.logConfig`, so in-place mutation would leak driver-only transports/level into the user's saved config
+		// Clone mutable option bags after Object.assign so driver-only log and external storage settings cannot leak into persisted config
 		if (zwaveOptions.logConfig) {
 			zwaveOptions.logConfig = { ...zwaveOptions.logConfig }
+		}
+		if (zwaveOptions.storage) {
+			zwaveOptions.storage = { ...zwaveOptions.storage }
 		}
 
 		let s0Key: string | undefined
@@ -668,7 +675,7 @@ export class DriverLifecycle {
 		}
 	}
 
-	/** Awaits destroy() before clearing the host's driver field so the failed driver releases the serial port before a retry or coalesced connect builds a replacement */
+	/** Awaits destroy() before clearing the host's driver field whenever teardown completes normally */
 	private async teardownConnectDriver(
 		driver: Driver,
 		cause?: unknown,
@@ -680,7 +687,10 @@ export class DriverLifecycle {
 				`Error while destroying driver ${getErrorMessage(err)}`,
 				cause,
 			)
-			// Keep this instance as owner so a later close/retry can destroy it again instead of stranding the port it may still hold
+			// zwave-js leaves its memoized destroy promise pending after rejection, so release this terminal instance instead of hanging a later close
+			if (this.host.getDriver() === driver) {
+				this.host.setDriver(null)
+			}
 			return
 		}
 		if (this.host.getDriver() === driver) {
@@ -692,7 +702,7 @@ export class DriverLifecycle {
 	async close(keepListeners = false): Promise<void> {
 		// Bump the generation so a driver that becomes ready or errors after this cannot mutate replacement state
 		this._generation++
-		this._readyEpoch++
+		this.invalidateReady()
 
 		// Stop a post-close duplicate connect from coalescing onto the superseded startup
 		this._activeConnect = null
@@ -713,9 +723,22 @@ export class DriverLifecycle {
 		}
 
 		const driver = this.host.getDriver()
+		let destroyFailed = false
+		let destroyError: unknown
 		if (driver) {
-			await driver.destroy()
-			this.host.setDriver(null)
+			try {
+				await driver.destroy()
+			} catch (error) {
+				// zwave-js memoizes an unsettled destroy promise after failure, so this instance cannot be retried safely
+				if (this.host.getDriver() === driver) {
+					this.host.setDriver(null)
+				}
+				destroyFailed = true
+				destroyError = error
+			}
+			if (this.host.getDriver() === driver) {
+				this.host.setDriver(null)
+			}
 		}
 
 		if (!keepListeners) {
@@ -723,6 +746,9 @@ export class DriverLifecycle {
 		}
 
 		logger.info('Client closed')
+		if (destroyFailed) {
+			throw destroyError
+		}
 	}
 
 	// Generation-guarded dispatch drops events from an obsolete driver generation
@@ -732,6 +758,8 @@ export class DriverLifecycle {
 		}
 
 		const readyEpoch = ++this._readyEpoch
+		this._completedReadyEpoch = -1
+		this._pendingScan = undefined
 		let ready: Promise<void>
 		try {
 			ready = this.host.onDriverReady(generation, readyEpoch)
@@ -741,9 +769,30 @@ export class DriverLifecycle {
 			return
 		}
 
-		void ready.catch((error: unknown) => {
-			this.handleDriverReadyFailure(generation, readyEpoch, error)
-		})
+		void ready
+			.then(() => {
+				this.completeDriverReady(generation, readyEpoch)
+			})
+			.catch((error: unknown) => {
+				this.handleDriverReadyFailure(generation, readyEpoch, error)
+			})
+	}
+
+	private completeDriverReady(generation: number, readyEpoch: number): void {
+		if (
+			this._generation !== generation ||
+			this._readyEpoch !== readyEpoch
+		) {
+			return
+		}
+		this._completedReadyEpoch = readyEpoch
+		if (
+			this._pendingScan?.generation === generation &&
+			this._pendingScan.readyEpoch === readyEpoch
+		) {
+			this._pendingScan = undefined
+			this.publishScanComplete()
+		}
 	}
 
 	private handleDriverReadyFailure(
@@ -758,6 +807,8 @@ export class DriverLifecycle {
 			return
 		}
 		this._readyEpoch++
+		this._completedReadyEpoch = -1
+		this._pendingScan = undefined
 		this.host.setDriverReady(false)
 		this.host.onDriverError(toError(error), true)
 		this.backoffRestart()
@@ -772,7 +823,7 @@ export class DriverLifecycle {
 			error.code === ZWaveErrorCodes.Driver_Failed
 		) {
 			this._generation++
-			this._readyEpoch++
+			this.invalidateReady()
 		}
 		this.host.onDriverError(error, false)
 	}
@@ -781,7 +832,22 @@ export class DriverLifecycle {
 		if (this._generation !== generation) {
 			return
 		}
-		this.host.onScanComplete()
+		const readyEpoch = this._readyEpoch
+		if (this._completedReadyEpoch === readyEpoch) {
+			this.publishScanComplete()
+		} else {
+			this._pendingScan = { generation, readyEpoch }
+		}
+	}
+
+	private publishScanComplete(): void {
+		try {
+			this.host.onScanComplete()
+		} catch (error) {
+			logger.error(
+				`Error while handling scan completion: ${getErrorMessage(error)}`,
+			)
+		}
 	}
 
 	private dispatchBootLoaderReady(generation: number): void {

--- a/api/lib/zwave/DriverLifecycle.ts
+++ b/api/lib/zwave/DriverLifecycle.ts
@@ -305,7 +305,25 @@ export class DriverLifecycle {
 			}`,
 		)
 
+		// Coalesce repeated backoff schedules into a SINGLE pending restart.
+		// Without this, a second call would overwrite `_restartTimeout` and
+		// leak the earlier handle — leaving it live to fire an extra restart.
+		// The most recent call wins (its delay is used), matching the previous
+		// "latest schedule decides the delay" behavior.
+		if (this._restartTimeout) {
+			clearTimeout(this._restartTimeout)
+			this._restartTimeout = null
+		}
+
+		// Fence the callback to the generation active at schedule time, so a
+		// close()/restart or a healthy replacement driver (either of which bumps
+		// the generation) can never let a stale timer fire an unwanted restart.
+		const generation = this._generation
 		this._restartTimeout = setTimeout(() => {
+			this._restartTimeout = null
+			if (this._generation !== generation) {
+				return
+			}
 			this.host.restart().catch((error: Error) => {
 				logger.error(`Error while restarting driver: ${error.message}`)
 			})
@@ -527,8 +545,16 @@ export class DriverLifecycle {
 		const logTransport = new JSONTransport()
 		logTransport.format = createDefaultTransportFormat(true, false)
 
-		if (logConfig) {
-			logConfig.transports = [
+		// Resolve the log transports/level against the FINAL `logConfig` that
+		// the driver will actually receive — i.e. AFTER `Object.assign(cfg.options)`
+		// and `applyExternalDriverSettings()` above may have replaced or mutated
+		// it. Mutating the pre-override local `logConfig` here would silently drop
+		// the required JSON transport (and every registered extra transport) from
+		// the driver whenever a documented `zwave.options.logConfig` override
+		// replaced the object reference.
+		const finalLogConfig = zwaveOptions.logConfig
+		if (finalLogConfig) {
+			finalLogConfig.transports = [
 				logTransport,
 				...this._extraLogTransports.map((e) => e.transport),
 			]
@@ -546,14 +572,14 @@ export class DriverLifecycle {
 						: best
 				}, undefined)
 			if (extraLevel) {
-				const currentLevel = logConfig.level
+				const currentLevel = finalLogConfig.level
 				const currentIdx =
 					typeof currentLevel === 'string'
 						? LOG_LEVEL_ORDER.indexOf(currentLevel)
 						: -1
 				const extraIdx = LOG_LEVEL_ORDER.indexOf(extraLevel)
 				if (extraIdx > currentIdx) {
-					logConfig.level = extraLevel
+					finalLogConfig.level = extraLevel
 				}
 			}
 		}
@@ -561,6 +587,12 @@ export class DriverLifecycle {
 		logTransport.stream.on('data', (data: any) => {
 			this.host.emitDebug(data.message.toString())
 		})
+
+		// Retain the exact `Driver` instance THIS generation creates, so every
+		// stale/error exit can tear down that specific instance and never a
+		// replacement that a newer generation may have stored on the host. See
+		// {@link teardownConnectDriver}.
+		let createdDriver: Driver | null = null
 
 		try {
 			if (shouldUpdateSettings) {
@@ -572,6 +604,7 @@ export class DriverLifecycle {
 			// init driver here because if connect fails the driver is destroyed
 			// this could throw so include in the try/catch
 			const driver = new Driver(port, zwaveOptions)
+			createdDriver = driver
 			this.host.setDriver(driver)
 			driver.on('error', (error) =>
 				this.dispatchDriverError(generation, error),
@@ -598,6 +631,7 @@ export class DriverLifecycle {
 			const hasConnectedClients = await this.host.hasConnectedClients()
 
 			if (this._generation !== generation) {
+				this.teardownConnectDriver(driver)
 				return
 			}
 
@@ -608,6 +642,7 @@ export class DriverLifecycle {
 			await driver.start()
 
 			if (this._generation !== generation) {
+				this.teardownConnectDriver(driver)
 				return
 			}
 
@@ -625,15 +660,13 @@ export class DriverLifecycle {
 
 			this.host.setStatus(ZwaveClientStatus.CONNECTED)
 		} catch (error) {
-			// destroy diver instance when it fails
-			const driver = this.host.getDriver()
-			if (driver) {
-				driver.destroy().catch((err: Error) => {
-					logger.error(
-						`Error while destroying driver ${err.message}`,
-						error,
-					)
-				})
+			// Tear down the driver THIS generation created (if any). We must NOT
+			// read `host.getDriver()` here: a newer generation may already have
+			// stored its own replacement driver on the host, and destroying that
+			// would kill a live replacement. Tearing down the exact instance we
+			// created leaks nothing and never touches a replacement.
+			if (createdDriver) {
+				this.teardownConnectDriver(createdDriver, error)
 			}
 
 			if (this._generation !== generation) {
@@ -657,6 +690,22 @@ export class DriverLifecycle {
 					error,
 				)
 			}
+		}
+	}
+
+	/**
+	 * Tear down a specific driver instance created by {@link connect} on a
+	 * stale/error exit. Destroys that exact instance (idempotent in `zwave-js`),
+	 * and clears the host's driver field ONLY when it still references this
+	 * instance — so a replacement generation that has already stored its own
+	 * driver on the host is left untouched.
+	 */
+	private teardownConnectDriver(driver: Driver, cause?: unknown): void {
+		driver.destroy().catch((err: Error) => {
+			logger.error(`Error while destroying driver ${err.message}`, cause)
+		})
+		if (this.host.getDriver() === driver) {
+			this.host.setDriver(null)
 		}
 	}
 

--- a/api/lib/zwave/DriverLifecycle.ts
+++ b/api/lib/zwave/DriverLifecycle.ts
@@ -5,9 +5,11 @@ import type {
 	PartialZWaveOptions,
 } from 'zwave-js'
 import { ZWaveErrorCodes, isZWaveError } from '@zwave-js/core'
+import type { LogConfig } from '@zwave-js/core'
 import { createDefaultTransportFormat } from '@zwave-js/core/bindings/log/node'
 import { JSONTransport } from '@zwave-js/log-transport-json'
 import type { ZwavejsServer } from '@zwave-js/server'
+import type Transport from 'winston-transport'
 
 import * as LogManager from '../logger.ts'
 import * as utils from '../utils.ts'
@@ -28,6 +30,21 @@ const logger = LogManager.module('Z-Wave')
 
 // Least-to-most verbose ordering so the most verbose extra-transport level wins
 const LOG_LEVEL_ORDER = ['error', 'warn', 'info', 'verbose', 'debug', 'silly']
+
+/** Constructor-injected builders for the external objects the lifecycle constructs, so callers (production or tests) supply them without module-level mocking */
+export interface DriverLifecycleDeps {
+	createDriver(port: string, options: PartialZWaveOptions): Driver
+	createLogTransport(): JSONTransport
+	createServerManager(host: ZwaveServerHost): ZwaveServerManager
+	ensureDir(dir: string): Promise<void>
+}
+
+const defaultDriverLifecycleDeps: DriverLifecycleDeps = {
+	createDriver: (port, options) => new Driver(port, options),
+	createLogTransport: () => new JSONTransport(),
+	createServerManager: (host) => new ZwaveServerManager(host),
+	ensureDir: (dir) => utils.ensureDir(dir),
+}
 
 /** Every method resolves live client state so nothing is captured at construction across driver/config swaps */
 export interface DriverLifecycleHost {
@@ -78,7 +95,10 @@ export class DriverLifecycle {
 	/** Generation `_activeConnect` belongs to, so a duplicate connect coalesces only while this still equals `_generation` */
 	private _activeConnectGeneration = 0
 
-	private _extraLogTransports: Array<{ transport: any; level?: string }> = []
+	private _extraLogTransports: Array<{
+		transport: Transport
+		level?: string
+	}> = []
 
 	/** JSON-socket transport for the current generation, re-sent first on every live add/remove because `updateLogConfig` replaces the driver's whole custom transport list */
 	private _driverLogTransport: JSONTransport | null = null
@@ -88,8 +108,14 @@ export class DriverLifecycle {
 
 	private _serverManager?: ZwaveServerManager
 
-	constructor(host: DriverLifecycleHost) {
+	private readonly deps: DriverLifecycleDeps
+
+	constructor(
+		host: DriverLifecycleHost,
+		deps: DriverLifecycleDeps = defaultDriverLifecycleDeps,
+	) {
 		this.host = host
+		this.deps = deps
 	}
 
 	get generation(): number {
@@ -99,7 +125,7 @@ export class DriverLifecycle {
 	/** Lazily builds a standalone fallback manager on first access so a directly-constructed client's server lifecycle works with no coordinator to adopt one */
 	get zwaveServer(): ZwaveServerManager {
 		if (!this._serverManager) {
-			this._serverManager = new ZwaveServerManager(
+			this._serverManager = this.deps.createServerManager(
 				this.host.buildServerHost(),
 			)
 		}
@@ -159,13 +185,13 @@ export class DriverLifecycle {
 		)
 	}
 
-	addExtraLogTransport(transport: any, level?: string): void {
+	addExtraLogTransport(transport: Transport, level?: string): void {
 		// Store on the lifecycle so the transport survives driver restarts
 		this._extraLogTransports.push({ transport, level })
 		this.applyRuntimeLogConfig()
 	}
 
-	removeExtraLogTransport(transport: any): void {
+	removeExtraLogTransport(transport: Transport): void {
 		const idx = this._extraLogTransports.findIndex(
 			(e) => e.transport === transport,
 		)
@@ -175,8 +201,8 @@ export class DriverLifecycle {
 		this.applyRuntimeLogConfig()
 	}
 
-	private computeRuntimeLogTransports(): any[] {
-		const transports: any[] = []
+	private computeRuntimeLogTransports(): Transport[] {
+		const transports: Transport[] = []
 		if (this._driverLogTransport) {
 			transports.push(this._driverLogTransport)
 		}
@@ -207,7 +233,7 @@ export class DriverLifecycle {
 		if (!driver || !this.host.isDriverReadyRaw()) {
 			return
 		}
-		const config: any = {
+		const config: Partial<LogConfig> = {
 			transports: this.computeRuntimeLogTransports(),
 		}
 		const level = this.computeRuntimeLogLevel()
@@ -442,7 +468,7 @@ export class DriverLifecycle {
 
 		// ensure deviceConfigPriorityDir exists to prevent warnings #2374
 		// lgtm [js/path-injection]
-		await utils.ensureDir(priorityDir)
+		await this.deps.ensureDir(priorityDir)
 
 		if (this._generation !== generation) {
 			return
@@ -495,7 +521,7 @@ export class DriverLifecycle {
 		// Apply storage, presets, logFilename and forceConsole directly to driver options since they aren't in ZwaveConfig
 		applyExternalDriverSettings(zwaveOptions)
 
-		const logTransport = new JSONTransport()
+		const logTransport = this.deps.createLogTransport()
 		logTransport.format = createDefaultTransportFormat(true, false)
 
 		// Bind this generation's JSON-socket transport so live add/remove re-sends it in the full replacement list
@@ -532,7 +558,7 @@ export class DriverLifecycle {
 				}
 			}
 			// Constructing the Driver can throw, so keep it inside the try/catch that destroys it on a failed connect
-			const driver = new Driver(port, zwaveOptions)
+			const driver = this.deps.createDriver(port, zwaveOptions)
 			createdDriver = driver
 			this.host.setDriver(driver)
 			driver.on('error', (error) =>

--- a/api/lib/zwave/DriverLifecycle.ts
+++ b/api/lib/zwave/DriverLifecycle.ts
@@ -140,7 +140,47 @@ export class DriverLifecycle {
 	private _backoffRetry = 0
 	private _restartTimeout: NodeJS.Timeout | null = null
 
+	/**
+	 * The in-flight startup promise for the CURRENT connect generation, or
+	 * `null` when no connect is committed/in-flight. A duplicate `connect()`
+	 * that arrives while a startup is still running coalesces onto THIS exact
+	 * promise instead of returning early (which used to falsely signal success
+	 * before the driver was CONNECTED, or even when the startup later failed):
+	 * concurrent callers therefore share the first caller's settlement timing
+	 * and error semantics, and no second `Driver` is ever constructed. Set right
+	 * after {@link _startDriver} commits a generation and cleared only when THAT
+	 * startup settles (or {@link close} cancels it).
+	 */
+	private _activeConnect: Promise<void> | null = null
+
+	/**
+	 * The generation {@link _activeConnect} belongs to. A duplicate connect only
+	 * coalesces when this still equals {@link _generation}; once {@link close}
+	 * (or a fresh {@link connect}) bumps the generation, a later connect builds a
+	 * new driver instead of joining a superseded startup.
+	 */
+	private _activeConnectGeneration = 0
+
 	private _extraLogTransports: Array<{ transport: any; level?: string }> = []
+
+	/**
+	 * The required JSON-socket log transport constructed for the CURRENT driver
+	 * generation (see {@link connect}). `zwave-js`'s `updateLogConfig({transports})`
+	 * REPLACES the driver's whole custom transport list, so every live
+	 * add/remove must re-send this transport FIRST or it would silently drop the
+	 * `debug` socket stream. Re-created on each {@link connect}; a restart/replace
+	 * therefore rebinds to the new generation's transport with nothing captured.
+	 */
+	private _driverLogTransport: JSONTransport | null = null
+
+	/**
+	 * The immutable configured log level for the current driver generation,
+	 * captured from the driver-only `logConfig` in {@link connect} BEFORE any
+	 * extra-transport elevation. Runtime level is always recomputed as the most
+	 * verbose of this baseline and every registered extra, so removing a verbose
+	 * extra restores exactly this level instead of leaving the driver stuck high.
+	 */
+	private _baseLogLevel: string | undefined = undefined
 
 	private _serverManager?: ZwaveServerManager
 
@@ -250,16 +290,7 @@ export class DriverLifecycle {
 	 */
 	addExtraLogTransport(transport: any, level?: string): void {
 		this._extraLogTransports.push({ transport, level })
-		const driver = this.host.getDriver()
-		if (driver && this.host.isDriverReadyRaw()) {
-			const config: any = {
-				transports: [transport],
-			}
-			if (level) {
-				config.level = level
-			}
-			driver.updateLogConfig(config)
-		}
+		this.applyRuntimeLogConfig()
 	}
 
 	/**
@@ -273,12 +304,71 @@ export class DriverLifecycle {
 		if (idx !== -1) {
 			this._extraLogTransports.splice(idx, 1)
 		}
-		const driver = this.host.getDriver()
-		if (driver && this.host.isDriverReadyRaw()) {
-			driver.updateLogConfig({
-				transports: [],
-			})
+		this.applyRuntimeLogConfig()
+	}
+
+	/**
+	 * The COMPLETE runtime custom-transport list the active driver must receive:
+	 * the required JSON-socket transport FIRST, then every currently-registered
+	 * extra transport. `updateLogConfig({transports})` replaces the driver's
+	 * custom transports wholesale in `zwave-js` 15.25.x, so a live add/remove
+	 * that sends anything less silently drops the JSON socket stream and/or the
+	 * other extras. Computed from live state so it always reflects the current
+	 * registration set for the active generation.
+	 */
+	private computeRuntimeLogTransports(): any[] {
+		const transports: any[] = []
+		if (this._driverLogTransport) {
+			transports.push(this._driverLogTransport)
 		}
+		for (const extra of this._extraLogTransports) {
+			transports.push(extra.transport)
+		}
+		return transports
+	}
+
+	/**
+	 * The effective runtime log level: the immutable configured
+	 * {@link _baseLogLevel} raised to the most verbose level requested by any
+	 * registered extra transport. Recomputed from the baseline on every
+	 * add/remove so dropping a verbose extra returns to the configured level.
+	 */
+	private computeRuntimeLogLevel(): string | undefined {
+		let level = this._baseLogLevel
+		let bestIdx =
+			typeof level === 'string' ? LOG_LEVEL_ORDER.indexOf(level) : -1
+		for (const extra of this._extraLogTransports) {
+			if (!extra.level) continue
+			const idx = LOG_LEVEL_ORDER.indexOf(extra.level)
+			if (idx > bestIdx) {
+				bestIdx = idx
+				level = extra.level
+			}
+		}
+		return level
+	}
+
+	/**
+	 * Apply the current runtime log configuration (the full transport set from
+	 * {@link computeRuntimeLogTransports} plus the recomputed level from
+	 * {@link computeRuntimeLogLevel}) to the active driver, but only once it is
+	 * ready. Before ready this is a no-op: {@link connect} builds the identical
+	 * configuration into the driver options up front using the same two
+	 * helpers, so the runtime and startup paths never diverge.
+	 */
+	private applyRuntimeLogConfig(): void {
+		const driver = this.host.getDriver()
+		if (!driver || !this.host.isDriverReadyRaw()) {
+			return
+		}
+		const config: any = {
+			transports: this.computeRuntimeLogTransports(),
+		}
+		const level = this.computeRuntimeLogLevel()
+		if (level) {
+			config.level = level
+		}
+		driver.updateLogConfig(config)
 	}
 
 	// -----------------------------------------------------------------------
@@ -381,29 +471,77 @@ export class DriverLifecycle {
 			return
 		}
 
-		// Coalesce a reconnect onto an already in-flight connect. A previous
-		// connect() may have constructed a driver and stored it on the host, but
-		// that driver has NOT fired `driver ready` yet (its `start()` may have
-		// resolved so the outer connect() has already returned CONNECTED, or it
-		// may still be awaiting `start()`). Either way the ready-only guard above
-		// does not catch it. Proceeding here would mint a new generation,
-		// construct a REPLACEMENT driver and overwrite the host field — stranding
-		// the first, still-live, non-ready driver: unreachable, never torn down,
-		// and still holding the serial port. Coalescing keeps public connect
-		// timing unchanged on the common (no driver yet) path. Callers that
-		// genuinely need a fresh driver (config change, backoff retry, hard
-		// reset) go through close()/restart(), which destroys the current driver
-		// and nulls this field BEFORE reconnecting, so a legitimate restart is
-		// never blocked here.
+		// Capture the now-narrowed port (a `string`) before the coalescing
+		// checks below: an intervening host method call can reset TypeScript's
+		// property narrowing, and `_startDriver` needs a definite port.
+		const port = cfg.port
+
+		// A duplicate connect that arrives while a startup is still in flight
+		// must COALESCE onto that exact startup — not return early. Returning
+		// early used to falsely signal success before the driver reached
+		// CONNECTED (and even when the startup went on to fail), because the
+		// ready-only guard above does not catch a driver that is mid-`start()`.
+		// Joining `_activeConnect` gives the duplicate caller the first caller's
+		// settlement timing and error semantics while constructing NO second
+		// Driver. Only a startup for the CURRENT generation is joinable: a
+		// close()/restart bumps the generation and clears `_activeConnect`, so a
+		// genuine fresh connect afterwards builds a new driver instead.
+		if (
+			this._activeConnect &&
+			this._activeConnectGeneration === this._generation
+		) {
+			logger.info(`Driver is already connecting to ${cfg.port}`)
+			return this._activeConnect
+		}
+
+		// After a startup has fully SETTLED but the driver has not fired
+		// `driver ready` yet, `_activeConnect` is already cleared. A duplicate
+		// connect in that window must still not build a replacement: the host
+		// field still points at the live, connecting-but-not-ready driver.
+		// Returning here preserves that long-standing compatible behavior (a
+		// legitimate fresh driver only ever comes via close()/restart(), which
+		// destroys the current driver and nulls this field first).
 		if (this.host.getDriver()) {
 			logger.info(`Driver is already connecting to ${cfg.port}`)
 			return
 		}
 
+		// Commit to a new driver generation and run the startup. The startup
+		// promise is tracked as `_activeConnect` so concurrent callers coalesce
+		// onto it (above); it is cleared only when THIS startup settles, so a
+		// duplicate can never observe a stale success.
+		const startup = this._startDriver(cfg, port)
+		this._activeConnect = startup
+		this._activeConnectGeneration = this._generation
+		try {
+			await startup
+		} finally {
+			// Clear only if a later connect/close has not already replaced it.
+			if (this._activeConnect === startup) {
+				this._activeConnect = null
+			}
+		}
+	}
+
+	/**
+	 * Build, wire and start a brand-new `Driver` for a freshly-committed
+	 * generation. Extracted from {@link connect} so the connect facade can track
+	 * the returned promise as {@link _activeConnect} and coalesce duplicate
+	 * connects onto it. Every early `return` here settles that shared promise,
+	 * so a coalesced caller sees the exact same completion — including the
+	 * internal catch that logs/backs-off instead of rejecting, which is the
+	 * facade's long-standing public contract. NEVER call this directly except
+	 * through {@link connect}.
+	 *
+	 * @param port The serial port to open. {@link connect} has already rejected
+	 * a missing port before calling here, so it is passed in pre-narrowed as a
+	 * definite `string` (the connect/_startDriver split otherwise loses that
+	 * narrowing across the intervening host calls).
+	 */
+	private async _startDriver(cfg: ZwaveConfig, port: string): Promise<void> {
 		// Commit to a new driver generation. Any obsolete driver's late async
 		// callbacks now detect the bump and abort.
 		const generation = ++this._generation
-		const port = cfg.port
 
 		let shouldUpdateSettings = false
 
@@ -582,42 +720,37 @@ export class DriverLifecycle {
 		const logTransport = new JSONTransport()
 		logTransport.format = createDefaultTransportFormat(true, false)
 
+		// Bind the required JSON-socket transport to this generation so live
+		// add/remove log-transport calls re-send it (and every extra) as the
+		// COMPLETE replacement transport list the driver expects.
+		this._driverLogTransport = logTransport
+
 		// Resolve the log transports/level against the FINAL `logConfig` that
 		// the driver will actually receive. This is now a driver-only shallow
 		// clone (see the clone right after `Object.assign(cfg.options)` above),
 		// so enriching it here injects the required JSON transport and every
 		// registered extra transport — plus any raised level — into the driver's
 		// copy WITHOUT mutating the user's persisted `cfg.options.logConfig`.
+		//
+		// The transports/level are computed through the SAME helpers the live
+		// {@link addExtraLogTransport}/{@link removeExtraLogTransport} path uses
+		// ({@link computeRuntimeLogTransports}/{@link computeRuntimeLogLevel}),
+		// so the startup and runtime configurations can never diverge. The
+		// configured level is captured into {@link _baseLogLevel} FIRST (from
+		// the immutable persisted config) so a later removal restores it.
 		const finalLogConfig = zwaveOptions.logConfig
 		if (finalLogConfig) {
-			finalLogConfig.transports = [
-				logTransport,
-				...this._extraLogTransports.map((e) => e.transport),
-			]
-
-			// If any extra transport requires a more verbose log level, apply it.
-			// Use the most verbose (highest priority) level among all extra transports.
-			const extraLevel = this._extraLogTransports
-				.map((e) => e.level)
-				.filter((level): level is string => Boolean(level))
-				.reduce<string | undefined>((best, level) => {
-					if (!best) return level
-					return LOG_LEVEL_ORDER.indexOf(level) >
-						LOG_LEVEL_ORDER.indexOf(best)
-						? level
-						: best
-				}, undefined)
-			if (extraLevel) {
-				const currentLevel = finalLogConfig.level
-				const currentIdx =
-					typeof currentLevel === 'string'
-						? LOG_LEVEL_ORDER.indexOf(currentLevel)
-						: -1
-				const extraIdx = LOG_LEVEL_ORDER.indexOf(extraLevel)
-				if (extraIdx > currentIdx) {
-					finalLogConfig.level = extraLevel
-				}
+			this._baseLogLevel =
+				typeof finalLogConfig.level === 'string'
+					? finalLogConfig.level
+					: undefined
+			finalLogConfig.transports = this.computeRuntimeLogTransports()
+			const level = this.computeRuntimeLogLevel()
+			if (level) {
+				finalLogConfig.level = level
 			}
+		} else {
+			this._baseLogLevel = undefined
 		}
 
 		logTransport.stream.on('data', (data: any) => {
@@ -667,7 +800,7 @@ export class DriverLifecycle {
 			const hasConnectedClients = await this.host.hasConnectedClients()
 
 			if (this._generation !== generation) {
-				this.teardownConnectDriver(driver)
+				await this.teardownConnectDriver(driver)
 				return
 			}
 
@@ -678,7 +811,7 @@ export class DriverLifecycle {
 			await driver.start()
 
 			if (this._generation !== generation) {
-				this.teardownConnectDriver(driver)
+				await this.teardownConnectDriver(driver)
 				return
 			}
 
@@ -700,9 +833,11 @@ export class DriverLifecycle {
 			// read `host.getDriver()` here: a newer generation may already have
 			// stored its own replacement driver on the host, and destroying that
 			// would kill a live replacement. Tearing down the exact instance we
-			// created leaks nothing and never touches a replacement.
+			// created leaks nothing and never touches a replacement. Awaited so
+			// the failed instance releases the port BEFORE the backoff restart
+			// below is allowed to build a replacement (teardown ownership).
 			if (createdDriver) {
-				this.teardownConnectDriver(createdDriver, error)
+				await this.teardownConnectDriver(createdDriver, error)
 			}
 
 			if (this._generation !== generation) {
@@ -731,15 +866,42 @@ export class DriverLifecycle {
 
 	/**
 	 * Tear down a specific driver instance created by {@link connect} on a
-	 * stale/error exit. Destroys that exact instance (idempotent in `zwave-js`),
-	 * and clears the host's driver field ONLY when it still references this
-	 * instance — so a replacement generation that has already stored its own
-	 * driver on the host is left untouched.
+	 * stale/error exit, as an explicit **teardown-ownership** step.
+	 *
+	 * The destruction of that exact instance is AWAITED before any host state
+	 * is cleared, so the failed/stale driver has fully released the serial port
+	 * before a backoff/retry (or a coalesced connect waiting on the same
+	 * startup promise) is allowed to construct a replacement. This closes the
+	 * race where the old code cleared the host field immediately while
+	 * `destroy()` ran unawaited: a slow/rejected destroy could let a replacement
+	 * driver be built while the old owner still held the port, leaving the
+	 * controller unreachable.
+	 *
+	 * Ownership rules:
+	 *  - On a CLEAN destroy, clear the host's driver field ONLY when it still
+	 *    references this exact instance — a replacement generation that already
+	 *    stored its own driver on the host is never touched.
+	 *  - On a REJECTED destroy, the exact instance is RETAINED as the owner (the
+	 *    field is not cleared and no replacement is permitted through this path):
+	 *    the driver may still hold the port, so dropping it would leak it and
+	 *    strand the port. The rejection stays observable/retryable — a later
+	 *    {@link close}/retry re-invokes `destroy()` on this same owner.
 	 */
-	private teardownConnectDriver(driver: Driver, cause?: unknown): void {
-		driver.destroy().catch((err: Error) => {
-			logger.error(`Error while destroying driver ${err.message}`, cause)
-		})
+	private async teardownConnectDriver(
+		driver: Driver,
+		cause?: unknown,
+	): Promise<void> {
+		try {
+			await driver.destroy()
+		} catch (err) {
+			logger.error(
+				`Error while destroying driver ${(err as Error).message}`,
+				cause,
+			)
+			// Retain ownership of the exact instance: do NOT clear the host
+			// field or allow a replacement — cleanup can be retried later.
+			return
+		}
 		if (this.host.getDriver() === driver) {
 			this.host.setDriver(null)
 		}
@@ -753,6 +915,13 @@ export class DriverLifecycle {
 		// Invalidate any in-flight generation so a driver that becomes ready or
 		// errors after this point cannot mutate replacement state.
 		this._generation++
+
+		// Cancel any in-flight startup coalescing: a duplicate connect after
+		// this close must NOT join the now-superseded startup. The startup's own
+		// generation checks already make it tear down its driver and bail; here
+		// we simply stop new callers from coalescing onto it. Callers already
+		// awaiting it still settle when it does (no deadlock).
+		this._activeConnect = null
 
 		this.host.setStatus(ZwaveClientStatus.CLOSED)
 		this.host.setClosed(true)

--- a/api/lib/zwave/DriverLifecycle.ts
+++ b/api/lib/zwave/DriverLifecycle.ts
@@ -1,15 +1,3 @@
-/**
- * Owns the low-level lifecycle of one `zwave-js` {@link Driver} for `ZwaveClient`:
- * creation, `@zwave-js/server` coordination, backoff restarts, statistics, log
- * transports and idempotent teardown.
- *
- * A monotonic generation counter lets late `driver ready`/`error`/`all nodes
- * ready`/OTW callbacks from an obsolete driver be ignored so they can't mutate a
- * replacement driver's state. All client state is reached through
- * {@link DriverLifecycleHost}, so this service never imports `ZwaveClient` (no
- * import cycle) and every accessor resolves live state across driver/config swaps.
- */
-
 import { Driver } from 'zwave-js'
 import type {
 	OTWFirmwareUpdateProgress,
@@ -41,7 +29,7 @@ const logger = LogManager.module('Z-Wave')
 // Least-to-most verbose ordering so the most verbose extra-transport level wins
 const LOG_LEVEL_ORDER = ['error', 'warn', 'info', 'verbose', 'debug', 'silly']
 
-/** Narrow port into `ZwaveClient`; every method resolves live client state so nothing is captured at construction across driver/config swaps */
+/** Every method resolves live client state so nothing is captured at construction across driver/config swaps */
 export interface DriverLifecycleHost {
 	getConfig(): ZwaveConfig
 	getDriver(): Driver | null
@@ -66,7 +54,7 @@ export interface DriverLifecycleHost {
 	/** Runs mid-close, after the lifecycle's own timers are cleared and before the server/driver are destroyed */
 	clearRuntimeOnClose(): void
 	finalizeClose(): void
-	/** Node-registry restoration stays on `ZwaveClient`; the lifecycle only drives the generation */
+	/** Lifecycle drives only the generation, leaving node-registry restoration to ZwaveClient */
 	onDriverReady(generation: number): Promise<void>
 	onDriverError(error: unknown, skipRestart: boolean): void
 	onScanComplete(): void
@@ -78,21 +66,21 @@ export interface DriverLifecycleHost {
 export class DriverLifecycle {
 	private readonly host: DriverLifecycleHost
 
-	/** Bumped when a new driver starts connecting and when the client closes, so in-flight work from an obsolete driver detects the mismatch and aborts; never reset by init() */
+	/** Bumped when a new driver starts connecting and when the client closes, so in-flight work from an obsolete driver detects the mismatch and aborts */
 	private _generation = 0
 
 	private _backoffRetry = 0
 	private _restartTimeout: NodeJS.Timeout | null = null
 
-	/** In-flight startup promise for the current connect generation; a duplicate connect coalesces onto this exact promise instead of returning a premature success or building a second Driver */
+	/** In-flight startup promise the current generation's duplicate connect coalesces onto instead of building a second Driver */
 	private _activeConnect: Promise<void> | null = null
 
-	/** Generation `_activeConnect` belongs to; a duplicate connect only coalesces while this equals `_generation`, so once close/connect bumps it a later connect builds a new driver */
+	/** Generation `_activeConnect` belongs to, so a duplicate connect coalesces only while this still equals `_generation` */
 	private _activeConnectGeneration = 0
 
 	private _extraLogTransports: Array<{ transport: any; level?: string }> = []
 
-	/** JSON-socket transport for the current driver generation; `updateLogConfig({transports})` replaces the driver's whole custom list, so every live add/remove must re-send this one first or drop the debug stream */
+	/** JSON-socket transport for the current generation, re-sent first on every live add/remove because `updateLogConfig` replaces the driver's whole custom transport list */
 	private _driverLogTransport: JSONTransport | null = null
 
 	/** Configured log level captured before any extra-transport elevation, so removing a verbose extra recomputes back to this baseline instead of leaving the driver stuck high */
@@ -108,12 +96,7 @@ export class DriverLifecycle {
 		return this._generation
 	}
 
-	/**
-	 * The lifecycle-managed `@zwave-js/server` subsystem. In production this is
-	 * the HA-owned manager adopted via {@link adoptServerManager}; a
-	 * directly-constructed client lazily builds a standalone fallback here on
-	 * first access so its server lifecycle keeps working with no coordinator.
-	 */
+	/** Lazily builds a standalone fallback manager on first access so a directly-constructed client's server lifecycle works with no coordinator to adopt one */
 	get zwaveServer(): ZwaveServerManager {
 		if (!this._serverManager) {
 			this._serverManager = new ZwaveServerManager(
@@ -136,17 +119,13 @@ export class DriverLifecycle {
 		this.zwaveServer.server = value
 	}
 
-	/**
-	 * Adopt the HA-owned server manager. Called by `HomeAssistantManager` once,
-	 * before the driver connects, so `create()/startIfNeeded()/destroy()` all
-	 * drive the manager the coordinator owns.
-	 */
 	adoptServerManager(manager: ZwaveServerManager): void {
+		// Set before the driver connects so create/startIfNeeded/destroy all drive the HA-owned manager
 		this._serverManager = manager
 	}
 
-	/** Constructs but does not start the server; called from connect() only when serverEnabled, so the server exists before the driver becomes ready */
 	createServer(): void {
+		// Construct without starting so the server exists before the driver becomes ready
 		this.zwaveServer.create()
 	}
 
@@ -180,8 +159,8 @@ export class DriverLifecycle {
 		)
 	}
 
-	/** Registers an extra log transport that persists across driver restarts */
 	addExtraLogTransport(transport: any, level?: string): void {
+		// Store on the lifecycle so the transport survives driver restarts
 		this._extraLogTransports.push({ transport, level })
 		this.applyRuntimeLogConfig()
 	}
@@ -196,7 +175,6 @@ export class DriverLifecycle {
 		this.applyRuntimeLogConfig()
 	}
 
-	/** Full transport list (JSON-socket transport first, then extras); `updateLogConfig({transports})` replaces the driver's custom transports wholesale, so a partial list drops the socket stream or other extras */
 	private computeRuntimeLogTransports(): any[] {
 		const transports: any[] = []
 		if (this._driverLogTransport) {
@@ -208,7 +186,6 @@ export class DriverLifecycle {
 		return transports
 	}
 
-	/** Configured base level raised to the most verbose registered extra, recomputed from baseline so dropping a verbose extra restores the configured level */
 	private computeRuntimeLogLevel(): string | undefined {
 		let level = this._baseLogLevel
 		let bestIdx =
@@ -224,8 +201,8 @@ export class DriverLifecycle {
 		return level
 	}
 
-	/** No-op until the driver is ready, since connect() builds the identical config into the driver options up front */
 	private applyRuntimeLogConfig(): void {
+		// No-op until the driver is ready, since connect() builds the identical config into the driver options up front
 		const driver = this.host.getDriver()
 		if (!driver || !this.host.isDriverReadyRaw()) {
 			return
@@ -245,7 +222,7 @@ export class DriverLifecycle {
 	}
 
 	backoffRestart(): void {
-		// fix edge case where client is half closed and restart is called
+		// Abort the restart when the client is half-closed
 		if (this.checkIfDestroyed()) {
 			return
 		}
@@ -278,10 +255,6 @@ export class DriverLifecycle {
 		}, timeout)
 	}
 
-	/**
-	 * Checks if the client is destroyed and if so closes it.
-	 * @returns True if the client is destroyed
-	 */
 	checkIfDestroyed(): boolean {
 		if (this.host.isDestroyed()) {
 			logger.debug(
@@ -315,7 +288,7 @@ export class DriverLifecycle {
 			return
 		}
 
-		// this could happen when the driver fails the connect and a reconnect timeout triggers
+		// Bail when a failed connect's reconnect timeout races an already-closed client
 		if (this.host.isClosed() || this.checkIfDestroyed()) {
 			return
 		}
@@ -328,7 +301,7 @@ export class DriverLifecycle {
 		// Capture the narrowed port before the host calls below, which reset TypeScript's property narrowing
 		const port = cfg.port
 
-		// Coalesce a duplicate connect onto the in-flight startup of the current generation so callers share its outcome and no second Driver is built; a close/restart bumps the generation and clears `_activeConnect`, so a later connect builds fresh
+		// Coalesce a duplicate connect onto the in-flight startup of the current generation so callers share its outcome and no second Driver is built
 		if (
 			this._activeConnect &&
 			this._activeConnectGeneration === this._generation
@@ -357,11 +330,7 @@ export class DriverLifecycle {
 		}
 	}
 
-	/**
-	 * Builds, wires and starts a new `Driver` for the committed generation. Its
-	 * internal catch logs and backs off instead of rejecting, matching connect()'s
-	 * no-throw contract, so a coalesced caller sees the same completion.
-	 */
+	/** Catches internally and backs off instead of rejecting so a coalesced connect() caller sees the same no-throw completion */
 	private async _startDriver(cfg: ZwaveConfig, port: string): Promise<void> {
 		// Bump the generation so any obsolete driver's late callbacks detect the change and abort
 		const generation = ++this._generation
@@ -523,8 +492,7 @@ export class DriverLifecycle {
 
 		utils.parseSecurityKeys(cfg, zwaveOptions)
 
-		// Apply driver-only external settings (storage, presets, logFilename, forceConsole).
-		// These are not in ZwaveConfig/settings.json, so they must be applied directly to driver options.
+		// Apply storage, presets, logFilename and forceConsole directly to driver options since they aren't in ZwaveConfig
 		applyExternalDriverSettings(zwaveOptions)
 
 		const logTransport = new JSONTransport()
@@ -533,7 +501,7 @@ export class DriverLifecycle {
 		// Bind this generation's JSON-socket transport so live add/remove re-sends it in the full replacement list
 		this._driverLogTransport = logTransport
 
-		// Enrich the driver-only clone via the same helpers as the runtime path so startup and live configs can't diverge; capture `_baseLogLevel` first so a later transport removal can restore it
+		// Enrich the driver-only clone via the same helpers as the runtime path so startup and live configs can't diverge
 		const finalLogConfig = zwaveOptions.logConfig
 		if (finalLogConfig) {
 			this._baseLogLevel =
@@ -553,7 +521,7 @@ export class DriverLifecycle {
 			this.host.emitDebug(data.message.toString())
 		})
 
-		// Hold the exact instance this generation creates so a stale/error exit tears down this driver, never a replacement stored by a newer generation
+		// Hold the exact instance this generation creates so a stale/error exit tears down this driver rather than a newer generation's replacement
 		let createdDriver: Driver | null = null
 
 		try {
@@ -563,8 +531,7 @@ export class DriverLifecycle {
 					return
 				}
 			}
-			// init driver here because if connect fails the driver is destroyed
-			// this could throw so include in the try/catch
+			// Constructing the Driver can throw, so keep it inside the try/catch that destroys it on a failed connect
 			const driver = new Driver(port, zwaveOptions)
 			createdDriver = driver
 			this.host.setDriver(driver)
@@ -622,7 +589,7 @@ export class DriverLifecycle {
 
 			this.host.setStatus(ZwaveClientStatus.CONNECTED)
 		} catch (error) {
-			// Tear down the instance this generation created, not `host.getDriver()`, which may already point at a newer generation's replacement; awaited so the failed instance releases the port before backoff builds a replacement
+			// Tear down the instance this generation created and await it so the failed driver releases the port before backoff builds a replacement
 			if (createdDriver) {
 				await this.teardownConnectDriver(createdDriver, error)
 			}
@@ -651,15 +618,7 @@ export class DriverLifecycle {
 		}
 	}
 
-	/**
-	 * Destroys a specific driver instance from a stale/error exit, awaiting
-	 * `destroy()` before clearing host state so the failed driver releases the
-	 * serial port before a backoff/retry or coalesced connect builds a
-	 * replacement. On a clean destroy the host field is cleared only while it
-	 * still references this exact instance; on a rejected destroy the instance is
-	 * retained as owner (field left set, no replacement), since it may still hold
-	 * the port, and a later {@link close}/retry re-invokes `destroy()` on it.
-	 */
+	/** Awaits destroy() before clearing the host's driver field so the failed driver releases the serial port before a retry or coalesced connect builds a replacement */
 	private async teardownConnectDriver(
 		driver: Driver,
 		cause?: unknown,
@@ -671,7 +630,7 @@ export class DriverLifecycle {
 				`Error while destroying driver ${(err as Error).message}`,
 				cause,
 			)
-			// Keep this instance as owner so a later close/retry can destroy it again; clearing the field now would strand the port it may still hold
+			// Keep this instance as owner so a later close/retry can destroy it again instead of stranding the port it may still hold
 			return
 		}
 		if (this.host.getDriver() === driver) {
@@ -679,12 +638,12 @@ export class DriverLifecycle {
 		}
 	}
 
-	/** Closes the connection, destroying the server before the driver and clearing every lifecycle timer; idempotent and safe to retry */
+	/** Idempotent and safe to retry */
 	async close(keepListeners = false): Promise<void> {
 		// Bump the generation so a driver that becomes ready or errors after this cannot mutate replacement state
 		this._generation++
 
-		// Stop a post-close duplicate connect from coalescing onto the superseded startup; callers already awaiting it still settle when it does
+		// Stop a post-close duplicate connect from coalescing onto the superseded startup
 		this._activeConnect = null
 
 		this.host.setStatus(ZwaveClientStatus.CLOSED)
@@ -715,7 +674,7 @@ export class DriverLifecycle {
 		logger.info('Client closed')
 	}
 
-	// Generation-guarded dispatch drops events from an obsolete driver generation; handler bodies that touch node/controller state stay in ZwaveClient behind the host port
+	// Generation-guarded dispatch drops events from an obsolete driver generation
 	private dispatchDriverReady(generation: number): void {
 		if (this._generation !== generation) {
 			return

--- a/api/lib/zwave/DriverLifecycle.ts
+++ b/api/lib/zwave/DriverLifecycle.ts
@@ -4,7 +4,11 @@ import type {
 	OTWFirmwareUpdateResult,
 	PartialZWaveOptions,
 } from 'zwave-js'
-import { ZWaveErrorCodes, isZWaveError } from '@zwave-js/core'
+import {
+	ZWaveErrorCodes,
+	isZWaveError,
+	CONTROLLER_LOGLEVEL,
+} from '@zwave-js/core'
 import type { LogConfig } from '@zwave-js/core'
 import { createDefaultTransportFormat } from '@zwave-js/core/bindings/log/node'
 import { JSONTransport } from '@zwave-js/log-transport-json'
@@ -27,9 +31,6 @@ import {
 } from './ports.ts'
 
 const logger = LogManager.module('Z-Wave')
-
-// Least-to-most verbose ordering so the most verbose extra-transport level wins
-const LOG_LEVEL_ORDER = ['error', 'warn', 'info', 'verbose', 'debug', 'silly']
 
 /** Constructor-injected builders for the external objects the lifecycle constructs, so callers (production or tests) supply them without module-level mocking */
 export interface DriverLifecycleDeps {
@@ -103,8 +104,8 @@ export class DriverLifecycle {
 	/** JSON-socket transport for the current generation, re-sent first on every live add/remove because `updateLogConfig` replaces the driver's whole custom transport list */
 	private _driverLogTransport: JSONTransport | null = null
 
-	/** Configured log level captured before any extra-transport elevation, so removing a verbose extra recomputes back to this baseline instead of leaving the driver stuck high */
-	private _baseLogLevel: string | undefined = undefined
+	/** Baseline level name captured before any extra-transport elevation, so removing the last verbose extra recomputes back to it instead of leaving the driver stuck high. Defaults to the exported `CONTROLLER_LOGLEVEL`, which matches this app's configured default level, when the driver config carries no explicit level. */
+	private _baseLogLevel: string = CONTROLLER_LOGLEVEL
 
 	private _serverManager?: ZwaveServerManager
 
@@ -212,15 +213,14 @@ export class DriverLifecycle {
 		return transports
 	}
 
-	private computeRuntimeLogLevel(): string | undefined {
+	private computeRuntimeLogLevel(): string {
 		let level = this._baseLogLevel
-		let bestIdx =
-			typeof level === 'string' ? LOG_LEVEL_ORDER.indexOf(level) : -1
+		let bestRank = utils.logLevelRank(level)
 		for (const extra of this._extraLogTransports) {
 			if (!extra.level) continue
-			const idx = LOG_LEVEL_ORDER.indexOf(extra.level)
-			if (idx > bestIdx) {
-				bestIdx = idx
+			const rank = utils.logLevelRank(extra.level)
+			if (rank > bestRank) {
+				bestRank = rank
 				level = extra.level
 			}
 		}
@@ -233,12 +233,10 @@ export class DriverLifecycle {
 		if (!driver || !this.host.isDriverReadyRaw()) {
 			return
 		}
+		// Always resend the level: updateLogConfig merges partial updates, so omitting it would leave a previously elevated level in place once the last verbose extra is removed
 		const config: Partial<LogConfig> = {
 			transports: this.computeRuntimeLogTransports(),
-		}
-		const level = this.computeRuntimeLogLevel()
-		if (level) {
-			config.level = level
+			level: this.computeRuntimeLogLevel(),
 		}
 		driver.updateLogConfig(config)
 	}
@@ -530,17 +528,13 @@ export class DriverLifecycle {
 		// Enrich the driver-only clone via the same helpers as the runtime path so startup and live configs can't diverge
 		const finalLogConfig = zwaveOptions.logConfig
 		if (finalLogConfig) {
+			// buildLogConfig stores the configured level as a numeric rank, so resolve it back to a name; fall back to the CONTROLLER_LOGLEVEL default when the config carries no level
 			this._baseLogLevel =
-				typeof finalLogConfig.level === 'string'
-					? finalLogConfig.level
-					: undefined
+				utils.logLevelName(finalLogConfig.level) ?? CONTROLLER_LOGLEVEL
 			finalLogConfig.transports = this.computeRuntimeLogTransports()
-			const level = this.computeRuntimeLogLevel()
-			if (level) {
-				finalLogConfig.level = level
-			}
+			finalLogConfig.level = this.computeRuntimeLogLevel()
 		} else {
-			this._baseLogLevel = undefined
+			this._baseLogLevel = CONTROLLER_LOGLEVEL
 		}
 
 		logTransport.stream.on('data', (data: any) => {

--- a/api/lib/zwave/DriverLifecycle.ts
+++ b/api/lib/zwave/DriverLifecycle.ts
@@ -1,29 +1,13 @@
 /**
- * DriverLifecycle
- * ----------------
- * Owns the low-level lifecycle of a single `zwave-js` {@link Driver} instance
- * on behalf of `ZwaveClient`:
+ * Owns the low-level lifecycle of one `zwave-js` {@link Driver} for `ZwaveClient`:
+ * creation, `@zwave-js/server` coordination, backoff restarts, statistics, log
+ * transports and idempotent teardown.
  *
- *  - driver creation, option building, log-transport injection and binding of
- *    the driver event handlers ({@link connect});
- *  - the official `@zwave-js/server` (`ZwavejsServer`) coordination
- *    (create / start-if-needed / destroy / adopt) through {@link ZwaveServerManager};
- *  - retry/backoff restart timing ({@link backoffRestart});
- *  - usage-statistics enable/disable and extra log transports;
- *  - idempotent teardown ({@link close}) that destroys the server BEFORE the
- *    driver and clears every timer it owns;
- *  - a monotonic **generation** counter so a late `driver ready` / `error` /
- *    `all nodes ready` / OTW callback from an obsolete driver can never mutate
- *    a replacement generation's state (the same pattern the other extracted
- *    services use).
- *
- * Everything the service needs from `ZwaveClient` — the current config, the
- * driver field, status/ready/closed/destroyed state, node restoration, socket
- * IO and the driver-event handler bodies (which do node-registry work retained
- * in `ZwaveClient`) — is reached through the narrow {@link DriverLifecycleHost}
- * port. The service therefore never imports `ZwaveClient` and cannot create an
- * import cycle. Every accessor resolves the CURRENT value, so a driver swap on
- * restart is honoured with nothing captured at construction time.
+ * A monotonic generation counter lets late `driver ready`/`error`/`all nodes
+ * ready`/OTW callbacks from an obsolete driver be ignored so they can't mutate a
+ * replacement driver's state. All client state is reached through
+ * {@link DriverLifecycleHost}, so this service never imports `ZwaveClient` (no
+ * import cycle) and every accessor resolves live state across driver/config swaps.
  */
 
 import { Driver } from 'zwave-js'
@@ -54,132 +38,64 @@ import {
 
 const logger = LogManager.module('Z-Wave')
 
-/**
- * Log levels ordered from least to most verbose. Used to pick the most
- * verbose level requested by any registered extra log transport.
- */
+// Least-to-most verbose ordering so the most verbose extra-transport level wins
 const LOG_LEVEL_ORDER = ['error', 'warn', 'info', 'verbose', 'debug', 'silly']
 
-/**
- * Narrow port back into `ZwaveClient`. Every method resolves the CURRENT
- * client state so the lifecycle keeps working across driver/config swaps
- * without capturing anything at construction time.
- */
+/** Narrow port into `ZwaveClient`; every method resolves live client state so nothing is captured at construction across driver/config swaps */
 export interface DriverLifecycleHost {
-	/** The current Z-Wave configuration (`ZwaveClient.cfg`). */
 	getConfig(): ZwaveConfig
-	/** The current driver instance (`ZwaveClient._driver`), if any. */
 	getDriver(): Driver | null
-	/** Store the driver instance back on the client (compatibility field). */
 	setDriver(driver: Driver | null): void
-	/** `ZwaveClient.driverReady` getter (driver && ready && !closed). */
 	isDriverReady(): boolean
-	/** The raw `ZwaveClient._driverReady` field (no closed/driver checks). */
+	/** Raw `_driverReady` field without the driver/closed checks `isDriverReady` applies */
 	isDriverReadyRaw(): boolean
-	/** `ZwaveClient.closed`. */
 	isClosed(): boolean
-	/** Set `ZwaveClient.closed`. */
 	setClosed(closed: boolean): void
-	/** `ZwaveClient.destroyed`. */
 	isDestroyed(): boolean
-	/** Set `ZwaveClient.status`. */
 	setStatus(status: ZwaveClientStatus): void
-	/** Set `ZwaveClient.driverReady` (fires `driverStatus` when it changes). */
+	/** Fires `driverStatus` when the value changes */
 	setDriverReady(ready: boolean): void
-	/** True when at least one socket client is connected. */
 	hasConnectedClients(): Promise<boolean>
-	/** Forward a driver log line to the `debug` socket room. */
 	emitDebug(message: string): void
-	/** The inclusion user callbacks to attach when no server is enabled. */
+	/** Callbacks attached only when the server is disabled, so inclusion still works over MQTT */
 	getInclusionUserCallbacks(): InclusionUserCallbacks
-	/** Install the inclusion user callbacks on the current driver. */
 	installUserCallbacks(): void
-	/** Persist the current config to settings.json (startup migrations). */
 	persistConfig(): Promise<void>
-	/** Re-run the full client init/connect (used by the backoff timer). */
 	restart(): Promise<void>
-	/** Build the {@link ZwaveServerHost} for a standalone fallback manager. */
 	buildServerHost(): ZwaveServerHost
-	/**
-	 * Clear the runtime timers/throttles that live on `ZwaveClient` and reset
-	 * the inclusion coordinator + firmware update service generations. Run
-	 * during {@link close} after the lifecycle's own timers are cleared and
-	 * before the server/driver are destroyed.
-	 */
+	/** Runs mid-close, after the lifecycle's own timers are cleared and before the server/driver are destroyed */
 	clearRuntimeOnClose(): void
-	/**
-	 * Finalise a non-`keepListeners` close: mark the client destroyed and
-	 * remove all its event listeners.
-	 */
 	finalizeClose(): void
-	/** Driver `driver ready` handler body (node restoration lives here). */
+	/** Node-registry restoration stays on `ZwaveClient`; the lifecycle only drives the generation */
 	onDriverReady(generation: number): Promise<void>
-	/** Driver `error` handler body. */
 	onDriverError(error: unknown, skipRestart: boolean): void
-	/** Driver `all nodes ready` handler body. */
 	onScanComplete(): void
-	/** Driver `bootloader ready` handler body. */
 	onBootLoaderReady(): void
-	/** Driver `firmware update progress` (OTW) handler body. */
 	onOTWFirmwareUpdateProgress(progress: OTWFirmwareUpdateProgress): void
-	/** Driver `firmware update finished` (OTW) handler body. */
 	onOTWFirmwareUpdateFinished(result: OTWFirmwareUpdateResult): void
 }
 
 export class DriverLifecycle {
 	private readonly host: DriverLifecycleHost
 
-	/**
-	 * Monotonically increasing generation counter. Bumped when a new driver
-	 * starts connecting AND when the client is closed, so any in-flight async
-	 * work from an obsolete driver detects the mismatch and aborts instead of
-	 * mutating the replacement generation. NEVER reset by `init()`.
-	 */
+	/** Bumped when a new driver starts connecting and when the client closes, so in-flight work from an obsolete driver detects the mismatch and aborts; never reset by init() */
 	private _generation = 0
 
 	private _backoffRetry = 0
 	private _restartTimeout: NodeJS.Timeout | null = null
 
-	/**
-	 * The in-flight startup promise for the CURRENT connect generation, or
-	 * `null` when no connect is committed/in-flight. A duplicate `connect()`
-	 * that arrives while a startup is still running coalesces onto THIS exact
-	 * promise instead of returning early (which used to falsely signal success
-	 * before the driver was CONNECTED, or even when the startup later failed):
-	 * concurrent callers therefore share the first caller's settlement timing
-	 * and error semantics, and no second `Driver` is ever constructed. Set right
-	 * after {@link _startDriver} commits a generation and cleared only when THAT
-	 * startup settles (or {@link close} cancels it).
-	 */
+	/** In-flight startup promise for the current connect generation; a duplicate connect coalesces onto this exact promise instead of returning a premature success or building a second Driver */
 	private _activeConnect: Promise<void> | null = null
 
-	/**
-	 * The generation {@link _activeConnect} belongs to. A duplicate connect only
-	 * coalesces when this still equals {@link _generation}; once {@link close}
-	 * (or a fresh {@link connect}) bumps the generation, a later connect builds a
-	 * new driver instead of joining a superseded startup.
-	 */
+	/** Generation `_activeConnect` belongs to; a duplicate connect only coalesces while this equals `_generation`, so once close/connect bumps it a later connect builds a new driver */
 	private _activeConnectGeneration = 0
 
 	private _extraLogTransports: Array<{ transport: any; level?: string }> = []
 
-	/**
-	 * The required JSON-socket log transport constructed for the CURRENT driver
-	 * generation (see {@link connect}). `zwave-js`'s `updateLogConfig({transports})`
-	 * REPLACES the driver's whole custom transport list, so every live
-	 * add/remove must re-send this transport FIRST or it would silently drop the
-	 * `debug` socket stream. Re-created on each {@link connect}; a restart/replace
-	 * therefore rebinds to the new generation's transport with nothing captured.
-	 */
+	/** JSON-socket transport for the current driver generation; `updateLogConfig({transports})` replaces the driver's whole custom list, so every live add/remove must re-send this one first or drop the debug stream */
 	private _driverLogTransport: JSONTransport | null = null
 
-	/**
-	 * The immutable configured log level for the current driver generation,
-	 * captured from the driver-only `logConfig` in {@link connect} BEFORE any
-	 * extra-transport elevation. Runtime level is always recomputed as the most
-	 * verbose of this baseline and every registered extra, so removing a verbose
-	 * extra restores exactly this level instead of leaving the driver stuck high.
-	 */
+	/** Configured log level captured before any extra-transport elevation, so removing a verbose extra recomputes back to this baseline instead of leaving the driver stuck high */
 	private _baseLogLevel: string | undefined = undefined
 
 	private _serverManager?: ZwaveServerManager
@@ -188,14 +104,9 @@ export class DriverLifecycle {
 		this.host = host
 	}
 
-	/** The current generation token (see {@link _generation}). */
 	get generation(): number {
 		return this._generation
 	}
-
-	// -----------------------------------------------------------------------
-	// @zwave-js/server coordination
-	// -----------------------------------------------------------------------
 
 	/**
 	 * The lifecycle-managed `@zwave-js/server` subsystem. In production this is
@@ -212,7 +123,6 @@ export class DriverLifecycle {
 		return this._serverManager
 	}
 
-	/** The adopted/lazily-built server manager, or `undefined` if none yet. */
 	get serverManager(): ZwaveServerManager | undefined {
 		return this._serverManager
 	}
@@ -222,9 +132,7 @@ export class DriverLifecycle {
 	}
 
 	set server(value: ZwavejsServer | null) {
-		// Route through the lazy accessor so a directly-constructed client
-		// (standalone / tests) that assigns `server` before any create() still
-		// has a manager to hold it.
+		// Route through the lazy accessor so a client assigning `server` before create() still has a manager to hold it
 		this.zwaveServer.server = value
 	}
 
@@ -237,18 +145,10 @@ export class DriverLifecycle {
 		this._serverManager = manager
 	}
 
-	/**
-	 * Construct (but do not yet start) the server. Called from {@link connect}
-	 * right after the driver is created (and only when `serverEnabled`), so the
-	 * server always exists BEFORE the driver becomes ready.
-	 */
+	/** Constructs but does not start the server; called from connect() only when serverEnabled, so the server exists before the driver becomes ready */
 	createServer(): void {
 		this.zwaveServer.create()
 	}
-
-	// -----------------------------------------------------------------------
-	// Statistics
-	// -----------------------------------------------------------------------
 
 	enableStatistics(): void {
 		const driver = this.host.getDriver()
@@ -280,23 +180,12 @@ export class DriverLifecycle {
 		)
 	}
 
-	// -----------------------------------------------------------------------
-	// Extra log transports (persist across driver restarts)
-	// -----------------------------------------------------------------------
-
-	/**
-	 * Register an extra log transport that persists across driver restarts.
-	 * If the driver is already running, the transport is applied immediately.
-	 */
+	/** Registers an extra log transport that persists across driver restarts */
 	addExtraLogTransport(transport: any, level?: string): void {
 		this._extraLogTransports.push({ transport, level })
 		this.applyRuntimeLogConfig()
 	}
 
-	/**
-	 * Remove a previously registered extra log transport.
-	 * If the driver is running, the transport is detached immediately.
-	 */
 	removeExtraLogTransport(transport: any): void {
 		const idx = this._extraLogTransports.findIndex(
 			(e) => e.transport === transport,
@@ -307,15 +196,7 @@ export class DriverLifecycle {
 		this.applyRuntimeLogConfig()
 	}
 
-	/**
-	 * The COMPLETE runtime custom-transport list the active driver must receive:
-	 * the required JSON-socket transport FIRST, then every currently-registered
-	 * extra transport. `updateLogConfig({transports})` replaces the driver's
-	 * custom transports wholesale in `zwave-js` 15.25.x, so a live add/remove
-	 * that sends anything less silently drops the JSON socket stream and/or the
-	 * other extras. Computed from live state so it always reflects the current
-	 * registration set for the active generation.
-	 */
+	/** Full transport list (JSON-socket transport first, then extras); `updateLogConfig({transports})` replaces the driver's custom transports wholesale, so a partial list drops the socket stream or other extras */
 	private computeRuntimeLogTransports(): any[] {
 		const transports: any[] = []
 		if (this._driverLogTransport) {
@@ -327,12 +208,7 @@ export class DriverLifecycle {
 		return transports
 	}
 
-	/**
-	 * The effective runtime log level: the immutable configured
-	 * {@link _baseLogLevel} raised to the most verbose level requested by any
-	 * registered extra transport. Recomputed from the baseline on every
-	 * add/remove so dropping a verbose extra returns to the configured level.
-	 */
+	/** Configured base level raised to the most verbose registered extra, recomputed from baseline so dropping a verbose extra restores the configured level */
 	private computeRuntimeLogLevel(): string | undefined {
 		let level = this._baseLogLevel
 		let bestIdx =
@@ -348,14 +224,7 @@ export class DriverLifecycle {
 		return level
 	}
 
-	/**
-	 * Apply the current runtime log configuration (the full transport set from
-	 * {@link computeRuntimeLogTransports} plus the recomputed level from
-	 * {@link computeRuntimeLogLevel}) to the active driver, but only once it is
-	 * ready. Before ready this is a no-op: {@link connect} builds the identical
-	 * configuration into the driver options up front using the same two
-	 * helpers, so the runtime and startup paths never diverge.
-	 */
+	/** No-op until the driver is ready, since connect() builds the identical config into the driver options up front */
 	private applyRuntimeLogConfig(): void {
 		const driver = this.host.getDriver()
 		if (!driver || !this.host.isDriverReadyRaw()) {
@@ -371,11 +240,6 @@ export class DriverLifecycle {
 		driver.updateLogConfig(config)
 	}
 
-	// -----------------------------------------------------------------------
-	// Restart / destroyed helpers
-	// -----------------------------------------------------------------------
-
-	/** Reset the exponential backoff counter (called on `driver ready`). */
 	resetBackoff(): void {
 		this._backoffRetry = 0
 	}
@@ -395,19 +259,13 @@ export class DriverLifecycle {
 			}`,
 		)
 
-		// Coalesce repeated backoff schedules into a SINGLE pending restart.
-		// Without this, a second call would overwrite `_restartTimeout` and
-		// leak the earlier handle — leaving it live to fire an extra restart.
-		// The most recent call wins (its delay is used), matching the previous
-		// "latest schedule decides the delay" behavior.
+		// Clear any pending restart so repeated schedules coalesce into one and don't leak a timer that fires twice
 		if (this._restartTimeout) {
 			clearTimeout(this._restartTimeout)
 			this._restartTimeout = null
 		}
 
-		// Fence the callback to the generation active at schedule time, so a
-		// close()/restart or a healthy replacement driver (either of which bumps
-		// the generation) can never let a stale timer fire an unwanted restart.
+		// Fence the callback to the generation at schedule time so a close/restart or replacement driver can't fire a stale restart
 		const generation = this._generation
 		this._restartTimeout = setTimeout(() => {
 			this._restartTimeout = null
@@ -438,10 +296,6 @@ export class DriverLifecycle {
 		return false
 	}
 
-	// -----------------------------------------------------------------------
-	// connect / close
-	// -----------------------------------------------------------------------
-
 	async connect(): Promise<void> {
 		const cfg = this.host.getConfig()
 
@@ -471,21 +325,10 @@ export class DriverLifecycle {
 			return
 		}
 
-		// Capture the now-narrowed port (a `string`) before the coalescing
-		// checks below: an intervening host method call can reset TypeScript's
-		// property narrowing, and `_startDriver` needs a definite port.
+		// Capture the narrowed port before the host calls below, which reset TypeScript's property narrowing
 		const port = cfg.port
 
-		// A duplicate connect that arrives while a startup is still in flight
-		// must COALESCE onto that exact startup — not return early. Returning
-		// early used to falsely signal success before the driver reached
-		// CONNECTED (and even when the startup went on to fail), because the
-		// ready-only guard above does not catch a driver that is mid-`start()`.
-		// Joining `_activeConnect` gives the duplicate caller the first caller's
-		// settlement timing and error semantics while constructing NO second
-		// Driver. Only a startup for the CURRENT generation is joinable: a
-		// close()/restart bumps the generation and clears `_activeConnect`, so a
-		// genuine fresh connect afterwards builds a new driver instead.
+		// Coalesce a duplicate connect onto the in-flight startup of the current generation so callers share its outcome and no second Driver is built; a close/restart bumps the generation and clears `_activeConnect`, so a later connect builds fresh
 		if (
 			this._activeConnect &&
 			this._activeConnectGeneration === this._generation
@@ -494,29 +337,20 @@ export class DriverLifecycle {
 			return this._activeConnect
 		}
 
-		// After a startup has fully SETTLED but the driver has not fired
-		// `driver ready` yet, `_activeConnect` is already cleared. A duplicate
-		// connect in that window must still not build a replacement: the host
-		// field still points at the live, connecting-but-not-ready driver.
-		// Returning here preserves that long-standing compatible behavior (a
-		// legitimate fresh driver only ever comes via close()/restart(), which
-		// destroys the current driver and nulls this field first).
+		// Skip building a replacement while a driver already exists (connecting but not yet ready) after `_activeConnect` cleared; only close/restart nulls that field first
 		if (this.host.getDriver()) {
 			logger.info(`Driver is already connecting to ${cfg.port}`)
 			return
 		}
 
-		// Commit to a new driver generation and run the startup. The startup
-		// promise is tracked as `_activeConnect` so concurrent callers coalesce
-		// onto it (above); it is cleared only when THIS startup settles, so a
-		// duplicate can never observe a stale success.
+		// Track the startup as `_activeConnect` so concurrent callers coalesce onto it
 		const startup = this._startDriver(cfg, port)
 		this._activeConnect = startup
 		this._activeConnectGeneration = this._generation
 		try {
 			await startup
 		} finally {
-			// Clear only if a later connect/close has not already replaced it.
+			// Clear only if a later connect/close hasn't already replaced it
 			if (this._activeConnect === startup) {
 				this._activeConnect = null
 			}
@@ -524,23 +358,12 @@ export class DriverLifecycle {
 	}
 
 	/**
-	 * Build, wire and start a brand-new `Driver` for a freshly-committed
-	 * generation. Extracted from {@link connect} so the connect facade can track
-	 * the returned promise as {@link _activeConnect} and coalesce duplicate
-	 * connects onto it. Every early `return` here settles that shared promise,
-	 * so a coalesced caller sees the exact same completion — including the
-	 * internal catch that logs/backs-off instead of rejecting, which is the
-	 * facade's long-standing public contract. NEVER call this directly except
-	 * through {@link connect}.
-	 *
-	 * @param port The serial port to open. {@link connect} has already rejected
-	 * a missing port before calling here, so it is passed in pre-narrowed as a
-	 * definite `string` (the connect/_startDriver split otherwise loses that
-	 * narrowing across the intervening host calls).
+	 * Builds, wires and starts a new `Driver` for the committed generation. Its
+	 * internal catch logs and backs off instead of rejecting, matching connect()'s
+	 * no-throw contract, so a coalesced caller sees the same completion.
 	 */
 	private async _startDriver(cfg: ZwaveConfig, port: string): Promise<void> {
-		// Commit to a new driver generation. Any obsolete driver's late async
-		// callbacks now detect the bump and abort.
+		// Bump the generation so any obsolete driver's late callbacks detect the change and abort
 		const generation = ++this._generation
 
 		let shouldUpdateSettings = false
@@ -677,20 +500,7 @@ export class DriverLifecycle {
 
 		Object.assign(zwaveOptions, cfg.options)
 
-		// Clone the (possibly user-overridden) logConfig into a driver-only
-		// object BEFORE any runtime enrichment below. `Object.assign` above
-		// aliases `zwaveOptions.logConfig` onto the persisted
-		// `cfg.options.logConfig` whenever a documented `zwave.options.logConfig`
-		// override is present. The steps that follow —
-		// `applyExternalDriverSettings()` (filename/forceConsole) and the
-		// JSON/extra-transport + effective-level enrichment — mutate this object
-		// in place. Without this clone those mutations would leak into the user's
-		// persisted config: e.g. raising the level for a temporary debug transport
-		// would permanently overwrite the configured level, so removing the
-		// transport and restarting could never return to it. A shallow copy is
-		// sufficient because every enrichment step REPLACES a top-level property
-		// (filename, forceConsole, transports, level) rather than mutating a
-		// nested value, so the source object's identity and content stay intact.
+		// Clone logConfig before the enrichment below: `Object.assign(cfg.options)` above can alias it onto the persisted `cfg.options.logConfig`, so in-place mutation would leak driver-only transports/level into the user's saved config
 		if (zwaveOptions.logConfig) {
 			zwaveOptions.logConfig = { ...zwaveOptions.logConfig }
 		}
@@ -720,24 +530,10 @@ export class DriverLifecycle {
 		const logTransport = new JSONTransport()
 		logTransport.format = createDefaultTransportFormat(true, false)
 
-		// Bind the required JSON-socket transport to this generation so live
-		// add/remove log-transport calls re-send it (and every extra) as the
-		// COMPLETE replacement transport list the driver expects.
+		// Bind this generation's JSON-socket transport so live add/remove re-sends it in the full replacement list
 		this._driverLogTransport = logTransport
 
-		// Resolve the log transports/level against the FINAL `logConfig` that
-		// the driver will actually receive. This is now a driver-only shallow
-		// clone (see the clone right after `Object.assign(cfg.options)` above),
-		// so enriching it here injects the required JSON transport and every
-		// registered extra transport — plus any raised level — into the driver's
-		// copy WITHOUT mutating the user's persisted `cfg.options.logConfig`.
-		//
-		// The transports/level are computed through the SAME helpers the live
-		// {@link addExtraLogTransport}/{@link removeExtraLogTransport} path uses
-		// ({@link computeRuntimeLogTransports}/{@link computeRuntimeLogLevel}),
-		// so the startup and runtime configurations can never diverge. The
-		// configured level is captured into {@link _baseLogLevel} FIRST (from
-		// the immutable persisted config) so a later removal restores it.
+		// Enrich the driver-only clone via the same helpers as the runtime path so startup and live configs can't diverge; capture `_baseLogLevel` first so a later transport removal can restore it
 		const finalLogConfig = zwaveOptions.logConfig
 		if (finalLogConfig) {
 			this._baseLogLevel =
@@ -757,10 +553,7 @@ export class DriverLifecycle {
 			this.host.emitDebug(data.message.toString())
 		})
 
-		// Retain the exact `Driver` instance THIS generation creates, so every
-		// stale/error exit can tear down that specific instance and never a
-		// replacement that a newer generation may have stored on the host. See
-		// {@link teardownConnectDriver}.
+		// Hold the exact instance this generation creates so a stale/error exit tears down this driver, never a replacement stored by a newer generation
 		let createdDriver: Driver | null = null
 
 		try {
@@ -829,13 +622,7 @@ export class DriverLifecycle {
 
 			this.host.setStatus(ZwaveClientStatus.CONNECTED)
 		} catch (error) {
-			// Tear down the driver THIS generation created (if any). We must NOT
-			// read `host.getDriver()` here: a newer generation may already have
-			// stored its own replacement driver on the host, and destroying that
-			// would kill a live replacement. Tearing down the exact instance we
-			// created leaks nothing and never touches a replacement. Awaited so
-			// the failed instance releases the port BEFORE the backoff restart
-			// below is allowed to build a replacement (teardown ownership).
+			// Tear down the instance this generation created, not `host.getDriver()`, which may already point at a newer generation's replacement; awaited so the failed instance releases the port before backoff builds a replacement
 			if (createdDriver) {
 				await this.teardownConnectDriver(createdDriver, error)
 			}
@@ -865,27 +652,13 @@ export class DriverLifecycle {
 	}
 
 	/**
-	 * Tear down a specific driver instance created by {@link connect} on a
-	 * stale/error exit, as an explicit **teardown-ownership** step.
-	 *
-	 * The destruction of that exact instance is AWAITED before any host state
-	 * is cleared, so the failed/stale driver has fully released the serial port
-	 * before a backoff/retry (or a coalesced connect waiting on the same
-	 * startup promise) is allowed to construct a replacement. This closes the
-	 * race where the old code cleared the host field immediately while
-	 * `destroy()` ran unawaited: a slow/rejected destroy could let a replacement
-	 * driver be built while the old owner still held the port, leaving the
-	 * controller unreachable.
-	 *
-	 * Ownership rules:
-	 *  - On a CLEAN destroy, clear the host's driver field ONLY when it still
-	 *    references this exact instance — a replacement generation that already
-	 *    stored its own driver on the host is never touched.
-	 *  - On a REJECTED destroy, the exact instance is RETAINED as the owner (the
-	 *    field is not cleared and no replacement is permitted through this path):
-	 *    the driver may still hold the port, so dropping it would leak it and
-	 *    strand the port. The rejection stays observable/retryable — a later
-	 *    {@link close}/retry re-invokes `destroy()` on this same owner.
+	 * Destroys a specific driver instance from a stale/error exit, awaiting
+	 * `destroy()` before clearing host state so the failed driver releases the
+	 * serial port before a backoff/retry or coalesced connect builds a
+	 * replacement. On a clean destroy the host field is cleared only while it
+	 * still references this exact instance; on a rejected destroy the instance is
+	 * retained as owner (field left set, no replacement), since it may still hold
+	 * the port, and a later {@link close}/retry re-invokes `destroy()` on it.
 	 */
 	private async teardownConnectDriver(
 		driver: Driver,
@@ -898,8 +671,7 @@ export class DriverLifecycle {
 				`Error while destroying driver ${(err as Error).message}`,
 				cause,
 			)
-			// Retain ownership of the exact instance: do NOT clear the host
-			// field or allow a replacement — cleanup can be retried later.
+			// Keep this instance as owner so a later close/retry can destroy it again; clearing the field now would strand the port it may still hold
 			return
 		}
 		if (this.host.getDriver() === driver) {
@@ -907,20 +679,12 @@ export class DriverLifecycle {
 		}
 	}
 
-	/**
-	 * Close the client connection. Destroys the server BEFORE the driver and
-	 * clears every timer the lifecycle owns. Idempotent and safe to retry.
-	 */
+	/** Closes the connection, destroying the server before the driver and clearing every lifecycle timer; idempotent and safe to retry */
 	async close(keepListeners = false): Promise<void> {
-		// Invalidate any in-flight generation so a driver that becomes ready or
-		// errors after this point cannot mutate replacement state.
+		// Bump the generation so a driver that becomes ready or errors after this cannot mutate replacement state
 		this._generation++
 
-		// Cancel any in-flight startup coalescing: a duplicate connect after
-		// this close must NOT join the now-superseded startup. The startup's own
-		// generation checks already make it tear down its driver and bail; here
-		// we simply stop new callers from coalescing onto it. Callers already
-		// awaiting it still settle when it does (no deadlock).
+		// Stop a post-close duplicate connect from coalescing onto the superseded startup; callers already awaiting it still settle when it does
 		this._activeConnect = null
 
 		this.host.setStatus(ZwaveClientStatus.CLOSED)
@@ -932,8 +696,6 @@ export class DriverLifecycle {
 			this._restartTimeout = null
 		}
 
-		// Clears heal/updates/stateless/poll/throttle timers on ZwaveClient and
-		// resets the inclusion coordinator + firmware update service.
 		this.host.clearRuntimeOnClose()
 
 		if (this._serverManager) {
@@ -953,14 +715,7 @@ export class DriverLifecycle {
 		logger.info('Client closed')
 	}
 
-	// -----------------------------------------------------------------------
-	// Generation-guarded driver-event dispatch
-	//
-	// The handler bodies (which touch ZwaveClient node/controller state) stay
-	// in ZwaveClient behind the host port; the dispatch here drops any event
-	// coming from an obsolete driver generation.
-	// -----------------------------------------------------------------------
-
+	// Generation-guarded dispatch drops events from an obsolete driver generation; handler bodies that touch node/controller state stay in ZwaveClient behind the host port
 	private dispatchDriverReady(generation: number): void {
 		if (this._generation !== generation) {
 			return

--- a/api/lib/zwave/DriverLifecycle.ts
+++ b/api/lib/zwave/DriverLifecycle.ts
@@ -539,6 +539,24 @@ export class DriverLifecycle {
 
 		Object.assign(zwaveOptions, cfg.options)
 
+		// Clone the (possibly user-overridden) logConfig into a driver-only
+		// object BEFORE any runtime enrichment below. `Object.assign` above
+		// aliases `zwaveOptions.logConfig` onto the persisted
+		// `cfg.options.logConfig` whenever a documented `zwave.options.logConfig`
+		// override is present. The steps that follow —
+		// `applyExternalDriverSettings()` (filename/forceConsole) and the
+		// JSON/extra-transport + effective-level enrichment — mutate this object
+		// in place. Without this clone those mutations would leak into the user's
+		// persisted config: e.g. raising the level for a temporary debug transport
+		// would permanently overwrite the configured level, so removing the
+		// transport and restarting could never return to it. A shallow copy is
+		// sufficient because every enrichment step REPLACES a top-level property
+		// (filename, forceConsole, transports, level) rather than mutating a
+		// nested value, so the source object's identity and content stay intact.
+		if (zwaveOptions.logConfig) {
+			zwaveOptions.logConfig = { ...zwaveOptions.logConfig }
+		}
+
 		let s0Key: string | undefined
 
 		// back compatibility
@@ -565,12 +583,11 @@ export class DriverLifecycle {
 		logTransport.format = createDefaultTransportFormat(true, false)
 
 		// Resolve the log transports/level against the FINAL `logConfig` that
-		// the driver will actually receive — i.e. AFTER `Object.assign(cfg.options)`
-		// and `applyExternalDriverSettings()` above may have replaced or mutated
-		// it. Mutating the pre-override local `logConfig` here would silently drop
-		// the required JSON transport (and every registered extra transport) from
-		// the driver whenever a documented `zwave.options.logConfig` override
-		// replaced the object reference.
+		// the driver will actually receive. This is now a driver-only shallow
+		// clone (see the clone right after `Object.assign(cfg.options)` above),
+		// so enriching it here injects the required JSON transport and every
+		// registered extra transport — plus any raised level — into the driver's
+		// copy WITHOUT mutating the user's persisted `cfg.options.logConfig`.
 		const finalLogConfig = zwaveOptions.logConfig
 		if (finalLogConfig) {
 			finalLogConfig.transports = [

--- a/api/lib/zwave/DriverLifecycle.ts
+++ b/api/lib/zwave/DriverLifecycle.ts
@@ -73,8 +73,8 @@ export interface DriverLifecycleHost {
 	/** Runs mid-close, after the lifecycle's own timers are cleared and before the server/driver are destroyed */
 	clearRuntimeOnClose(): void
 	finalizeClose(): void
-	/** Lifecycle drives only the generation, leaving node-registry restoration to ZwaveClient */
-	onDriverReady(generation: number): Promise<void>
+	/** Lifecycle drives generation and ready epochs, leaving node-registry restoration to ZwaveClient */
+	onDriverReady(generation: number, readyEpoch: number): Promise<void>
 	onDriverError(error: unknown, skipRestart: boolean): void
 	onScanComplete(): void
 	onBootLoaderReady(): void
@@ -87,6 +87,9 @@ export class DriverLifecycle {
 
 	/** Bumped when a new driver starts connecting and when the client closes, so in-flight work from an obsolete driver detects the mismatch and aborts */
 	private _generation = 0
+
+	/** Separately fences repeated ready events and init() calls that keep the same driver generation */
+	private _readyEpoch = 0
 
 	private _backoffRetry = 0
 	private _restartTimeout: NodeJS.Timeout | null = null
@@ -108,6 +111,8 @@ export class DriverLifecycle {
 	/** Baseline level name captured before any extra-transport elevation, so removing the last verbose extra recomputes back to it instead of leaving the driver stuck high. Defaults to the exported `CONTROLLER_LOGLEVEL`, which matches this app's configured default level, when the driver config carries no explicit level. */
 	private _baseLogLevel: string = CONTROLLER_LOGLEVEL
 
+	private _runtimeLogConfigDirty = false
+
 	private _serverManager?: ZwaveServerManager
 
 	private readonly deps: DriverLifecycleDeps
@@ -122,6 +127,14 @@ export class DriverLifecycle {
 
 	get generation(): number {
 		return this._generation
+	}
+
+	get readyEpoch(): number {
+		return this._readyEpoch
+	}
+
+	invalidateReady(): void {
+		this._readyEpoch++
 	}
 
 	/** Lazily builds a standalone fallback manager on first access so a directly-constructed client's server lifecycle works with no coordinator to adopt one */
@@ -190,6 +203,7 @@ export class DriverLifecycle {
 	addExtraLogTransport(transport: Transport, level?: string): void {
 		// Store on the lifecycle so the transport survives driver restarts
 		this._extraLogTransports.push({ transport, level })
+		this._runtimeLogConfigDirty = true
 		this.applyRuntimeLogConfig()
 	}
 
@@ -199,6 +213,7 @@ export class DriverLifecycle {
 		)
 		if (idx !== -1) {
 			this._extraLogTransports.splice(idx, 1)
+			this._runtimeLogConfigDirty = true
 		}
 		this.applyRuntimeLogConfig()
 	}
@@ -229,7 +244,11 @@ export class DriverLifecycle {
 	}
 
 	private applyRuntimeLogConfig(): void {
-		// No-op until the driver is ready, since connect() builds the identical config into the driver options up front
+		if (!this._runtimeLogConfigDirty) {
+			return
+		}
+
+		// Defer changes made after startup options were built until the driver is ready
 		const driver = this.host.getDriver()
 		if (!driver || !this.host.isDriverReadyRaw()) {
 			return
@@ -240,10 +259,15 @@ export class DriverLifecycle {
 			level: this.computeRuntimeLogLevel(),
 		}
 		driver.updateLogConfig(config)
+		this._runtimeLogConfigDirty = false
 	}
 
 	resetBackoff(): void {
 		this._backoffRetry = 0
+		if (this._restartTimeout) {
+			clearTimeout(this._restartTimeout)
+			this._restartTimeout = null
+		}
 	}
 
 	backoffRestart(): void {
@@ -541,6 +565,7 @@ export class DriverLifecycle {
 		} else {
 			this._baseLogLevel = CONTROLLER_LOGLEVEL
 		}
+		this._runtimeLogConfigDirty = false
 
 		logTransport.stream.on('data', (data: any) => {
 			this.host.emitDebug(data.message.toString())
@@ -667,6 +692,7 @@ export class DriverLifecycle {
 	async close(keepListeners = false): Promise<void> {
 		// Bump the generation so a driver that becomes ready or errors after this cannot mutate replacement state
 		this._generation++
+		this._readyEpoch++
 
 		// Stop a post-close duplicate connect from coalescing onto the superseded startup
 		this._activeConnect = null
@@ -704,14 +730,37 @@ export class DriverLifecycle {
 		if (this._generation !== generation) {
 			return
 		}
-		void this.host.onDriverReady(generation).catch((error: unknown) => {
-			if (this._generation !== generation) {
-				return
-			}
-			this.host.setDriverReady(false)
-			this.host.onDriverError(toError(error), true)
-			this.backoffRestart()
+
+		const readyEpoch = ++this._readyEpoch
+		let ready: Promise<void>
+		try {
+			ready = this.host.onDriverReady(generation, readyEpoch)
+			this.applyRuntimeLogConfig()
+		} catch (error) {
+			this.handleDriverReadyFailure(generation, readyEpoch, error)
+			return
+		}
+
+		void ready.catch((error: unknown) => {
+			this.handleDriverReadyFailure(generation, readyEpoch, error)
 		})
+	}
+
+	private handleDriverReadyFailure(
+		generation: number,
+		readyEpoch: number,
+		error: unknown,
+	): void {
+		if (
+			this._generation !== generation ||
+			this._readyEpoch !== readyEpoch
+		) {
+			return
+		}
+		this._readyEpoch++
+		this.host.setDriverReady(false)
+		this.host.onDriverError(toError(error), true)
+		this.backoffRestart()
 	}
 
 	private dispatchDriverError(generation: number, error: Error): void {

--- a/api/lib/zwave/DriverLifecycle.ts
+++ b/api/lib/zwave/DriverLifecycle.ts
@@ -381,6 +381,25 @@ export class DriverLifecycle {
 			return
 		}
 
+		// Coalesce a reconnect onto an already in-flight connect. A previous
+		// connect() may have constructed a driver and stored it on the host, but
+		// that driver has NOT fired `driver ready` yet (its `start()` may have
+		// resolved so the outer connect() has already returned CONNECTED, or it
+		// may still be awaiting `start()`). Either way the ready-only guard above
+		// does not catch it. Proceeding here would mint a new generation,
+		// construct a REPLACEMENT driver and overwrite the host field — stranding
+		// the first, still-live, non-ready driver: unreachable, never torn down,
+		// and still holding the serial port. Coalescing keeps public connect
+		// timing unchanged on the common (no driver yet) path. Callers that
+		// genuinely need a fresh driver (config change, backoff retry, hard
+		// reset) go through close()/restart(), which destroys the current driver
+		// and nulls this field BEFORE reconnecting, so a legitimate restart is
+		// never blocked here.
+		if (this.host.getDriver()) {
+			logger.info(`Driver is already connecting to ${cfg.port}`)
+			return
+		}
+
 		// Commit to a new driver generation. Any obsolete driver's late async
 		// callbacks now detect the bump and abort.
 		const generation = ++this._generation

--- a/api/lib/zwave/DriverLifecycle.ts
+++ b/api/lib/zwave/DriverLifecycle.ts
@@ -767,6 +767,13 @@ export class DriverLifecycle {
 		if (this._generation !== generation) {
 			return
 		}
+		if (
+			isZWaveError(error) &&
+			error.code === ZWaveErrorCodes.Driver_Failed
+		) {
+			this._generation++
+			this._readyEpoch++
+		}
 		this.host.onDriverError(error, false)
 	}
 

--- a/api/lib/zwave/DriverLifecycle.ts
+++ b/api/lib/zwave/DriverLifecycle.ts
@@ -732,13 +732,16 @@ export class DriverLifecycle {
 
 		this.host.clearRuntimeOnClose()
 
+		let teardownError: unknown
 		if (this._serverManager) {
-			await this._serverManager.destroy()
+			try {
+				await this._serverManager.destroy()
+			} catch (error) {
+				teardownError = error
+			}
 		}
 
 		const driver = this.host.getDriver()
-		let destroyFailed = false
-		let destroyError: unknown
 		if (driver) {
 			try {
 				await this.destroyDriver(driver)
@@ -747,8 +750,7 @@ export class DriverLifecycle {
 				if (this.host.getDriver() === driver) {
 					this.host.setDriver(null)
 				}
-				destroyFailed = true
-				destroyError = error
+				teardownError ??= error
 			}
 			if (this.host.getDriver() === driver) {
 				this.host.setDriver(null)
@@ -760,8 +762,8 @@ export class DriverLifecycle {
 		}
 
 		logger.info('Client closed')
-		if (destroyFailed) {
-			throw destroyError
+		if (teardownError !== undefined) {
+			throw teardownError
 		}
 	}
 
@@ -800,6 +802,7 @@ export class DriverLifecycle {
 			return
 		}
 		this._completedReadyEpoch = readyEpoch
+		this.resetBackoff()
 		if (
 			this._pendingScan?.generation === generation &&
 			this._pendingScan.readyEpoch === readyEpoch

--- a/api/lib/zwave/FirmwareUpdateService.ts
+++ b/api/lib/zwave/FirmwareUpdateService.ts
@@ -80,8 +80,17 @@ export class FirmwareUpdateService {
 		this.clearScheduledCheck()
 	}
 
-	private _assertFence(gen: number, operation: string): void {
-		if (this._generation !== gen || this._disposed) {
+	private _assertFence(
+		gen: number,
+		operation: string,
+		scheduleChain?: number,
+	): void {
+		if (
+			this._generation !== gen ||
+			this._disposed ||
+			(scheduleChain !== undefined &&
+				this._scheduleChain !== scheduleChain)
+		) {
 			throw new FirmwareLifecycleCancelledError(operation)
 		}
 	}
@@ -128,6 +137,13 @@ export class FirmwareUpdateService {
 	async checkAllNodesFirmwareUpdates(
 		options?: unknown,
 	): Promise<Map<number, FirmwareUpdateInfo[]> | undefined> {
+		return this._checkAllNodesFirmwareUpdates(options)
+	}
+
+	private async _checkAllNodesFirmwareUpdates(
+		options?: unknown,
+		scheduleChain?: number,
+	): Promise<Map<number, FirmwareUpdateInfo[]> | undefined> {
 		const drv = this._driver.getDriver()
 		if (!drv || !this._driver.isDriverReady()) {
 			throw new Error('Driver is not ready')
@@ -148,7 +164,11 @@ export class FirmwareUpdateService {
 			const result =
 				await drv.controller.getAllAvailableFirmwareUpdates(options)
 
-			this._assertFence(gen, 'checkAllNodesFirmwareUpdates')
+			this._assertFence(
+				gen,
+				'checkAllNodesFirmwareUpdates',
+				scheduleChain,
+			)
 
 			if (result) {
 				const now = Date.now()
@@ -177,6 +197,7 @@ export class FirmwareUpdateService {
 					staged,
 					gen,
 					'checkAllNodesFirmwareUpdates',
+					scheduleChain,
 				)
 			}
 
@@ -590,11 +611,17 @@ export class FirmwareUpdateService {
 		const gen = this._generation
 
 		try {
-			await this.checkAllNodesFirmwareUpdates()
+			await this._checkAllNodesFirmwareUpdates(undefined, chain)
 		} catch (error) {
-			this._logger.warn(
-				`Scheduled firmware update check has failed: ${getErrorMessage(error)}`,
-			)
+			if (
+				this._generation === gen &&
+				this._scheduleChain === chain &&
+				!this._disposed
+			) {
+				this._logger.warn(
+					`Scheduled firmware update check has failed: ${getErrorMessage(error)}`,
+				)
+			}
 		}
 
 		// Skip the reschedule if this chain was superseded or torn down mid-check, so it can't leak a stale timer
@@ -694,6 +721,7 @@ export class FirmwareUpdateService {
 		staged: ReadonlyArray<StagedFirmwareNodeUpdate>,
 		gen: number,
 		operation: string,
+		scheduleChain?: number,
 	): Promise<void> {
 		const persistenceTargets = staged.flatMap((projection) => {
 			const node = this._nodes.getNode(projection.nodeId)
@@ -767,6 +795,7 @@ export class FirmwareUpdateService {
 					})
 				}
 			},
+			scheduleChain,
 		)
 	}
 
@@ -777,21 +806,40 @@ export class FirmwareUpdateService {
 		publish?: (
 			restore?: FirmwarePersistenceRestore,
 		) => Promise<void> | void,
+		scheduleChain?: number,
 	): Promise<void> {
 		const persistence = this._persistenceTail.then(async () => {
-			this._assertFence(gen, operation)
-			const restore = await persist()
-
-			if (this._generation !== gen || this._disposed) {
-				// Restore current state because an in-flight filesystem write cannot be cancelled
-				if (restore) {
-					await restore()
-				} else {
-					await this._nodes.updateStoreNodes()
-				}
+			this._assertFence(gen, operation, scheduleChain)
+			let persistenceFailed = false
+			let persistenceError: unknown
+			let restore: FirmwarePersistenceRestore | void = undefined
+			try {
+				restore = await persist()
+			} catch (error) {
+				persistenceFailed = true
+				persistenceError = error
 			}
 
-			this._assertFence(gen, operation)
+			if (
+			this._generation !== gen ||
+			this._disposed ||
+			(scheduleChain !== undefined &&
+				this._scheduleChain !== scheduleChain)
+		) {
+			// Restore current state because an in-flight filesystem write cannot be cancelled
+			if (restore) {
+				await restore()
+			} else {
+				await this._nodes.updateStoreNodes()
+				this._assertFence(gen, operation, scheduleChain)
+			}
+		}
+
+			if (persistenceFailed) {
+				throw persistenceError
+			}
+
+			this._assertFence(gen, operation, scheduleChain)
 			await publish?.(restore || undefined)
 		})
 

--- a/api/lib/zwave/FirmwareUpdateService.ts
+++ b/api/lib/zwave/FirmwareUpdateService.ts
@@ -38,6 +38,18 @@ export class FirmwareUpdateService {
 	private _firmwareUpdateCheckTimeout: ReturnType<typeof setTimeout> | null =
 		null
 
+	/**
+	 * Monotonic token identifying the CURRENT scheduled-check chain. Bumped by
+	 * every {@link scheduledFirmwareUpdateCheck} entry so that repeated
+	 * `all nodes ready` events on the SAME generation (an NVM restore or a
+	 * controller firmware update re-emits it with no dispose/reset) cannot stack
+	 * parallel ~24h chains: the previous chain's armed timer is cleared and its
+	 * in-flight check bails on the token mismatch, leaving exactly one chain.
+	 * Distinct from {@link _generation} (only bumped on dispose/reset), which
+	 * cannot fence a same-generation repeat.
+	 */
+	private _scheduleChain = 0
+
 	private _nvmEventSetter: ((event: string) => void) | undefined
 
 	// Advance on reset so suspended work cannot publish into a new lifecycle
@@ -581,6 +593,15 @@ export class FirmwareUpdateService {
 			return
 		}
 
+		// Enforce a single armed/in-flight chain: cancel any timer a previous
+		// (same-generation) `all nodes ready` armed, and supersede its still
+		// in-flight check, BEFORE starting this one. A repeated `all nodes
+		// ready` (an NVM restore or a controller firmware update re-emits it
+		// with no dispose/reset) otherwise overwrote and leaked the earlier
+		// ~24h handle, stacking parallel daily chains. `_generation` cannot
+		// fence this because it is only bumped on dispose/reset.
+		this.clearScheduledCheck()
+		const chain = ++this._scheduleChain
 		const gen = this._generation
 
 		try {
@@ -591,8 +612,14 @@ export class FirmwareUpdateService {
 			)
 		}
 
-		// Skip rescheduling after reset to prevent duplicate loops
-		if (this._generation !== gen || this._disposed) {
+		// Generation + chain fence: if disposed, reset, or superseded by a
+		// fresh same-generation chain during the check, do NOT reschedule —
+		// the old chain must not produce a new timer.
+		if (
+			this._generation !== gen ||
+			this._scheduleChain !== chain ||
+			this._disposed
+		) {
 			return
 		}
 

--- a/api/lib/zwave/FirmwareUpdateService.ts
+++ b/api/lib/zwave/FirmwareUpdateService.ts
@@ -38,7 +38,7 @@ export class FirmwareUpdateService {
 	private _firmwareUpdateCheckTimeout: ReturnType<typeof setTimeout> | null =
 		null
 
-	/** Dedupes same-generation scheduled-check chains; `_generation` can't, because `all nodes ready` re-fires without a dispose/reset (NVM restore, controller firmware update) */
+	/** Dedupes same-generation scheduled-check chains that `_generation` can't, because `all nodes ready` re-fires without a dispose or reset on NVM restore and controller firmware update */
 	private _scheduleChain = 0
 
 	private _nvmEventSetter: ((event: string) => void) | undefined

--- a/api/lib/zwave/FirmwareUpdateService.ts
+++ b/api/lib/zwave/FirmwareUpdateService.ts
@@ -19,11 +19,14 @@ import type {
 
 export class FirmwareLifecycleCancelledError extends Error {
 	constructor(operation: string) {
-		super(
-			`Firmware operation "${operation}" cancelled: service generation advanced`,
-		)
+		super(`Firmware operation "${operation}" cancelled: lifecycle advanced`)
 		this.name = 'FirmwareLifecycleCancelledError'
 	}
+}
+
+interface FirmwareOperationFence {
+	scheduleChain?: number
+	bulkCheckEpoch?: number
 }
 
 export class FirmwareUpdateService {
@@ -40,6 +43,9 @@ export class FirmwareUpdateService {
 
 	/** Dedupes same-generation scheduled-check chains that `_generation` can't, because `all nodes ready` re-fires without a dispose or reset on NVM restore and controller firmware update */
 	private _scheduleChain = 0
+
+	/** Latest-started bulk firmware check allowed to persist and publish */
+	private _bulkCheckEpoch = 0
 
 	private _nvmEventSetter: ((event: string) => void) | undefined
 
@@ -83,16 +89,25 @@ export class FirmwareUpdateService {
 	private _assertFence(
 		gen: number,
 		operation: string,
-		scheduleChain?: number,
+		fence?: FirmwareOperationFence,
 	): void {
-		if (
-			this._generation !== gen ||
-			this._disposed ||
-			(scheduleChain !== undefined &&
-				this._scheduleChain !== scheduleChain)
-		) {
+		if (!this._isFenceCurrent(gen, fence)) {
 			throw new FirmwareLifecycleCancelledError(operation)
 		}
+	}
+
+	private _isFenceCurrent(
+		gen: number,
+		fence?: FirmwareOperationFence,
+	): boolean {
+		return (
+			this._generation === gen &&
+			!this._disposed &&
+			(fence?.scheduleChain === undefined ||
+				this._scheduleChain === fence.scheduleChain) &&
+			(fence?.bulkCheckEpoch === undefined ||
+				this._bulkCheckEpoch === fence.bulkCheckEpoch)
+		)
 	}
 
 	async getAvailableFirmwareUpdates(
@@ -157,6 +172,10 @@ export class FirmwareUpdateService {
 		}
 
 		const gen = this._generation
+		const fence: FirmwareOperationFence = {
+			scheduleChain,
+			bulkCheckEpoch: ++this._bulkCheckEpoch,
+		}
 
 		this._logger.info('Starting bulk firmware update check for all nodes')
 
@@ -164,11 +183,7 @@ export class FirmwareUpdateService {
 			const result =
 				await drv.controller.getAllAvailableFirmwareUpdates(options)
 
-			this._assertFence(
-				gen,
-				'checkAllNodesFirmwareUpdates',
-				scheduleChain,
-			)
+			this._assertFence(gen, 'checkAllNodesFirmwareUpdates', fence)
 
 			if (result) {
 				const now = Date.now()
@@ -197,7 +212,7 @@ export class FirmwareUpdateService {
 					staged,
 					gen,
 					'checkAllNodesFirmwareUpdates',
-					scheduleChain,
+					fence,
 				)
 			}
 
@@ -614,6 +629,7 @@ export class FirmwareUpdateService {
 			await this._checkAllNodesFirmwareUpdates(undefined, chain)
 		} catch (error) {
 			if (
+				!(error instanceof FirmwareLifecycleCancelledError) &&
 				this._generation === gen &&
 				this._scheduleChain === chain &&
 				!this._disposed
@@ -663,7 +679,6 @@ export class FirmwareUpdateService {
 		}
 
 		const gen = this._generation
-
 		try {
 			const drv = this._driver.getDriver()
 			if (!drv) {
@@ -721,7 +736,7 @@ export class FirmwareUpdateService {
 		staged: ReadonlyArray<StagedFirmwareNodeUpdate>,
 		gen: number,
 		operation: string,
-		scheduleChain?: number,
+		fence?: FirmwareOperationFence,
 	): Promise<void> {
 		const persistenceTargets = staged.flatMap((projection) => {
 			const node = this._nodes.getNode(projection.nodeId)
@@ -795,7 +810,7 @@ export class FirmwareUpdateService {
 					})
 				}
 			},
-			scheduleChain,
+			fence,
 		)
 	}
 
@@ -806,10 +821,10 @@ export class FirmwareUpdateService {
 		publish?: (
 			restore?: FirmwarePersistenceRestore,
 		) => Promise<void> | void,
-		scheduleChain?: number,
+		fence?: FirmwareOperationFence,
 	): Promise<void> {
 		const persistence = this._persistenceTail.then(async () => {
-			this._assertFence(gen, operation, scheduleChain)
+			this._assertFence(gen, operation, fence)
 			let persistenceFailed = false
 			let persistenceError: unknown
 			let restore: FirmwarePersistenceRestore | void = undefined
@@ -820,26 +835,21 @@ export class FirmwareUpdateService {
 				persistenceError = error
 			}
 
-			if (
-			this._generation !== gen ||
-			this._disposed ||
-			(scheduleChain !== undefined &&
-				this._scheduleChain !== scheduleChain)
-		) {
-			// Restore current state because an in-flight filesystem write cannot be cancelled
-			if (restore) {
-				await restore()
-			} else {
-				await this._nodes.updateStoreNodes()
-				this._assertFence(gen, operation, scheduleChain)
+			if (!this._isFenceCurrent(gen, fence)) {
+				// Restore current state because an in-flight filesystem write cannot be cancelled
+				if (restore) {
+					await restore()
+				} else {
+					await this._nodes.updateStoreNodes()
+					this._assertFence(gen, operation, fence)
+				}
 			}
-		}
 
 			if (persistenceFailed) {
 				throw persistenceError
 			}
 
-			this._assertFence(gen, operation, scheduleChain)
+			this._assertFence(gen, operation, fence)
 			await publish?.(restore || undefined)
 		})
 

--- a/api/lib/zwave/FirmwareUpdateService.ts
+++ b/api/lib/zwave/FirmwareUpdateService.ts
@@ -38,16 +38,7 @@ export class FirmwareUpdateService {
 	private _firmwareUpdateCheckTimeout: ReturnType<typeof setTimeout> | null =
 		null
 
-	/**
-	 * Monotonic token identifying the CURRENT scheduled-check chain. Bumped by
-	 * every {@link scheduledFirmwareUpdateCheck} entry so that repeated
-	 * `all nodes ready` events on the SAME generation (an NVM restore or a
-	 * controller firmware update re-emits it with no dispose/reset) cannot stack
-	 * parallel ~24h chains: the previous chain's armed timer is cleared and its
-	 * in-flight check bails on the token mismatch, leaving exactly one chain.
-	 * Distinct from {@link _generation} (only bumped on dispose/reset), which
-	 * cannot fence a same-generation repeat.
-	 */
+	/** Dedupes same-generation scheduled-check chains; `_generation` can't, because `all nodes ready` re-fires without a dispose/reset (NVM restore, controller firmware update) */
 	private _scheduleChain = 0
 
 	private _nvmEventSetter: ((event: string) => void) | undefined
@@ -593,13 +584,7 @@ export class FirmwareUpdateService {
 			return
 		}
 
-		// Enforce a single armed/in-flight chain: cancel any timer a previous
-		// (same-generation) `all nodes ready` armed, and supersede its still
-		// in-flight check, BEFORE starting this one. A repeated `all nodes
-		// ready` (an NVM restore or a controller firmware update re-emits it
-		// with no dispose/reset) otherwise overwrote and leaked the earlier
-		// ~24h handle, stacking parallel daily chains. `_generation` cannot
-		// fence this because it is only bumped on dispose/reset.
+		// Supersede any prior same-generation chain before starting so daily checks can't stack
 		this.clearScheduledCheck()
 		const chain = ++this._scheduleChain
 		const gen = this._generation
@@ -612,9 +597,7 @@ export class FirmwareUpdateService {
 			)
 		}
 
-		// Generation + chain fence: if disposed, reset, or superseded by a
-		// fresh same-generation chain during the check, do NOT reschedule —
-		// the old chain must not produce a new timer.
+		// Skip the reschedule if this chain was superseded or torn down mid-check, so it can't leak a stale timer
 		if (
 			this._generation !== gen ||
 			this._scheduleChain !== chain ||

--- a/api/lib/zwave/ports.ts
+++ b/api/lib/zwave/ports.ts
@@ -20,6 +20,8 @@ import type {
 	JoinNetworkResult,
 	PlannedProvisioningEntry,
 	QRProvisioningInformation,
+	ZWaveOptions,
+	RFRegion,
 } from 'zwave-js'
 import { InclusionStrategy, QRCodeVersion } from 'zwave-js'
 import type {
@@ -29,6 +31,7 @@ import type {
 } from '@zwave-js/core'
 import type { ConfigManager } from '@zwave-js/config'
 import type { DeepPartial } from '../utils.ts'
+import type * as LogManager from '../logger.ts'
 
 export type {
 	FirmwareFileFormat,
@@ -46,6 +49,78 @@ export type {
 	QRProvisioningInformation,
 }
 export { InclusionStrategy, QRCodeVersion }
+
+// Define shared lifecycle types here to avoid a ZwaveClient import cycle
+export type SensorTypeScale = {
+	key: string | number
+	sensor: string
+	label: string
+	unit?: string
+	description?: string
+}
+
+export type ZwaveConfig = {
+	enabled?: boolean
+	allowBootloaderOnly?: boolean
+	port?: string
+	networkKey?: string
+	securityKeys?: DeepPartial<{
+		S2_Unauthenticated: string
+		S2_Authenticated: string
+		S2_AccessControl: string
+		S0_Legacy: string
+	}>
+	securityKeysLongRange?: DeepPartial<{
+		S2_Authenticated: string
+		S2_AccessControl: string
+	}>
+	serverEnabled?: boolean
+	enableSoftReset?: boolean
+	disableWatchdog?: boolean
+	deviceConfigPriorityDir?: string
+	serverPort?: number
+	serverHost?: string
+	logEnabled?: boolean
+	maxFiles?: number
+	logLevel?: LogManager.LogLevel
+	commandsTimeout?: number
+	sendToSleepTimeout?: number
+	responseTimeout?: number
+	enableStatistics?: boolean
+	disableOptimisticValueUpdate?: boolean
+	disclaimerVersion?: number
+	options?: ZWaveOptions
+	// healNetwork?: boolean
+	healHour?: number
+	logToFile?: boolean
+	nodeFilter?: string[]
+	scales?: SensorTypeScale[]
+	serverServiceDiscoveryDisabled?: boolean
+	maxNodeEventsQueueSize?: number
+	higherReportsTimeout?: boolean
+	disableControllerRecovery?: boolean
+	disableAutomaticFirmwareUpdateChecks?: boolean
+	rf?: {
+		region?: RFRegion
+		maxLongRangePowerlevel?: number | 'auto'
+		autoPowerlevels?: boolean
+		txPower?: {
+			powerlevel: number | 'auto'
+			measured0dBm?: number
+		}
+	}
+}
+
+export const ZwaveClientStatus = {
+	CONNECTED: 'connected',
+	BOOTLOADER_READY: 'bootloader ready',
+	DRIVER_READY: 'driver ready',
+	SCAN_DONE: 'scan done',
+	DRIVER_FAILED: 'driver failed',
+	CLOSED: 'closed',
+} as const
+export type ZwaveClientStatus =
+	(typeof ZwaveClientStatus)[keyof typeof ZwaveClientStatus]
 
 export const ZUIScheduleEntryLockMode = {
 	DAILY: 'daily',

--- a/api/lib/zwave/ports.ts
+++ b/api/lib/zwave/ports.ts
@@ -50,7 +50,7 @@ export type {
 }
 export { InclusionStrategy, QRCodeVersion }
 
-// Define shared lifecycle types here to avoid a ZwaveClient import cycle
+// Defined here so extracted services like DriverLifecycle can reference client config/status types without an import cycle on ZwaveClient
 export type SensorTypeScale = {
 	key: string | number
 	sensor: string

--- a/api/lib/zwave/ports.ts
+++ b/api/lib/zwave/ports.ts
@@ -528,6 +528,7 @@ export interface FirmwareNodeStorePort {
 		nodeIds?: readonly number[],
 		requiredNodes?: readonly FirmwarePersistenceNodeTarget[],
 	): Promise<FirmwarePersistenceRestore | void>
+	runStoreTransaction(operation: () => Promise<void>): Promise<void>
 	/** Captures the current store identity and authoritative state before a filesystem write starts */
 	createStoreRestorePoint(): () => Promise<void>
 	/** Filesystem writes may complete after reset, so callers must fence before publishing staged state */

--- a/api/lib/zwave/ports.ts
+++ b/api/lib/zwave/ports.ts
@@ -523,10 +523,13 @@ export interface FirmwareNodeStorePort {
 	getNode(nodeId: number): FirmwareUpdateNodeState | undefined
 	getStoreNode(nodeId: number): Partial<FirmwareUpdateNodeState> | undefined
 	ensureStoreNode(nodeId: number): Partial<FirmwareUpdateNodeState>
+	getStoreHomeId(): string | undefined
 	updateStoreNodes(
 		nodeIds?: readonly number[],
 		requiredNodes?: readonly FirmwarePersistenceNodeTarget[],
 	): Promise<FirmwarePersistenceRestore | void>
+	/** Captures the current store identity and authoritative state before a filesystem write starts */
+	createStoreRestorePoint(): () => Promise<void>
 	/** Filesystem writes may complete after reset, so callers must fence before publishing staged state */
 	persistStagedNodeUpdates(
 		staged: ReadonlyArray<StagedFirmwareNodeUpdate>,

--- a/api/lib/zwave/ports.ts
+++ b/api/lib/zwave/ports.ts
@@ -523,14 +523,10 @@ export interface FirmwareNodeStorePort {
 	getNode(nodeId: number): FirmwareUpdateNodeState | undefined
 	getStoreNode(nodeId: number): Partial<FirmwareUpdateNodeState> | undefined
 	ensureStoreNode(nodeId: number): Partial<FirmwareUpdateNodeState>
-	getStoreHomeId(): string | undefined
 	updateStoreNodes(
 		nodeIds?: readonly number[],
 		requiredNodes?: readonly FirmwarePersistenceNodeTarget[],
 	): Promise<FirmwarePersistenceRestore | void>
-	runStoreTransaction(operation: () => Promise<void>): Promise<void>
-	/** Captures the current store identity and authoritative state before a filesystem write starts */
-	createStoreRestorePoint(): () => Promise<void>
 	/** Filesystem writes may complete after reset, so callers must fence before publishing staged state */
 	persistStagedNodeUpdates(
 		staged: ReadonlyArray<StagedFirmwareNodeUpdate>,

--- a/test/lib/hass/server.test.ts
+++ b/test/lib/hass/server.test.ts
@@ -22,6 +22,7 @@ import {
 } from 'vitest'
 import { ensureTestEnv, cleanupTestEnv } from './env.ts'
 import { createRecordingSocket } from './fixtures.ts'
+import { createDeferred } from '../zwave/serviceTestSupport.ts'
 import type ZWaveClientType from '#api/lib/ZwaveClient.ts'
 import { ZwaveClientStatus } from '#api/lib/ZwaveClient.ts'
 import { NODE_ID_BROADCAST, NODE_ID_BROADCAST_LR } from '@zwave-js/core'
@@ -176,6 +177,7 @@ function waitForDriverReadyEvent(zwave: ZWaveClientType): Promise<void> {
 async function driveConnectToReady(
 	cfg: Record<string, any> = {},
 	connectedSockets: unknown[] = [],
+	prepareDriver?: (driver: ReturnType<typeof lastDriver>) => void,
 ) {
 	const socket = createRecordingSocket(connectedSockets)
 	const zwave = new ZWaveClient(
@@ -193,6 +195,7 @@ async function driveConnectToReady(
 	const ready = waitForDriverReadyEvent(zwave)
 
 	await zwave.connect()
+	prepareDriver?.(lastDriver())
 
 	// The server exists (created after await driver.start()), but the
 	// driver-ready event is still queued, so nothing has started yet
@@ -275,6 +278,35 @@ describe('connecting and reaching driver ready', () => {
 		expect(hoisted.servers).toHaveLength(1)
 
 		await zwave.close(true)
+	})
+
+	it('keeps a newer manual config result when the scheduled check finishes later', async () => {
+		const scheduledCheck = createDeferred<string | undefined>()
+		const manualCheck = createDeferred<string | undefined>()
+		const { zwave, driver } = await driveConnectToReady(
+			{},
+			[],
+			(driver) => {
+				driver.checkForConfigUpdates
+					.mockReturnValueOnce(scheduledCheck.promise)
+					.mockReturnValueOnce(manualCheck.promise)
+			},
+		)
+
+		try {
+			expect(driver.checkForConfigUpdates).toHaveBeenCalledTimes(1)
+
+			const manualRun = zwave.checkForConfigUpdates()
+			manualCheck.resolve('newer')
+			await expect(manualRun).resolves.toBe('newer')
+
+			scheduledCheck.resolve('older')
+			await tick()
+
+			expect(zwave.getInfo().newConfigVersion).toBe('newer')
+		} finally {
+			await zwave.close(true)
+		}
 	})
 
 	it('closing shuts down the server before the driver even when server shutdown is deferred', async () => {

--- a/test/lib/hass/server.test.ts
+++ b/test/lib/hass/server.test.ts
@@ -124,6 +124,7 @@ vi.mock('zwave-js', async () => {
 			return Promise.resolve()
 		})
 		checkForConfigUpdates = vi.fn(() => Promise.resolve(undefined))
+		installConfigUpdate = vi.fn(() => Promise.resolve(false))
 		// The real Driver exposes updateOptions; connect() calls it through
 		// setUserCallbacks() when a user socket is already connected
 		updateOptions = vi.fn()
@@ -304,6 +305,34 @@ describe('connecting and reaching driver ready', () => {
 			await tick()
 
 			expect(zwave.getInfo().newConfigVersion).toBe('newer')
+		} finally {
+			await zwave.close(true)
+		}
+	})
+
+	it('clears an installed config update when a check overlaps installation', async () => {
+		const { zwave, driver } = await driveConnectToReady()
+		const install = createDeferred<boolean>()
+		const overlappingCheck = createDeferred<string | undefined>()
+
+		try {
+			driver.checkForConfigUpdates.mockResolvedValueOnce('available')
+			await zwave.checkForConfigUpdates()
+			expect(zwave.getInfo().newConfigVersion).toBe('available')
+
+			driver.installConfigUpdate.mockReturnValueOnce(install.promise)
+			driver.checkForConfigUpdates.mockReturnValueOnce(
+				overlappingCheck.promise,
+			)
+			const installRun = zwave.installConfigUpdate()
+			const checkRun = zwave.checkForConfigUpdates()
+
+			overlappingCheck.resolve('available')
+			await checkRun
+			install.resolve(true)
+			await expect(installRun).resolves.toBe(true)
+
+			expect(zwave.getInfo().newConfigVersion).toBeUndefined()
 		} finally {
 			await zwave.close(true)
 		}

--- a/test/lib/hass/server.test.ts
+++ b/test/lib/hass/server.test.ts
@@ -302,7 +302,7 @@ describe('connecting and reaching driver ready', () => {
 			await expect(manualRun).resolves.toBe('newer')
 
 			scheduledCheck.resolve('older')
-			await tick()
+			await scheduledCheck.promise
 
 			expect(zwave.getInfo().newConfigVersion).toBe('newer')
 		} finally {

--- a/test/lib/hass/server.test.ts
+++ b/test/lib/hass/server.test.ts
@@ -325,12 +325,15 @@ describe('connecting and reaching driver ready', () => {
 				overlappingCheck.promise,
 			)
 			const installRun = zwave.installConfigUpdate()
+			const duplicateInstallRun = zwave.installConfigUpdate()
 			const checkRun = zwave.checkForConfigUpdates()
+			expect(driver.installConfigUpdate).toHaveBeenCalledTimes(1)
 
 			overlappingCheck.resolve('available')
 			await checkRun
 			install.resolve(true)
 			await expect(installRun).resolves.toBe(true)
+			await expect(duplicateInstallRun).resolves.toBe(true)
 
 			expect(zwave.getInfo().newConfigVersion).toBeUndefined()
 		} finally {

--- a/test/lib/hass/server.test.ts
+++ b/test/lib/hass/server.test.ts
@@ -267,6 +267,7 @@ describe('connecting and reaching driver ready', () => {
 	it('does not start a second server when the driver re-emits ready', async () => {
 		const { zwave, driver, server } = await driveConnectToReady()
 		expect(server.start).toHaveBeenCalledOnce()
+		expect(driver.controller.listenerCount('inclusion started')).toBe(1)
 
 		// A re-emitted 'driver ready' (the #602 hard-reset scenario) must not
 		// start a second server. Wait on the client's re-emitted lifecycle
@@ -277,6 +278,7 @@ describe('connecting and reaching driver ready', () => {
 
 		expect(server.start).toHaveBeenCalledOnce()
 		expect(hoisted.servers).toHaveLength(1)
+		expect(driver.controller.listenerCount('inclusion started')).toBe(1)
 
 		await zwave.close(true)
 	})

--- a/test/lib/zwave/DriverLifecycle.test.ts
+++ b/test/lib/zwave/DriverLifecycle.test.ts
@@ -1198,6 +1198,27 @@ describe('DriverLifecycle — cleanup after a failed connect', () => {
 		expect(driver.destroy).toHaveBeenCalledTimes(1)
 	})
 
+	it('an in-flight connect settles after close already attempted terminal teardown', async () => {
+		const { lifecycle, world } = createHarness({
+			serverEnabled: false,
+		})
+		world.startBehavior = 'deferred'
+
+		const connect = lifecycle.connect()
+		await vi.waitFor(() => expect(world.startDeferreds).toHaveLength(1))
+		const driver = world.drivers[0]
+		const destroyError = new Error('destroy failed')
+		driver.destroy
+			.mockRejectedValueOnce(destroyError)
+			.mockImplementationOnce(() => new Promise<void>(() => {}))
+
+		await expect(lifecycle.close(true)).rejects.toBe(destroyError)
+		world.startDeferreds[0].resolve()
+
+		await expect(connect).resolves.toBeUndefined()
+		expect(driver.destroy).toHaveBeenCalledTimes(1)
+	})
+
 	it('a stale post-start exit tears down its own driver and never the live replacement', async () => {
 		const { lifecycle, world, state } = createHarness({
 			serverEnabled: false,

--- a/test/lib/zwave/DriverLifecycle.test.ts
+++ b/test/lib/zwave/DriverLifecycle.test.ts
@@ -117,7 +117,6 @@ class FakeDriver extends EventEmitter {
 				return Promise.resolve()
 			}
 
-			// Keep the failed instance as owner so a later close/retry destroys it again
 			const rejectThis =
 				world.destroyRejects ||
 				world.destroyBehavior === 'reject' ||
@@ -684,7 +683,7 @@ describe('DriverLifecycle — connect early returns', () => {
 
 describe('DriverLifecycle — connect happy path', () => {
 	it('creates a driver, starts it and sets CONNECTED', async () => {
-		const { lifecycle, world, state } = createHarness({
+		const { lifecycle, host, world, state } = createHarness({
 			serverEnabled: false,
 		})
 		await lifecycle.connect()
@@ -1130,7 +1129,7 @@ describe('DriverLifecycle — cleanup after a failed connect', () => {
 		}
 	})
 
-	it('a rejected destroy is retried by a later close without leaking or destroying the wrong driver', async () => {
+	it('a rejected destroy releases terminal ownership so a later connect can retry', async () => {
 		vi.useFakeTimers()
 		try {
 			const { lifecycle, world, state, host } = createHarness({
@@ -1144,17 +1143,16 @@ describe('DriverLifecycle — cleanup after a failed connect', () => {
 			const driver0 = world.drivers[0]
 
 			expect(world.drivers).toHaveLength(1)
-			expect(state.driver).toBe(driver0)
+			expect(state.driver).toBeNull()
 			expect(world.destroyInvocations).toBe(1)
 			expect(world.destroyOrder).toEqual([])
 			expect(host.onDriverError).toHaveBeenCalledTimes(1)
 
-			await lifecycle.close(true)
-			expect(world.destroyInvocations).toBe(2)
-			expect(world.destroyOrder).toEqual(['driver'])
-			expect(state.driver).toBeNull()
-			expect(world.drivers).toHaveLength(1)
-			expect(driver0.destroy).toHaveBeenCalledTimes(2)
+			world.startBehavior = 'resolve'
+			await lifecycle.connect()
+			expect(world.drivers).toHaveLength(2)
+			expect(state.driver).toBe(world.drivers[1])
+			expect(driver0.destroy).toHaveBeenCalledTimes(1)
 		} finally {
 			vi.useRealTimers()
 		}
@@ -1175,12 +1173,29 @@ describe('DriverLifecycle — cleanup after a failed connect', () => {
 		await expect(connect).resolves.toBeUndefined()
 
 		expect(host.onDriverError).toHaveBeenCalledWith(startupError, true)
-		expect(state.driver).toBe(driver)
+		expect(state.driver).toBeNull()
 		expect(driver.destroy).toHaveBeenCalledTimes(1)
 
 		await expect(lifecycle.close(true)).resolves.toBeUndefined()
-		expect(driver.destroy).toHaveBeenCalledTimes(2)
+		expect(driver.destroy).toHaveBeenCalledTimes(1)
 		expect(state.driver).toBeNull()
+	})
+
+	it('a close destroy rejection releases the terminal driver without retrying its pending teardown', async () => {
+		const { lifecycle, host, world, state } = createHarness({
+			serverEnabled: false,
+		})
+		await lifecycle.connect()
+		const driver = world.drivers[0]
+		const destroyError = new Error('destroy failed')
+		driver.destroy.mockRejectedValueOnce(destroyError)
+
+		await expect(lifecycle.close()).rejects.toBe(destroyError)
+		expect(state.driver).toBeNull()
+		expect(host.clearRuntimeOnClose).toHaveBeenCalledTimes(1)
+		expect(host.finalizeClose).toHaveBeenCalledTimes(1)
+		await expect(lifecycle.close(true)).resolves.toBeUndefined()
+		expect(driver.destroy).toHaveBeenCalledTimes(1)
 	})
 
 	it('a stale post-start exit tears down its own driver and never the live replacement', async () => {
@@ -1271,7 +1286,7 @@ describe('DriverLifecycle — logConfig override', () => {
 })
 
 describe('DriverLifecycle — persisted logConfig immutability', () => {
-	it('leaves the persisted logConfig unmutated and passes the driver a distinct clone', async () => {
+	it('leaves persisted log settings unchanged while enriching driver options', async () => {
 		const { lifecycle, world, state } = createHarness({
 			serverEnabled: false,
 			options: zwaveOpts({ logConfig: { level: 'warn', maxFiles: 5 } }),
@@ -1284,12 +1299,10 @@ describe('DriverLifecycle — persisted logConfig immutability', () => {
 		await lifecycle.connect()
 
 		const driverLogConfig = world.drivers[0].options.logConfig
-		expect(driverLogConfig).not.toBe(source)
 		expect(driverLogConfig?.transports).toContain(world.logTransports[0])
 		expect(driverLogConfig?.transports).toContain(extra)
 		expect(driverLogConfig?.level).toBe('debug')
 
-		expect(state.cfg.options?.logConfig).toBe(source)
 		expect(source).toEqual(sourceSnapshot)
 		expect(source?.transports).toBeUndefined()
 		expect(source?.level).toBe('warn')
@@ -1308,7 +1321,6 @@ describe('DriverLifecycle — persisted logConfig immutability', () => {
 		await lifecycle.connect()
 		expect(world.drivers[0].options.logConfig?.level).toBe('debug')
 		expect(source).toEqual(sourceSnapshot)
-		expect(state.cfg.options?.logConfig).toBe(source)
 
 		lifecycle.removeExtraLogTransport(extra)
 		await lifecycle.close()
@@ -1319,7 +1331,6 @@ describe('DriverLifecycle — persisted logConfig immutability', () => {
 		expect(restarted?.level).toBe('info')
 		expect(restarted?.transports).toEqual([world.logTransports[1]])
 
-		expect(state.cfg.options?.logConfig).toBe(source)
 		expect(source).toEqual(sourceSnapshot)
 		expect(source?.level).toBe('info')
 	})
@@ -1420,13 +1431,63 @@ describe('DriverLifecycle — driver-ready failures', () => {
 		await lifecycle.connect()
 
 		world.drivers[0].emit('driver ready')
-		await Promise.resolve()
+		world.drivers[0].emit('all nodes ready')
+		await vi.waitFor(() => {
+			expect(state.driverReady).toBe(false)
+		})
 
-		expect(state.driverReady).toBe(false)
+		expect(host.onScanComplete).not.toHaveBeenCalled()
 		expect(host.onDriverError).toHaveBeenCalledWith(readyError, true)
 		expect(host.restart).not.toHaveBeenCalled()
 		await vi.advanceTimersByTimeAsync(1000)
 		expect(host.restart).toHaveBeenCalledTimes(1)
+	})
+
+	it('defers scan completion until matching ready initialization succeeds', async () => {
+		const { lifecycle, host, world } = createHarness({
+			serverEnabled: false,
+		})
+		const ready = createDeferred<void>()
+		host.onDriverReady.mockReturnValueOnce(ready.promise)
+		await lifecycle.connect()
+
+		world.drivers[0].emit('driver ready')
+		world.drivers[0].emit('all nodes ready')
+		expect(host.onScanComplete).not.toHaveBeenCalled()
+
+		ready.resolve()
+		await Promise.resolve()
+		await Promise.resolve()
+
+		expect(host.onScanComplete).toHaveBeenCalledTimes(1)
+	})
+
+	it('does not carry pending scan completion into a newer ready event', async () => {
+		const { lifecycle, host, world } = createHarness({
+			serverEnabled: false,
+		})
+		const firstReady = createDeferred<void>()
+		const secondReady = createDeferred<void>()
+		host.onDriverReady
+			.mockReturnValueOnce(firstReady.promise)
+			.mockReturnValueOnce(secondReady.promise)
+		await lifecycle.connect()
+
+		world.drivers[0].emit('driver ready')
+		world.drivers[0].emit('all nodes ready')
+		world.drivers[0].emit('driver ready')
+		firstReady.resolve()
+		await Promise.resolve()
+		await Promise.resolve()
+		expect(host.onScanComplete).not.toHaveBeenCalled()
+
+		secondReady.resolve()
+		await Promise.resolve()
+		await Promise.resolve()
+		expect(host.onScanComplete).not.toHaveBeenCalled()
+
+		world.drivers[0].emit('all nodes ready')
+		expect(host.onScanComplete).toHaveBeenCalledTimes(1)
 	})
 
 	it('keeps newer ready state when an older same-generation initialization rejects', async () => {
@@ -1496,6 +1557,29 @@ describe('DriverLifecycle — driver-ready failures', () => {
 })
 
 describe('DriverLifecycle — driver options', () => {
+	it('isolates persisted storage settings from driver-only changes', async () => {
+		const { lifecycle, state, world } = createHarness({
+			serverEnabled: false,
+			options: zwaveOpts({
+				storage: {
+					cacheDir: '/persisted/cache',
+					throttle: 'normal',
+				},
+			}),
+		})
+		await lifecycle.connect()
+
+		const driverStorage = world.drivers[0].options.storage
+		expect(driverStorage).toBeDefined()
+		driverStorage.cacheDir = '/external/cache'
+		driverStorage.throttle = 'fast'
+
+		expect(state.cfg.options?.storage).toEqual({
+			cacheDir: '/persisted/cache',
+			throttle: 'normal',
+		})
+	})
+
 	it('builds scale preferences from cfg.scales', async () => {
 		const { lifecycle, world } = createHarness({
 			serverEnabled: false,

--- a/test/lib/zwave/DriverLifecycle.test.ts
+++ b/test/lib/zwave/DriverLifecycle.test.ts
@@ -3,27 +3,18 @@
  * Direct state-machine tests for the extracted {@link DriverLifecycle}
  * service (`api/lib/zwave/DriverLifecycle.ts`).
  *
- * The service owns the low-level lifecycle of a single `zwave-js` `Driver`
- * on behalf of `ZwaveClient`: driver creation/options, log-transport
- * injection, the `@zwave-js/server` coordination, retry/backoff timers,
- * statistics, idempotent teardown, and a monotonic **generation** counter
- * that fences late `driver ready`/`error`/OTW callbacks from an obsolete
- * driver so they can never mutate a replacement generation's state.
- *
- * Everything the service needs from `ZwaveClient` is reached through the
- * narrow {@link DriverLifecycleHost} port, so these tests drive the service
- * with a fully-faked host whose accessors read/write a small mutable state
- * object — exactly mirroring how the real client is wired. `zwave-js`'s
- * `Driver` is replaced with a faithful `EventEmitter` fake so the real
+ * The service reaches everything it needs from `ZwaveClient` through the
+ * narrow {@link DriverLifecycleHost} port, so these tests drive it with a
+ * fully-faked host whose accessors read/write a small mutable state object.
+ * `zwave-js`'s `Driver` is replaced with an `EventEmitter` fake so the real
  * `connect()` body runs verbatim (real option building, real event wiring),
  * and `@zwave-js/server` + `utils.ensureDir` are stubbed so no real server
  * binds a port and no directory is written to disk.
  *
- * The complementary end-to-end flow (real `connect()` → driver-ready →
- * `_onDriverReady()` → server start → `close()` through the `ZwaveClient`
- * facade) is characterized in `test/lib/hass/server.test.ts`; the generation
- * fencing of a late `_onDriverReady()` is additionally exercised through the
- * facade there and in the socket production-integration suite.
+ * The complementary end-to-end flow through the `ZwaveClient` facade (real
+ * `connect()` → driver-ready → `_onDriverReady()` → server start → `close()`),
+ * including generation fencing of a late `_onDriverReady()`, is characterized
+ * in `test/lib/hass/server.test.ts` and the socket production-integration suite.
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { ZWaveError, ZWaveErrorCodes } from '@zwave-js/core'
@@ -35,83 +26,36 @@ import type {
 } from '../../../api/lib/zwave/ports.ts'
 import { ZwaveClientStatus } from '../../../api/lib/zwave/ports.ts'
 
-// ---------------------------------------------------------------------------
-// Module mocks
-// ---------------------------------------------------------------------------
-
-// Plain, class-free holders the (lazy) `vi.mock` factories push into. Reset in
-// `beforeEach`. `vi.hoisted` guarantees they exist before any factory runs.
+// vi.hoisted holders the mock factories push into, reset in beforeEach
 const hoisted = vi.hoisted(() => ({
 	drivers: [] as any[],
 	destroyOrder: [] as string[],
-	/** 'resolve' | 'reject' | 'hang' | 'deferred' — how the fake `driver.start()` behaves. */
 	startBehavior: 'resolve' as 'resolve' | 'reject' | 'hang' | 'deferred',
-	/** Error thrown by `driver.start()` when `startBehavior === 'reject'`. */
 	startError: new Error('start failed'),
-	/**
-	 * When `startBehavior === 'deferred'`, each `driver.start()` call pushes a
-	 * controllable `{ resolve, reject }` here (in call order) and returns a
-	 * promise that only settles when the test drives it. Lets a test interleave
-	 * two overlapping `connect()` calls deterministically (old start settling
-	 * after a replacement has taken over) with no timers.
-	 */
+	/** In 'deferred' mode each start() pushes a controllable settler here so a test can interleave two overlapping connect() calls with no timers */
 	startDeferreds: [] as Array<{
 		resolve: () => void
 		reject: (err: unknown) => void
 	}>,
-	/** Synchronous hook invoked at the very start of `driver.start()`. */
 	startHook: null as null | (() => void),
-	/** Synchronous hook invoked inside the stubbed `utils.ensureDir`. */
 	ensureDirHook: null as null | (() => void),
-	/** When true, the fake `driver.destroy()` rejects. */
 	destroyRejects: false,
-	/**
-	 * How the fake `driver.destroy()` settles:
-	 *  - 'resolve'  (default): tears down cleanly.
-	 *  - 'reject'   : always rejects WITHOUT recording a teardown effect — the
-	 *                 instance stays intact and retryable (models a destroy that
-	 *                 fails while the driver may still hold the serial port).
-	 *  - 'deferred' : returns a promise the test settles via `destroyDeferreds`,
-	 *                 so a test can hold a teardown open and prove no replacement
-	 *                 Driver is constructed while the old owner is being torn
-	 *                 down (teardown ownership).
-	 */
+	/** 'reject' keeps the instance intact/retryable (models a destroy that fails while the driver may still hold the port); 'deferred' lets a test hold teardown open to prove no replacement is built mid-teardown */
 	destroyBehavior: 'resolve' as 'resolve' | 'reject' | 'deferred',
-	/**
-	 * When `destroyBehavior === 'deferred'`, each `driver.destroy()` call pushes
-	 * a controllable `{ resolve, reject }` here (in call order). `resolve()`
-	 * records the teardown effect once (like a clean idempotent destroy);
-	 * `reject()` leaves the instance intact/retryable.
-	 */
+	/** In 'deferred' mode each destroy() pushes a settler here; resolve() records the teardown effect once, reject() leaves the instance intact/retryable */
 	destroyDeferreds: [] as Array<{
 		resolve: () => void
 		reject: (err?: Error) => void
 	}>,
-	/**
-	 * Number of LEADING `driver.destroy()` calls that reject (without recording
-	 * a teardown effect) before one succeeds. Lets a test prove a rejected
-	 * destroy retains the exact owner and that a later retry actually tears it
-	 * down. Decremented on each rejecting call.
-	 */
+	/** Leading destroy() calls that reject before one succeeds, so a test can prove a rejected destroy keeps the owner and a later retry tears it down */
 	destroyRejectCount: 0,
-	/** Total `driver.destroy()` invocations across all fake drivers. */
 	destroyInvocations: 0,
-	/** Every fake JSON log transport constructed (to drive its `data` stream). */
 	logTransports: [] as any[],
-	/**
-	 * When set, overrides `utils.buildLogConfig(...)` for the next `connect()`
-	 * so a test can exercise the driver-log-config enrichment branches that the
-	 * real (always-populated) config never reaches: a driver built with NO
-	 * `logConfig` at all, or one whose `level` is not a string. Returns whatever
-	 * value the function yields (may be `undefined`). Reset in `beforeEach`.
-	 */
+	/** Overrides buildLogConfig() for the next connect() to reach enrichment branches the always-populated real config never hits (no logConfig, or a non-string level) */
 	buildLogConfigOverride: null as null | (() => any),
 }))
 
-// Faithful `zwave-js` Driver fake. Only `Driver` is replaced; every other
-// named export is preserved via `importActual`. Extends EventEmitter so the
-// production code can wire the real event handlers; `start()` honours the
-// controllable behavior; `destroy()` records teardown order.
+// zwave-js Driver fake: extends EventEmitter so production wires real handlers; start()/destroy() honour the controllable hoisted behavior
 vi.mock('zwave-js', async () => {
 	const actual = await vi.importActual<any>('zwave-js')
 	const { EventEmitter } = await import('node:events')
@@ -147,11 +91,7 @@ vi.mock('zwave-js', async () => {
 		destroy = vi.fn((): Promise<void> => {
 			hoisted.destroyInvocations++
 
-			// Record the teardown EFFECT at most once per instance, mirroring
-			// the real zwave-js `Driver.destroy()` idempotency (`_destroyPromise`):
-			// destroying an already-destroyed driver resolves without re-running
-			// teardown, so a stale-connect teardown racing a `close()` records
-			// the effect exactly once.
+			// Record the teardown effect at most once per instance, mirroring real zwave-js Driver.destroy() idempotency so a stale-connect teardown racing close() records it exactly once
 			const recordEffect = () => {
 				if (!this._destroyed) {
 					this._destroyed = true
@@ -172,15 +112,12 @@ vi.mock('zwave-js', async () => {
 				})
 			}
 
-			// Already torn down → idempotent clean resolve.
+			// Already torn down: idempotent clean resolve
 			if (this._destroyed) {
 				return Promise.resolve()
 			}
 
-			// A rejecting destroy (legacy `destroyRejects`, an explicit
-			// 'reject' behavior, or a leading run of `destroyRejectCount`
-			// failures) does NOT mark the instance destroyed or record an
-			// effect: the exact owner must stay intact and RETRYABLE.
+			// A rejecting destroy must not mark the instance destroyed or record an effect, so the exact owner stays intact and retryable
 			const rejectThis =
 				hoisted.destroyRejects ||
 				hoisted.destroyBehavior === 'reject' ||
@@ -210,8 +147,7 @@ vi.mock('zwave-js', async () => {
 	return { ...actual, Driver: FakeDriver }
 })
 
-// Minimal `@zwave-js/server` stub so the lazily-built fallback
-// `ZwaveServerManager` never constructs a real HTTP server / binds a port.
+// @zwave-js/server stub so the lazy fallback ZwaveServerManager never binds a real port
 vi.mock('@zwave-js/server', async () => {
 	const { EventEmitter } = await import('node:events')
 	class ZwavejsServerMock extends EventEmitter {
@@ -231,9 +167,7 @@ vi.mock('@zwave-js/server', async () => {
 	return { serverVersion: '0.0.0-test', ZwavejsServer: ZwavejsServerMock }
 })
 
-// Fake JSON log transport whose `.stream` is an EventEmitter we can drive, so
-// the production `stream.on('data', ...)` → `host.emitDebug(...)` wiring can be
-// exercised without a real driver logging pipeline.
+// JSON log transport fake whose `.stream` we can drive to exercise the production stream.on('data') → host.emitDebug wiring
 vi.mock('@zwave-js/log-transport-json', async () => {
 	const { EventEmitter } = await import('node:events')
 	class JSONTransportMock {
@@ -246,8 +180,7 @@ vi.mock('@zwave-js/log-transport-json', async () => {
 	return { JSONTransport: JSONTransportMock }
 })
 
-// Stub only `utils.ensureDir` (avoids a real mkdir side effect and gives a
-// hook to fence the generation mid-`await`). Every other util is real.
+// Stub only utils.ensureDir to avoid a real mkdir and to hook the generation mid-await; every other util stays real
 vi.mock('../../../api/lib/utils.ts', async () => {
 	const actual = await vi.importActual<any>('../../../api/lib/utils.ts')
 	return {
@@ -264,14 +197,10 @@ vi.mock('../../../api/lib/utils.ts', async () => {
 	}
 })
 
-// Import AFTER the mocks are registered.
+// Import after the mocks are registered
 const { DriverLifecycle } = await import(
 	'../../../api/lib/zwave/DriverLifecycle.ts'
 )
-
-// ---------------------------------------------------------------------------
-// Fake host
-// ---------------------------------------------------------------------------
 
 interface HarnessState {
 	cfg: ZwaveConfig
@@ -363,7 +292,7 @@ function createHarness(cfgOverrides: Partial<ZwaveConfig> = {}) {
 	return { lifecycle, host, state, serverHost }
 }
 
-/** A fake adopted server manager that records its destroy into the order log. */
+/** Fake adopted server manager that records its destroy into the order log */
 function fakeManager() {
 	return {
 		create: vi.fn(),
@@ -376,15 +305,9 @@ function fakeManager() {
 	}
 }
 
-/** Flush pending microtasks. */
 const flush = () => Promise.resolve()
 
-/**
- * Pump the microtask queue until `pred()` holds (or a bounded number of turns
- * elapses). Deterministic: every intermediate `await` inside `connect()`
- * resolves synchronously (mocked `ensureDir`/`hasConnectedClients`), so this
- * only advances already-settled microtasks — no timers, no wall-clock.
- */
+/** Pump the microtask queue until pred() holds; deterministic since every awaited step resolves synchronously (no timers) */
 async function until(pred: () => boolean, max = 100): Promise<void> {
 	for (let i = 0; i < max; i++) {
 		if (pred()) return
@@ -413,10 +336,6 @@ beforeEach(() => {
 	delete process.env.ZWAVE_PORT
 })
 
-// ===========================================================================
-// Server coordination
-// ===========================================================================
-
 describe('DriverLifecycle — @zwave-js/server coordination', () => {
 	it('adoptServerManager stores the manager and serverManager returns it', () => {
 		const { lifecycle } = createHarness()
@@ -431,7 +350,6 @@ describe('DriverLifecycle — @zwave-js/server coordination', () => {
 		const { lifecycle, host } = createHarness()
 		const first = lifecycle.zwaveServer
 		expect(first).toBeDefined()
-		// cached — same instance, host.buildServerHost only used once
 		expect(lifecycle.zwaveServer).toBe(first)
 		expect(host.buildServerHost).toHaveBeenCalledTimes(1)
 	})
@@ -451,10 +369,6 @@ describe('DriverLifecycle — @zwave-js/server coordination', () => {
 		expect(mgr.create).toHaveBeenCalledTimes(1)
 	})
 })
-
-// ===========================================================================
-// Statistics
-// ===========================================================================
 
 describe('DriverLifecycle — statistics', () => {
 	it('enableStatistics enables on the driver and always warns', () => {
@@ -495,18 +409,8 @@ describe('DriverLifecycle — statistics', () => {
 	})
 })
 
-// ===========================================================================
-// Extra log transports
-// ===========================================================================
-
 describe('DriverLifecycle — extra log transports', () => {
-	// These live add/remove tests connect first so the required JSON-socket
-	// transport actually exists for the active generation — the whole point of
-	// the fix is that `updateLogConfig({transports})` REPLACES the driver's
-	// custom transport list, so every runtime apply must re-send the JSON
-	// transport plus ALL current extras (not just the one being added, and
-	// never an empty array), and recompute the level from the configured
-	// baseline. `state.driverReadyRaw` is flipped on to model a ready driver.
+	// Connect first so the JSON-socket transport exists; updateLogConfig({transports}) replaces the whole list, so every apply re-sends it plus all current extras
 	async function connectedReadyHarness(cfgOverrides: any = {}) {
 		const harness = createHarness({ serverEnabled: false, ...cfgOverrides })
 		await harness.lifecycle.connect()
@@ -521,8 +425,6 @@ describe('DriverLifecycle — extra log transports', () => {
 		const { lifecycle, json, driver } = await connectedReadyHarness()
 		const extra = { id: 't1' }
 		lifecycle.addExtraLogTransport(extra, 'debug')
-		// Required JSON socket transport retained FIRST, extra appended, level
-		// raised from the configured 'info' baseline to the extra's 'debug'.
 		expect(driver.updateLogConfig).toHaveBeenCalledTimes(1)
 		expect(driver.updateLogConfig).toHaveBeenCalledWith({
 			transports: [json, extra],
@@ -534,8 +436,6 @@ describe('DriverLifecycle — extra log transports', () => {
 		const { lifecycle, json, driver } = await connectedReadyHarness()
 		const extra = { id: 't2' }
 		lifecycle.addExtraLogTransport(extra)
-		// No requested level → the recomputed level is the configured baseline
-		// ('info'), and the JSON socket transport is still present.
 		expect(driver.updateLogConfig).toHaveBeenCalledWith({
 			transports: [json, extra],
 			level: 'info',
@@ -550,8 +450,6 @@ describe('DriverLifecycle — extra log transports', () => {
 		lifecycle.addExtraLogTransport(a, 'warn')
 		lifecycle.addExtraLogTransport(b, 'silly')
 		lifecycle.addExtraLogTransport(c, 'verbose')
-		// Last apply carries ALL three extras (plus JSON) and the most verbose
-		// level requested by any of them ('silly').
 		expect(driver.updateLogConfig).toHaveBeenLastCalledWith({
 			transports: [json, a, b, c],
 			level: 'silly',
@@ -566,8 +464,6 @@ describe('DriverLifecycle — extra log transports', () => {
 		lifecycle.addExtraLogTransport(temp, 'debug')
 		driver.updateLogConfig.mockClear()
 
-		// Removing the verbose extra must keep the other extra AND the JSON
-		// transport, and drop the level back to the configured baseline.
 		lifecycle.removeExtraLogTransport(temp)
 		expect(driver.updateLogConfig).toHaveBeenCalledTimes(1)
 		expect(driver.updateLogConfig).toHaveBeenCalledWith({
@@ -582,8 +478,6 @@ describe('DriverLifecycle — extra log transports', () => {
 		lifecycle.addExtraLogTransport(temp, 'debug')
 		driver.updateLogConfig.mockClear()
 		lifecycle.removeExtraLogTransport(temp)
-		// The whole point of the fix: the JSON socket transport survives even
-		// when the last extra is removed.
 		expect(driver.updateLogConfig).toHaveBeenCalledWith({
 			transports: [json],
 			level: 'info',
@@ -597,14 +491,12 @@ describe('DriverLifecycle — extra log transports', () => {
 		lifecycle.addExtraLogTransport(warnT, 'warn')
 		lifecycle.addExtraLogTransport(debugT, 'debug')
 
-		// Remove the less verbose one first: 'debug' extra still forces 'debug'.
 		lifecycle.removeExtraLogTransport(warnT)
 		expect(driver.updateLogConfig).toHaveBeenLastCalledWith({
 			transports: [json, debugT],
 			level: 'debug',
 		})
 
-		// Now remove the verbose one: back to the baseline with only JSON.
 		lifecycle.removeExtraLogTransport(debugT)
 		expect(driver.updateLogConfig).toHaveBeenLastCalledWith({
 			transports: [json],
@@ -619,7 +511,6 @@ describe('DriverLifecycle — extra log transports', () => {
 		})
 		const extra = { id: 'quiet' }
 		lifecycle.addExtraLogTransport(extra, 'warn')
-		// Baseline 'verbose' is more verbose than the extra's 'warn' → retained.
 		expect(driver.updateLogConfig).toHaveBeenCalledWith({
 			transports: [json, extra],
 			level: 'verbose',
@@ -635,8 +526,6 @@ describe('DriverLifecycle — extra log transports', () => {
 		lifecycle.addExtraLogTransport({ id: 't3' }, 'debug')
 		expect(driver.updateLogConfig).not.toHaveBeenCalled()
 
-		// Registration persisted: it is applied the moment a subsequent
-		// (ready) apply runs — proven by a following remove of an unknown id.
 		state.driverReadyRaw = true
 		lifecycle.removeExtraLogTransport({ id: 'unknown' })
 		expect(driver.updateLogConfig).toHaveBeenCalledWith({
@@ -650,7 +539,6 @@ describe('DriverLifecycle — extra log transports', () => {
 
 	it('before connect there is no driver and add/remove are inert no-ops', () => {
 		const { lifecycle } = createHarness({ serverEnabled: false })
-		// No driver at all (never connected) → nothing to apply, no throw.
 		expect(() =>
 			lifecycle.addExtraLogTransport({ id: 'pre' }, 'debug'),
 		).not.toThrow()
@@ -660,10 +548,6 @@ describe('DriverLifecycle — extra log transports', () => {
 	})
 })
 
-// ===========================================================================
-// Backoff / destroyed helpers
-// ===========================================================================
-
 describe('DriverLifecycle — backoff restart & checkIfDestroyed', () => {
 	beforeEach(() => vi.useFakeTimers())
 	afterEach(() => vi.useRealTimers())
@@ -671,13 +555,11 @@ describe('DriverLifecycle — backoff restart & checkIfDestroyed', () => {
 	it('backoffRestart schedules restart with exponential delay and increments the retry', async () => {
 		const { lifecycle, host } = createHarness()
 		lifecycle.backoffRestart()
-		// first retry: 2^0 * 1000 = 1000ms
 		expect(host.restart).not.toHaveBeenCalled()
 		await vi.advanceTimersByTimeAsync(1000)
 		expect(host.restart).toHaveBeenCalledTimes(1)
 
 		lifecycle.backoffRestart()
-		// second retry: 2^1 * 1000 = 2000ms
 		await vi.advanceTimersByTimeAsync(1999)
 		expect(host.restart).toHaveBeenCalledTimes(1)
 		await vi.advanceTimersByTimeAsync(1)
@@ -686,15 +568,14 @@ describe('DriverLifecycle — backoff restart & checkIfDestroyed', () => {
 
 	it('resetBackoff resets the exponential counter back to the first delay', async () => {
 		const { lifecycle, host } = createHarness()
-		lifecycle.backoffRestart() // retry -> 1
+		lifecycle.backoffRestart()
 		await vi.advanceTimersByTimeAsync(1000)
-		lifecycle.backoffRestart() // retry -> 2 (2000ms)
+		lifecycle.backoffRestart()
 		await vi.advanceTimersByTimeAsync(2000)
 		expect(host.restart).toHaveBeenCalledTimes(2)
 
 		lifecycle.resetBackoff()
 		lifecycle.backoffRestart()
-		// back to 2^0 * 1000 = 1000ms
 		await vi.advanceTimersByTimeAsync(1000)
 		expect(host.restart).toHaveBeenCalledTimes(3)
 	})
@@ -705,7 +586,6 @@ describe('DriverLifecycle — backoff restart & checkIfDestroyed', () => {
 		lifecycle.backoffRestart()
 		await vi.advanceTimersByTimeAsync(20000)
 		expect(host.restart).not.toHaveBeenCalled()
-		// checkIfDestroyed() triggers an idempotent close(true)
 		expect(host.setStatus).toBeDefined()
 		expect(state.status).toBe(ZwaveClientStatus.CLOSED)
 	})
@@ -724,10 +604,6 @@ describe('DriverLifecycle — backoff restart & checkIfDestroyed', () => {
 	})
 })
 
-// ===========================================================================
-// backoff restart — coalescing & generation fencing (finding 3)
-// ===========================================================================
-
 describe('DriverLifecycle — backoff restart coalescing & fencing', () => {
 	beforeEach(() => vi.useFakeTimers())
 	afterEach(() => vi.useRealTimers())
@@ -735,22 +611,15 @@ describe('DriverLifecycle — backoff restart coalescing & fencing', () => {
 	it('coalesces two backoff schedules made before firing into a single restart (latest delay wins)', async () => {
 		const { lifecycle, host } = createHarness()
 
-		// Two backoff requests arrive before either timer fires. Previously the
-		// second overwrote `_restartTimeout` and LEAKED the first handle, so BOTH
-		// fired → a double restart. They must now coalesce into ONE pending
-		// restart using the most-recent delay (2^1 * 1000 = 2000ms).
-		lifecycle.backoffRestart() // 1st: 1000ms
-		lifecycle.backoffRestart() // 2nd: 2000ms (clears the 1000ms handle)
+		lifecycle.backoffRestart()
+		lifecycle.backoffRestart()
 
-		// The leaked first handle must NOT fire at its original 1000ms.
 		await vi.advanceTimersByTimeAsync(1000)
 		expect(host.restart).not.toHaveBeenCalled()
 
-		// Only the single coalesced restart fires at the latest 2000ms delay.
 		await vi.advanceTimersByTimeAsync(1000)
 		expect(host.restart).toHaveBeenCalledTimes(1)
 
-		// And nothing else is left pending afterwards.
 		await vi.advanceTimersByTimeAsync(60000)
 		expect(host.restart).toHaveBeenCalledTimes(1)
 	})
@@ -758,33 +627,26 @@ describe('DriverLifecycle — backoff restart coalescing & fencing', () => {
 	it('a healthy replacement (new generation) fences a still-pending backoff restart', async () => {
 		const { lifecycle, host } = createHarness({ serverEnabled: false })
 
-		// A backoff restart is scheduled...
-		lifecycle.backoffRestart() // 1000ms, captures generation 0
+		lifecycle.backoffRestart()
 
-		// ...then a healthy driver connects, bumping the generation. This does
-		// NOT clear the pending timer, so only the generation fence can stop the
-		// stale restart from firing.
+		// Connecting bumps the generation but does not clear the pending timer, so only the generation fence stops the stale restart
 		await lifecycle.connect()
 		expect(lifecycle.generation).toBe(1)
 
 		await vi.advanceTimersByTimeAsync(60000)
-		expect(host.restart).not.toHaveBeenCalled() // fenced: no stale restart
+		expect(host.restart).not.toHaveBeenCalled()
 	})
 
 	it('close() clears a pending backoff restart so it never fires', async () => {
 		const { lifecycle, host } = createHarness({ serverEnabled: false })
 
-		lifecycle.backoffRestart() // schedule
-		await lifecycle.close() // clears the handle AND bumps the generation
+		lifecycle.backoffRestart()
+		await lifecycle.close()
 
 		await vi.advanceTimersByTimeAsync(60000)
 		expect(host.restart).not.toHaveBeenCalled()
 	})
 })
-
-// ===========================================================================
-// connect() — early-return guards
-// ===========================================================================
 
 describe('DriverLifecycle — connect early returns', () => {
 	it('does nothing when the driver is disabled', async () => {
@@ -826,10 +688,6 @@ describe('DriverLifecycle — connect early returns', () => {
 	})
 })
 
-// ===========================================================================
-// connect() — happy path & option building
-// ===========================================================================
-
 describe('DriverLifecycle — connect happy path', () => {
 	it('creates a driver, wires all six events, starts it and sets CONNECTED', async () => {
 		const { lifecycle, state } = createHarness({ serverEnabled: false })
@@ -841,7 +699,6 @@ describe('DriverLifecycle — connect happy path', () => {
 		expect(driver.start).toHaveBeenCalledTimes(1)
 		expect(state.driver).toBe(driver)
 		expect(state.status).toBe(ZwaveClientStatus.CONNECTED)
-		// six driver events wired
 		for (const evt of [
 			'error',
 			'driver ready',
@@ -921,7 +778,6 @@ describe('DriverLifecycle — connect happy path', () => {
 		expect(rf.region).toBe(1)
 		expect(rf.maxLongRangePowerlevel).toBe('auto')
 		expect(rf.txPower.powerlevel).toBe('auto')
-		// inferred default is persisted
 		expect(host.persistConfig).toHaveBeenCalled()
 	})
 
@@ -965,10 +821,6 @@ describe('DriverLifecycle — connect happy path', () => {
 	})
 })
 
-// ===========================================================================
-// connect() — error handling
-// ===========================================================================
-
 describe('DriverLifecycle — connect error handling', () => {
 	it('on a generic start failure: destroys the driver, reports the error and backs off', async () => {
 		vi.useFakeTimers()
@@ -982,7 +834,6 @@ describe('DriverLifecycle — connect error handling', () => {
 				expect.any(Error),
 				true,
 			)
-			// backoff scheduled
 			await vi.advanceTimersByTimeAsync(1000)
 			expect(host.restart).toHaveBeenCalledTimes(1)
 		} finally {
@@ -1012,19 +863,13 @@ describe('DriverLifecycle — connect error handling', () => {
 	})
 })
 
-// ===========================================================================
-// connect() — generation fencing
-// ===========================================================================
-
 describe('DriverLifecycle — connect generation fencing', () => {
 	it('aborts before driver creation when the generation changes during ensureDir', async () => {
 		const { lifecycle, state } = createHarness()
 		hoisted.ensureDirHook = () => {
-			// simulate a concurrent close() bumping the generation
 			void lifecycle.close()
 		}
 		await lifecycle.connect()
-		// close() ran; no driver was created for the obsolete generation
 		expect(hoisted.drivers).toHaveLength(0)
 		expect(state.status).toBe(ZwaveClientStatus.CLOSED)
 	})
@@ -1036,7 +881,6 @@ describe('DriverLifecycle — connect generation fencing', () => {
 			return Promise.resolve(false)
 		})
 		await lifecycle.connect()
-		// driver was constructed but start() never ran (fenced right after)
 		expect(hoisted.drivers).toHaveLength(1)
 		expect(hoisted.drivers[0].start).not.toHaveBeenCalled()
 	})
@@ -1047,7 +891,6 @@ describe('DriverLifecycle — connect generation fencing', () => {
 			void lifecycle.close()
 		}
 		await lifecycle.connect()
-		// start ran, but CONNECTED was never set on the obsolete generation
 		expect(hoisted.drivers[0].start).toHaveBeenCalled()
 		expect(state.status).toBe(ZwaveClientStatus.CLOSED)
 	})
@@ -1055,38 +898,21 @@ describe('DriverLifecycle — connect generation fencing', () => {
 	it('aborts when the generation changes during persistConfig', async () => {
 		const { lifecycle, host } = createHarness({
 			serverEnabled: false,
-			rf: { region: 1 } as any, // forces shouldUpdateSettings -> persistConfig
+			rf: { region: 1 } as any,
 		})
 		;(host.persistConfig as any).mockImplementation(() => {
 			void lifecycle.close()
 			return Promise.resolve()
 		})
 		await lifecycle.connect()
-		// fenced right after persistConfig — no driver created
 		expect(hoisted.drivers).toHaveLength(0)
 	})
 })
-
-// ===========================================================================
-// connect() — pre-ready reconnect coalescing (re-review finding 1)
-// ===========================================================================
-//
-// A second connect() that lands after driver.start() has resolved (CONNECTED)
-// but before `driver ready` — or while the first connect is still awaiting
-// start() — used to pass the ready-only guard, mint a new generation and
-// construct a REPLACEMENT driver, overwriting the host field and stranding the
-// first, still-live, non-ready driver (unreachable, never torn down, still
-// holding the serial port). connect() now coalesces onto the in-flight connect
-// while a driver is already owned, so no replacement is constructed and nothing
-// leaks. A genuine reconnect (config change / backoff / hard reset) goes through
-// close()/restart(), which nulls the host driver first, so it is never blocked.
 
 describe('DriverLifecycle — pre-ready reconnect coalescing', () => {
 	it('a second connect after start() resolves but before driver ready does NOT construct or leak a replacement', async () => {
 		const { lifecycle, state } = createHarness({ serverEnabled: false })
 
-		// First connect reaches CONNECTED (start resolved) but the driver is NOT
-		// ready yet — driverReady only flips inside onDriverReady().
 		await lifecycle.connect()
 		expect(hoisted.drivers).toHaveLength(1)
 		const driver0 = hoisted.drivers[0]
@@ -1095,11 +921,8 @@ describe('DriverLifecycle — pre-ready reconnect coalescing', () => {
 		expect(state.driverReady).toBe(false)
 		const genAfterFirst = lifecycle.generation
 
-		// Second connect while driver0 is connecting-but-not-ready.
 		await lifecycle.connect()
 
-		// Coalesced: exactly ONE Driver ever constructed, the host still points
-		// at driver0, it is never destroyed, and the generation did not advance.
 		expect(hoisted.drivers).toHaveLength(1)
 		expect(state.driver).toBe(driver0)
 		expect(driver0.destroy).not.toHaveBeenCalled()
@@ -1116,8 +939,6 @@ describe('DriverLifecycle — pre-ready reconnect coalescing', () => {
 		const driver0 = hoisted.drivers[0]
 		const gen = lifecycle.generation
 
-		// Second connect while driver0 is mid-start → coalesced: no new Driver
-		// and no second start() call…
 		let firstSettled = false
 		let secondSettled = false
 		void first.then(() => {
@@ -1128,9 +949,6 @@ describe('DriverLifecycle — pre-ready reconnect coalescing', () => {
 			secondSettled = true
 		})
 
-		// …and, crucially, the second connect does NOT resolve early. It must
-		// remain pending exactly as long as the first does (the old bug returned
-		// success immediately here, before the driver was ever CONNECTED).
 		await until(() => hoisted.startDeferreds.length === 1)
 		expect(hoisted.drivers).toHaveLength(1)
 		expect(hoisted.startDeferreds).toHaveLength(1)
@@ -1140,8 +958,6 @@ describe('DriverLifecycle — pre-ready reconnect coalescing', () => {
 		expect(firstSettled).toBe(false)
 		expect(secondSettled).toBe(false)
 
-		// Settle the first startup; BOTH callers resolve together off the same
-		// startup promise, and still just the one driver was ever built.
 		hoisted.startDeferreds[0].resolve()
 		await Promise.all([first, second])
 		expect(firstSettled).toBe(true)
@@ -1174,27 +990,19 @@ describe('DriverLifecycle — pre-ready reconnect coalescing', () => {
 		expect(firstSettled).toBe(false)
 		expect(secondSettled).toBe(false)
 
-		// The first startup FAILS. The facade contract is that connect() catches
-		// the failure (reports it + schedules a backoff) and RESOLVES rather than
-		// rejecting — so the coalesced caller resolves at the SAME time with the
-		// SAME (non-throwing) settlement. No second driver was ever constructed
-		// and the failure is reported exactly once.
 		hoisted.startDeferreds[0].reject(new Error('start failed'))
 		await expect(Promise.all([first, second])).resolves.toBeDefined()
 		expect(firstSettled).toBe(true)
 		expect(secondSettled).toBe(true)
 		expect(hoisted.drivers).toHaveLength(1)
 		expect(driver0.destroy).toHaveBeenCalledTimes(1)
-		expect(state.driver).toBeNull() // clean teardown cleared the owner
+		expect(state.driver).toBeNull()
 		expect(host.onDriverError).toHaveBeenCalledTimes(1)
 	})
 
 	it('a duplicate connect AFTER the first start settled but BEFORE driver ready returns compatibly without a replacement', async () => {
 		const { lifecycle, state } = createHarness({ serverEnabled: false })
 
-		// First connect reaches CONNECTED (start resolved) but not ready yet, so
-		// `_activeConnect` is already cleared — the duplicate falls through to
-		// the compatible host-driver guard instead of coalescing.
 		await lifecycle.connect()
 		const driver0 = hoisted.drivers[0]
 		const gen = lifecycle.generation
@@ -1211,50 +1019,36 @@ describe('DriverLifecycle — pre-ready reconnect coalescing', () => {
 	it('a recovery reconnect after a start failure is NOT coalesced (host cleared) and builds exactly one fresh driver', async () => {
 		const { lifecycle, state } = createHarness({ serverEnabled: false })
 
-		// First connect fails inside start(): driver0 is constructed, then torn
-		// down, and the host field is cleared (a backoff restart is scheduled).
 		hoisted.startBehavior = 'reject'
 		await lifecycle.connect()
 		expect(hoisted.drivers).toHaveLength(1)
 		expect(hoisted.drivers[0].destroy).toHaveBeenCalledTimes(1)
 		expect(state.driver).toBeNull()
 
-		// The real backoff recovery is close()+init()+connect(): close() clears
-		// the pending restart timer and bumps the generation; init() re-opens the
-		// client. Mirror that, then reconnect.
 		await lifecycle.close(true)
 		state.closed = false
 
 		hoisted.startBehavior = 'resolve'
 		await lifecycle.connect()
 
-		// Not coalesced (host field was null): exactly one fresh driver adopted.
 		expect(hoisted.drivers).toHaveLength(2)
 		expect(state.driver).toBe(hoisted.drivers[1])
 		expect(state.status).toBe(ZwaveClientStatus.CONNECTED)
 	})
 
-	// A replacement can only legitimately appear via close()/restart() (which
-	// destroys the current driver and nulls the host field). These two tests
-	// preserve the prior-round ownership guarantee: a stale in-flight start that
-	// settles AFTER such a reconnect tears down only its own driver and never
-	// clobbers the live replacement.
 	async function openCloseReconnectWithStale() {
 		const harness = createHarness({ serverEnabled: false })
 		hoisted.startBehavior = 'deferred'
 
-		// Stale (soon-to-be-superseded) connect: driver0 on host, held at start.
 		const stalePromise = harness.lifecycle.connect()
 		await until(() => hoisted.startDeferreds.length === 1)
 		const driver0 = hoisted.drivers[0]
 		expect(harness.state.driver).toBe(driver0)
 
-		// close() bumps the generation, destroys driver0 and nulls the host field.
 		await harness.lifecycle.close(true)
 		expect(harness.state.driver).toBeNull()
-		harness.state.closed = false // init() re-opens before the reconnect
+		harness.state.closed = false
 
-		// Reconnect: host field is null → NOT coalesced → builds driver1.
 		hoisted.startBehavior = 'deferred'
 		const freshPromise = harness.lifecycle.connect()
 		await until(() => hoisted.startDeferreds.length === 2)
@@ -1274,9 +1068,6 @@ describe('DriverLifecycle — pre-ready reconnect coalescing', () => {
 		hoisted.startDeferreds[0].resolve()
 		await stalePromise
 
-		// driver0 was destroyed exactly once (by close(); the stale teardown is
-		// idempotent), the replacement was never destroyed, and the host still
-		// points at it.
 		expect(hoisted.destroyOrder.filter((d) => d === 'driver')).toHaveLength(
 			1,
 		)
@@ -1294,25 +1085,13 @@ describe('DriverLifecycle — pre-ready reconnect coalescing', () => {
 		expect(hoisted.destroyOrder.filter((d) => d === 'driver')).toHaveLength(
 			1,
 		)
-		expect(driver1.destroy).not.toHaveBeenCalled() // replacement retained
+		expect(driver1.destroy).not.toHaveBeenCalled()
 		expect(state.driver).toBe(driver1)
-		expect(host.onDriverError).not.toHaveBeenCalled() // stale error swallowed
-		expect(host.restart).not.toHaveBeenCalled() // no stale backoff restart
+		expect(host.onDriverError).not.toHaveBeenCalled()
+		expect(host.restart).not.toHaveBeenCalled()
 		void driver0
 	})
 })
-
-// ===========================================================================
-// connect() — failed-connect teardown ownership (HIGH)
-// ===========================================================================
-//
-// A failed connect must AWAIT the destruction of the exact instance it created
-// BEFORE it clears the host field or lets a backoff/retry build a replacement.
-// The old code fired `destroy()` unawaited and cleared the field immediately, so
-// a slow/rejected destroy could let a replacement driver be constructed while
-// the old owner still held the serial port (controller unreachable). These
-// tests drive `destroy()` deterministically (deferred / reject-once) to prove
-// the ownership contract.
 
 describe('DriverLifecycle — failed-connect teardown ownership', () => {
 	it('awaits the failed driver destroy before clearing the host or backing off (no replacement built while the owner is torn down)', async () => {
@@ -1327,27 +1106,18 @@ describe('DriverLifecycle — failed-connect teardown ownership', () => {
 
 			const connectP = lifecycle.connect()
 
-			// The connect is now suspended inside teardownConnectDriver awaiting
-			// driver0.destroy(). Until that destroy settles:
 			await until(() => hoisted.destroyDeferreds.length === 1)
 			expect(hoisted.drivers).toHaveLength(1)
 			const driver0 = hoisted.drivers[0]
-			// …the host STILL owns the exact failed instance (not cleared)…
 			expect(state.driver).toBe(driver0)
-			// …the error has NOT yet been reported and NO backoff scheduled…
 			expect(host.onDriverError).not.toHaveBeenCalled()
 			expect(host.restart).not.toHaveBeenCalled()
 
-			// …and a concurrent connect coalesces onto the in-flight startup
-			// rather than constructing a replacement Driver while the owner is
-			// still being torn down.
 			const concurrent = lifecycle.connect()
 			await until(() => hoisted.destroyDeferreds.length === 1)
 			expect(hoisted.drivers).toHaveLength(1)
 			expect(driver0.start).toHaveBeenCalledTimes(1)
 
-			// Complete the destroy: only now is the host field cleared and the
-			// error reported + backoff scheduled (serialized behind teardown).
 			hoisted.destroyDeferreds[0].resolve()
 			await connectP
 			await concurrent
@@ -1360,7 +1130,6 @@ describe('DriverLifecycle — failed-connect teardown ownership', () => {
 			)
 			await vi.advanceTimersByTimeAsync(1000)
 			expect(host.restart).toHaveBeenCalledTimes(1)
-			// Still exactly one Driver ever built across the whole sequence.
 			expect(hoisted.drivers).toHaveLength(1)
 		} finally {
 			vi.useRealTimers()
@@ -1375,24 +1144,17 @@ describe('DriverLifecycle — failed-connect teardown ownership', () => {
 			})
 			hoisted.startBehavior = 'reject'
 			hoisted.startError = new Error('start boom')
-			// First destroy rejects (owner intact/retryable); a later one succeeds.
 			hoisted.destroyRejectCount = 1
 
 			await lifecycle.connect()
 			const driver0 = hoisted.drivers[0]
 
-			// The rejected destroy did NOT drop the owner: the exact failed
-			// instance is still reachable/owned, nothing was recorded as torn
-			// down, and no replacement was built. The failure is still observable.
 			expect(hoisted.drivers).toHaveLength(1)
 			expect(state.driver).toBe(driver0)
 			expect(hoisted.destroyInvocations).toBe(1)
-			expect(hoisted.destroyOrder).toEqual([]) // no teardown effect yet
+			expect(hoisted.destroyOrder).toEqual([])
 			expect(host.onDriverError).toHaveBeenCalledTimes(1)
 
-			// Retry cleanup via close(): it re-invokes destroy() on the SAME
-			// owner, which now succeeds and clears the field. Exactly that
-			// instance is destroyed — no leak, no wrong/replacement destroy.
 			await lifecycle.close(true)
 			expect(hoisted.destroyInvocations).toBe(2)
 			expect(hoisted.destroyOrder).toEqual(['driver'])
@@ -1408,13 +1170,10 @@ describe('DriverLifecycle — failed-connect teardown ownership', () => {
 		const { lifecycle, state } = createHarness({ serverEnabled: false })
 		hoisted.startBehavior = 'deferred'
 
-		// Stale connect: driver0 on host, held at start().
 		const staleP = lifecycle.connect()
 		await until(() => hoisted.startDeferreds.length === 1)
 		const driver0 = hoisted.drivers[0]
 
-		// close() bumps the generation, destroys driver0 (clean) and nulls the
-		// host field; then a reconnect builds driver1.
 		await lifecycle.close(true)
 		state.closed = false
 		hoisted.startBehavior = 'deferred'
@@ -1425,13 +1184,9 @@ describe('DriverLifecycle — failed-connect teardown ownership', () => {
 		await freshP
 		expect(state.driver).toBe(driver1)
 
-		// Now the stale start resolves: its post-start generation check fails,
-		// so it tears down driver0 (idempotent — already destroyed by close).
 		hoisted.startDeferreds[0].resolve()
 		await staleP
 
-		// The replacement was never touched and remains owned; driver0's
-		// teardown recorded exactly once.
 		expect(driver1.destroy).not.toHaveBeenCalled()
 		expect(state.driver).toBe(driver1)
 		expect(hoisted.destroyOrder.filter((d) => d === 'driver')).toHaveLength(
@@ -1441,17 +1196,8 @@ describe('DriverLifecycle — failed-connect teardown ownership', () => {
 	})
 })
 
-// ===========================================================================
-// connect() — final logConfig override (finding 4)
-// ===========================================================================
-
 describe('DriverLifecycle — final logConfig override', () => {
 	it('a documented zwave.options.logConfig override still receives the JSON transport, extra transports and bumped level', async () => {
-		// A user-supplied `zwave.options.logConfig` (merged via Object.assign)
-		// REPLACES the log-config object reference. The required JSON transport
-		// (debug-socket forwarding) and every registered extra transport must
-		// still land on that FINAL object, and the most-verbose extra level must
-		// win over the override's level.
 		const { lifecycle } = createHarness({
 			serverEnabled: false,
 			options: { logConfig: { level: 'error' } } as any,
@@ -1464,11 +1210,8 @@ describe('DriverLifecycle — final logConfig override', () => {
 		const passedLogConfig = hoisted.drivers[0].options.logConfig
 		const jsonTransport = hoisted.logTransports[0]
 		expect(jsonTransport).toBeDefined()
-		// required JSON transport survived the override replacing the object
 		expect(passedLogConfig.transports).toContain(jsonTransport)
-		// registered extra transport survived too
 		expect(passedLogConfig.transports).toContain(extra)
-		// the extra transport's more-verbose 'debug' won over the override 'error'
 		expect(passedLogConfig.level).toBe('debug')
 	})
 
@@ -1483,29 +1226,19 @@ describe('DriverLifecycle — final logConfig override', () => {
 		const passedLogConfig = hoisted.drivers[0].options.logConfig
 		const jsonTransport = hoisted.logTransports[0]
 		expect(passedLogConfig.transports).toEqual([jsonTransport])
-		// no extra transport → the override's own level is preserved
 		expect(passedLogConfig.level).toBe('warn')
 	})
 
 	it('a driver built with NO logConfig object connects cleanly and leaves the base level unset', async () => {
-		// `utils.buildLogConfig` yields no logConfig object for an exotic
-		// external configuration. `_startDriver` must still construct and start
-		// the driver (there is no logConfig to enrich), and the captured base
-		// level stays unset — so a later runtime add/remove computes the level
-		// purely from the registered extras, with no configured floor.
 		hoisted.buildLogConfigOverride = () => undefined
 		const { lifecycle, state } = createHarness({ serverEnabled: false })
 
 		await lifecycle.connect()
 
-		// Driver constructed + started, and received no logConfig object at all.
 		expect(hoisted.drivers).toHaveLength(1)
 		expect(hoisted.drivers[0].options.logConfig).toBeUndefined()
 		expect(state.driver).toBe(hoisted.drivers[0])
 
-		// Base level unset: a subsequent extra drives the effective level on its
-		// own (its 'warn' is used verbatim, not merged over a configured floor),
-		// and the required JSON-socket transport is still re-sent first.
 		state.driverReadyRaw = true
 		hoisted.drivers[0].updateLogConfig.mockClear()
 		const extra = { id: 'x' }
@@ -1517,25 +1250,15 @@ describe('DriverLifecycle — final logConfig override', () => {
 	})
 
 	it('a driver logConfig with a non-string level leaves the base level unset and never overwrites it', async () => {
-		// A logConfig whose `level` is not a string must not be captured as the
-		// base level (the `typeof === 'string'` guard falls to `undefined`), and
-		// with no extras the computed runtime level is `undefined`, so the
-		// enrichment must NOT rewrite the driver's own level field.
 		hoisted.buildLogConfigOverride = () => ({ level: 42 })
 		const { lifecycle } = createHarness({ serverEnabled: false })
 
 		await lifecycle.connect()
 
 		const passedLogConfig = hoisted.drivers[0].options.logConfig
-		// The required JSON transport was still injected (the `if (finalLogConfig)`
-		// enrichment ran)...
 		expect(passedLogConfig.transports).toEqual([hoisted.logTransports[0]])
-		// ...but the non-string level was left exactly as-is (computed runtime
-		// level was `undefined`, so `if (level)` never overwrote it).
 		expect(passedLogConfig.level).toBe(42)
 
-		// Base level genuinely unset: adding a levelled extra now sets the level
-		// solely from that extra with no configured floor underneath it.
 		lifecycle['host'].isDriverReadyRaw = () => true
 		hoisted.drivers[0].updateLogConfig.mockClear()
 		const extra = { id: 'y' }
@@ -1546,18 +1269,6 @@ describe('DriverLifecycle — final logConfig override', () => {
 		})
 	})
 })
-
-// ===========================================================================
-// connect() — logConfig source isolation (re-review finding 3)
-// ===========================================================================
-//
-// `Object.assign(zwaveOptions, cfg.options)` aliases the driver's `logConfig`
-// onto the user's PERSISTED `cfg.options.logConfig` whenever a documented
-// `zwave.options.logConfig` override is present. The runtime enrichment that
-// follows (JSON transport + registered extra transports, and a raised effective
-// level) must land on a driver-only clone, NOT on that persisted object —
-// otherwise adding a temporary debug transport permanently rewrites the user's
-// configured level, and removing it + restarting can never return to it.
 
 describe('DriverLifecycle — logConfig source isolation', () => {
 	it('does not mutate the persisted cfg.options.logConfig; the driver receives a distinct enriched clone', async () => {
@@ -1575,16 +1286,11 @@ describe('DriverLifecycle — logConfig source isolation', () => {
 		await lifecycle.connect()
 
 		const driverLogConfig = hoisted.drivers[0].options.logConfig
-		// The driver received a DISTINCT object (a clone), enriched for the
-		// driver only: the required JSON transport, the registered extra, and a
-		// level raised to the extra's more-verbose 'debug'.
 		expect(driverLogConfig).not.toBe(source)
 		expect(driverLogConfig.transports).toContain(hoisted.logTransports[0])
 		expect(driverLogConfig.transports).toContain(extra)
 		expect(driverLogConfig.level).toBe('debug')
 
-		// The persisted source object is untouched: SAME reference, deep content
-		// unchanged, no runtime transports leaked in, configured level intact.
 		expect((state.cfg as any).options.logConfig).toBe(source)
 		expect(source).toEqual(sourceSnapshot)
 		expect(source.transports).toBeUndefined()
@@ -1600,39 +1306,26 @@ describe('DriverLifecycle — logConfig source isolation', () => {
 		const sourceSnapshot = JSON.parse(JSON.stringify(source))
 		const extra = { id: 'temp-debug' }
 
-		// Add a debug transport, then connect: the driver runs at the raised
-		// 'debug' level while the persisted source stays at 'info'.
 		lifecycle.addExtraLogTransport(extra, 'debug')
 		await lifecycle.connect()
 		expect(hoisted.drivers[0].options.logConfig.level).toBe('debug')
 		expect(source).toEqual(sourceSnapshot)
 		expect((state.cfg as any).options.logConfig).toBe(source)
 
-		// Remove the extra transport and restart. The real restart is
-		// close()+init()+connect(): close() destroys the driver and nulls the
-		// host field; init() re-opens the client (cleared here via state.closed).
 		lifecycle.removeExtraLogTransport(extra)
 		await lifecycle.close()
 		state.closed = false
 		await lifecycle.connect()
 
-		// The second driver is back at the CONFIGURED level and carries only the
-		// required JSON transport — no leftover runtime transport objects.
 		const restarted = hoisted.drivers[1].options.logConfig
 		expect(restarted.level).toBe('info')
 		expect(restarted.transports).toEqual([hoisted.logTransports[1]])
 
-		// Across the full add → connect → remove → close/restart sequence the
-		// persisted source kept its identity and exact content.
 		expect((state.cfg as any).options.logConfig).toBe(source)
 		expect(source).toEqual(sourceSnapshot)
 		expect(source.level).toBe('info')
 	})
 })
-
-// ===========================================================================
-// close()
-// ===========================================================================
 
 describe('DriverLifecycle — close', () => {
 	it('bumps the generation, transitions to CLOSED and clears runtime state', async () => {
@@ -1686,10 +1379,6 @@ describe('DriverLifecycle — close', () => {
 	})
 })
 
-// ===========================================================================
-// Generation-guarded driver-event dispatch
-// ===========================================================================
-
 describe('DriverLifecycle — driver-event dispatch', () => {
 	it('forwards every driver event to the host with the current generation', async () => {
 		const { lifecycle, host } = createHarness({ serverEnabled: false })
@@ -1723,7 +1412,7 @@ describe('DriverLifecycle — driver-event dispatch', () => {
 		const { lifecycle, host } = createHarness({ serverEnabled: false })
 		await lifecycle.connect()
 		const driver = hoisted.drivers[0]
-		await lifecycle.close() // bumps generation
+		await lifecycle.close()
 
 		host.onDriverReady = vi.fn(async () => {})
 		driver.emit('driver ready')
@@ -1750,10 +1439,6 @@ describe('DriverLifecycle — driver-event dispatch', () => {
 		expect(host.onOTWFirmwareUpdateFinished).not.toHaveBeenCalled()
 	})
 })
-
-// ===========================================================================
-// connect() — remaining option/edge coverage
-// ===========================================================================
 
 describe('DriverLifecycle — connect option/edge coverage', () => {
 	it('builds scale preferences from cfg.scales', async () => {
@@ -1783,14 +1468,12 @@ describe('DriverLifecycle — connect option/edge coverage', () => {
 		const { lifecycle } = createHarness({ serverEnabled: false })
 		const t1 = { id: 'extra-1' }
 		const t2 = { id: 'extra-2' }
-		// register before connect: applied while building driver log options
 		lifecycle.addExtraLogTransport(t1, 'warn')
 		lifecycle.addExtraLogTransport(t2, 'silly')
 		await lifecycle.connect()
 		const logConfig = hoisted.drivers[0].options.logConfig
 		expect(logConfig.transports).toContain(t1)
 		expect(logConfig.transports).toContain(t2)
-		// 'silly' is the most verbose requested level
 		expect(logConfig.level).toBe('silly')
 	})
 
@@ -1809,15 +1492,10 @@ describe('DriverLifecycle — connect option/edge coverage', () => {
 			state.destroyed = true
 		}
 		await lifecycle.connect()
-		// checkIfDestroyed() fired after start → CONNECTED never set
 		expect(state.status).not.toBe(ZwaveClientStatus.CONNECTED)
 		expect(hoisted.drivers[0].start).toHaveBeenCalled()
 	})
 })
-
-// ===========================================================================
-// connect() — catch-path edge coverage
-// ===========================================================================
 
 describe('DriverLifecycle — connect catch-path edges', () => {
 	it('swallows a driver.destroy() rejection while handling a start failure', async () => {
@@ -1829,7 +1507,6 @@ describe('DriverLifecycle — connect catch-path edges', () => {
 			hoisted.destroyRejects = true
 			await lifecycle.connect()
 			await flush()
-			// error still reported + backoff still scheduled despite destroy failing
 			expect(host.onDriverError).toHaveBeenCalledWith(
 				expect.any(Error),
 				true,
@@ -1846,7 +1523,7 @@ describe('DriverLifecycle — connect catch-path edges', () => {
 		hoisted.startBehavior = 'reject'
 		hoisted.startError = new Error('boom')
 		hoisted.startHook = () => {
-			void lifecycle.close() // bumps generation before the catch runs
+			void lifecycle.close()
 		}
 		await lifecycle.connect()
 		expect(host.onDriverError).not.toHaveBeenCalled()
@@ -1862,15 +1539,10 @@ describe('DriverLifecycle — connect catch-path edges', () => {
 			state.destroyed = true
 		}
 		await lifecycle.connect()
-		// checkIfDestroyed() short-circuits before onDriverError
 		expect(host.onDriverError).not.toHaveBeenCalled()
 		expect(state.closed).toBe(true)
 	})
 })
-
-// ===========================================================================
-// Async failure paths in timers/helpers
-// ===========================================================================
 
 describe('DriverLifecycle — async failure logging', () => {
 	it('logs (and swallows) a restart failure from the backoff timer', async () => {
@@ -1882,7 +1554,6 @@ describe('DriverLifecycle — async failure logging', () => {
 			await vi.advanceTimersByTimeAsync(1000)
 			await flush()
 			expect(host.restart).toHaveBeenCalledTimes(1)
-			// no unhandled rejection — the .catch handled it
 		} finally {
 			vi.useRealTimers()
 		}
@@ -1895,7 +1566,6 @@ describe('DriverLifecycle — async failure logging', () => {
 			destroy: vi.fn(() => Promise.reject(new Error('destroy boom'))),
 		}
 		expect(lifecycle.checkIfDestroyed()).toBe(true)
-		// let the rejected close() settle; the internal .catch handles it
 		await flush()
 		await flush()
 	})

--- a/test/lib/zwave/DriverLifecycle.test.ts
+++ b/test/lib/zwave/DriverLifecycle.test.ts
@@ -1083,6 +1083,89 @@ describe('DriverLifecycle — final logConfig override', () => {
 })
 
 // ===========================================================================
+// connect() — logConfig source isolation (re-review finding 3)
+// ===========================================================================
+//
+// `Object.assign(zwaveOptions, cfg.options)` aliases the driver's `logConfig`
+// onto the user's PERSISTED `cfg.options.logConfig` whenever a documented
+// `zwave.options.logConfig` override is present. The runtime enrichment that
+// follows (JSON transport + registered extra transports, and a raised effective
+// level) must land on a driver-only clone, NOT on that persisted object —
+// otherwise adding a temporary debug transport permanently rewrites the user's
+// configured level, and removing it + restarting can never return to it.
+
+describe('DriverLifecycle — logConfig source isolation', () => {
+	it('does not mutate the persisted cfg.options.logConfig; the driver receives a distinct enriched clone', async () => {
+		const { lifecycle, state } = createHarness({
+			serverEnabled: false,
+			options: {
+				logConfig: { level: 'warn', maxFiles: 5 },
+			} as any,
+		})
+		const source = (state.cfg as any).options.logConfig
+		const sourceSnapshot = JSON.parse(JSON.stringify(source))
+		const extra = { id: 'debug-forwarder' }
+		lifecycle.addExtraLogTransport(extra, 'debug')
+
+		await lifecycle.connect()
+
+		const driverLogConfig = hoisted.drivers[0].options.logConfig
+		// The driver received a DISTINCT object (a clone), enriched for the
+		// driver only: the required JSON transport, the registered extra, and a
+		// level raised to the extra's more-verbose 'debug'.
+		expect(driverLogConfig).not.toBe(source)
+		expect(driverLogConfig.transports).toContain(hoisted.logTransports[0])
+		expect(driverLogConfig.transports).toContain(extra)
+		expect(driverLogConfig.level).toBe('debug')
+
+		// The persisted source object is untouched: SAME reference, deep content
+		// unchanged, no runtime transports leaked in, configured level intact.
+		expect((state.cfg as any).options.logConfig).toBe(source)
+		expect(source).toEqual(sourceSnapshot)
+		expect(source.transports).toBeUndefined()
+		expect(source.level).toBe('warn')
+	})
+
+	it('removing a debug transport and restarting returns the driver to the configured level without leaking runtime transports', async () => {
+		const { lifecycle, state } = createHarness({
+			serverEnabled: false,
+			options: { logConfig: { level: 'info' } } as any,
+		})
+		const source = (state.cfg as any).options.logConfig
+		const sourceSnapshot = JSON.parse(JSON.stringify(source))
+		const extra = { id: 'temp-debug' }
+
+		// Add a debug transport, then connect: the driver runs at the raised
+		// 'debug' level while the persisted source stays at 'info'.
+		lifecycle.addExtraLogTransport(extra, 'debug')
+		await lifecycle.connect()
+		expect(hoisted.drivers[0].options.logConfig.level).toBe('debug')
+		expect(source).toEqual(sourceSnapshot)
+		expect((state.cfg as any).options.logConfig).toBe(source)
+
+		// Remove the extra transport and restart. The real restart is
+		// close()+init()+connect(): close() destroys the driver and nulls the
+		// host field; init() re-opens the client (cleared here via state.closed).
+		lifecycle.removeExtraLogTransport(extra)
+		await lifecycle.close()
+		state.closed = false
+		await lifecycle.connect()
+
+		// The second driver is back at the CONFIGURED level and carries only the
+		// required JSON transport — no leftover runtime transport objects.
+		const restarted = hoisted.drivers[1].options.logConfig
+		expect(restarted.level).toBe('info')
+		expect(restarted.transports).toEqual([hoisted.logTransports[1]])
+
+		// Across the full add → connect → remove → close/restart sequence the
+		// persisted source kept its identity and exact content.
+		expect((state.cfg as any).options.logConfig).toBe(source)
+		expect(source).toEqual(sourceSnapshot)
+		expect(source.level).toBe('info')
+	})
+})
+
+// ===========================================================================
 // close()
 // ===========================================================================
 

--- a/test/lib/zwave/DriverLifecycle.test.ts
+++ b/test/lib/zwave/DriverLifecycle.test.ts
@@ -8,7 +8,11 @@ import {
 	type Mock,
 } from 'vitest'
 import { EventEmitter } from 'node:events'
-import { ZWaveError, ZWaveErrorCodes } from '@zwave-js/core'
+import {
+	ZWaveError,
+	ZWaveErrorCodes,
+	CONTROLLER_LOGLEVEL,
+} from '@zwave-js/core'
 import { RFRegion } from 'zwave-js'
 import type { Driver, ZWaveOptions, PartialZWaveOptions } from 'zwave-js'
 import type { JSONTransport } from '@zwave-js/log-transport-json'
@@ -443,6 +447,66 @@ describe('DriverLifecycle — extra log transports', () => {
 		expect(driver.updateLogConfig).toHaveBeenCalledWith({
 			transports: [world.logTransports[0], extra],
 			level: 'debug',
+		})
+	})
+
+	// A configured level is persisted as an npm numeric rank, so the baseline
+	// has to survive the number→name round trip and be re-sent when the last
+	// verbose extra is dropped — updateLogConfig merges partial updates, so a
+	// missing level would leave the driver stuck at the elevated level.
+	it('a numeric configured baseline is restored when the last verbose extra is removed', async () => {
+		const { lifecycle, json, driver } = await connectedReadyHarness({
+			logLevel: 'verbose',
+		})
+		const extra = new Transport({})
+		lifecycle.addExtraLogTransport(extra, 'debug')
+		expect(driver.updateLogConfig).toHaveBeenLastCalledWith({
+			transports: [json, extra],
+			level: 'debug',
+		})
+		lifecycle.removeExtraLogTransport(extra)
+		expect(driver.updateLogConfig).toHaveBeenLastCalledWith({
+			transports: [json],
+			level: 'verbose',
+		})
+	})
+
+	// With no configured level the baseline defaults to zwave-js's documented
+	// level, which must be re-sent on removal so the driver returns to it
+	// instead of staying at the elevated level.
+	it('an omitted baseline returns to the documented default level when the last verbose extra is removed', async () => {
+		const { lifecycle, json, driver } = await connectedReadyHarness({
+			options: zwaveOpts({ logConfig: { maxFiles: 5 } }),
+		})
+		const extra = new Transport({})
+		lifecycle.addExtraLogTransport(extra, 'debug')
+		expect(driver.updateLogConfig).toHaveBeenLastCalledWith({
+			transports: [json, extra],
+			level: 'debug',
+		})
+		lifecycle.removeExtraLogTransport(extra)
+		expect(driver.updateLogConfig).toHaveBeenLastCalledWith({
+			transports: [json],
+			level: CONTROLLER_LOGLEVEL,
+		})
+	})
+
+	// A configured string level is the baseline and must be re-sent verbatim
+	// once the verbose extra is removed.
+	it('a configured string baseline is preserved across an extra add and removal', async () => {
+		const { lifecycle, json, driver } = await connectedReadyHarness({
+			options: zwaveOpts({ logConfig: { level: 'warn' } }),
+		})
+		const extra = new Transport({})
+		lifecycle.addExtraLogTransport(extra, 'debug')
+		expect(driver.updateLogConfig).toHaveBeenLastCalledWith({
+			transports: [json, extra],
+			level: 'debug',
+		})
+		lifecycle.removeExtraLogTransport(extra)
+		expect(driver.updateLogConfig).toHaveBeenLastCalledWith({
+			transports: [json],
+			level: 'warn',
 		})
 	})
 
@@ -1131,7 +1195,10 @@ describe('DriverLifecycle — logConfig override', () => {
 		expect(passedLogConfig?.level).toBe('warn')
 	})
 
-	it('a driver with no logConfig connects and leaves the level unset, then accepts a later transport', async () => {
+	// With no configured logConfig the driver options start with the level unset
+	// (connect() lets zwave-js pick its default), and a later, less-verbose extra
+	// is clamped to the documented default baseline rather than lowering the level.
+	it('a driver with no logConfig connects with the level unset, then clamps a less-verbose extra to the documented default', async () => {
 		const { lifecycle, world, state } = createHarness({
 			serverEnabled: false,
 			options: zwaveOpts({ logConfig: undefined }),
@@ -1149,7 +1216,7 @@ describe('DriverLifecycle — logConfig override', () => {
 		lifecycle.addExtraLogTransport(extra, 'warn')
 		expect(world.drivers[0].updateLogConfig).toHaveBeenCalledWith({
 			transports: [world.logTransports[0], extra],
-			level: 'warn',
+			level: CONTROLLER_LOGLEVEL,
 		})
 	})
 })

--- a/test/lib/zwave/DriverLifecycle.test.ts
+++ b/test/lib/zwave/DriverLifecycle.test.ts
@@ -444,7 +444,7 @@ describe('DriverLifecycle — extra log transports', () => {
 	})
 
 	it('addExtraLogTransport leaves the driver untouched until it is ready, then applies the registered transport', async () => {
-		const { lifecycle, world, state } = createHarness({
+		const { lifecycle, host, world, state } = createHarness({
 			serverEnabled: false,
 		})
 		await lifecycle.connect()
@@ -455,8 +455,12 @@ describe('DriverLifecycle — extra log transports', () => {
 		lifecycle.addExtraLogTransport(extra, 'debug')
 		expect(driver.updateLogConfig).not.toHaveBeenCalled()
 
-		state.driverReadyRaw = true
-		lifecycle.removeExtraLogTransport(new Transport({}))
+		host.onDriverReady.mockImplementationOnce(() => {
+			state.driverReadyRaw = true
+			return Promise.resolve()
+		})
+		driver.emit('driver ready')
+
 		expect(driver.updateLogConfig).toHaveBeenCalledWith({
 			transports: [world.logTransports[0], extra],
 			level: 'debug',
@@ -561,6 +565,16 @@ describe('DriverLifecycle — backoff restart & checkIfDestroyed', () => {
 		lifecycle.backoffRestart()
 		await vi.advanceTimersByTimeAsync(1000)
 		expect(host.restart).toHaveBeenCalledTimes(3)
+	})
+
+	it('resetBackoff cancels a restart after the driver recovers', async () => {
+		const { lifecycle, host } = createHarness()
+		lifecycle.backoffRestart()
+		lifecycle.resetBackoff()
+
+		await vi.advanceTimersByTimeAsync(1000)
+
+		expect(host.restart).not.toHaveBeenCalled()
 	})
 
 	it('backoffRestart aborts and closes when the client is already destroyed', async () => {
@@ -1413,6 +1427,32 @@ describe('DriverLifecycle — driver-ready failures', () => {
 		expect(host.restart).not.toHaveBeenCalled()
 		await vi.advanceTimersByTimeAsync(1000)
 		expect(host.restart).toHaveBeenCalledTimes(1)
+	})
+
+	it('keeps newer ready state when an older same-generation initialization rejects', async () => {
+		const { lifecycle, host, world, state } = createHarness({
+			serverEnabled: false,
+		})
+		const firstReady = createDeferred<void>()
+		host.onDriverReady
+			.mockImplementationOnce(() => {
+				state.driverReady = true
+				return firstReady.promise
+			})
+			.mockImplementationOnce(() => {
+				state.driverReady = true
+				return Promise.resolve()
+			})
+		await lifecycle.connect()
+
+		world.drivers[0].emit('driver ready')
+		world.drivers[0].emit('driver ready')
+		firstReady.reject(new Error('superseded ready failure'))
+		await vi.advanceTimersByTimeAsync(60000)
+
+		expect(state.driverReady).toBe(true)
+		expect(host.onDriverError).not.toHaveBeenCalled()
+		expect(host.restart).not.toHaveBeenCalled()
 	})
 
 	it('ignores a driver-ready failure after that generation closes', async () => {

--- a/test/lib/zwave/DriverLifecycle.test.ts
+++ b/test/lib/zwave/DriverLifecycle.test.ts
@@ -1395,16 +1395,20 @@ describe('DriverLifecycle — driver-ready failures', () => {
 	afterEach(() => vi.useRealTimers())
 
 	it('reports a current driver-ready initialization failure and restarts', async () => {
-		const { lifecycle, host, world } = createHarness({
+		const { lifecycle, host, world, state } = createHarness({
 			serverEnabled: false,
 		})
 		const readyError = new Error('ready initialization failed')
-		host.onDriverReady.mockRejectedValueOnce(readyError)
+		host.onDriverReady.mockImplementationOnce(() => {
+			state.driverReady = true
+			return Promise.reject(readyError)
+		})
 		await lifecycle.connect()
 
 		world.drivers[0].emit('driver ready')
 		await Promise.resolve()
 
+		expect(state.driverReady).toBe(false)
 		expect(host.onDriverError).toHaveBeenCalledWith(readyError, true)
 		expect(host.restart).not.toHaveBeenCalled()
 		await vi.advanceTimersByTimeAsync(1000)

--- a/test/lib/zwave/DriverLifecycle.test.ts
+++ b/test/lib/zwave/DriverLifecycle.test.ts
@@ -1,21 +1,4 @@
 /* eslint-disable @typescript-eslint/unbound-method */
-/**
- * Direct state-machine tests for the extracted {@link DriverLifecycle}
- * service (`api/lib/zwave/DriverLifecycle.ts`).
- *
- * The service reaches everything it needs from `ZwaveClient` through the
- * narrow {@link DriverLifecycleHost} port, so these tests drive it with a
- * fully-faked host whose accessors read/write a small mutable state object.
- * `zwave-js`'s `Driver` is replaced with an `EventEmitter` fake so the real
- * `connect()` body runs verbatim (real option building, real event wiring),
- * and `@zwave-js/server` + `utils.ensureDir` are stubbed so no real server
- * binds a port and no directory is written to disk.
- *
- * The complementary end-to-end flow through the `ZwaveClient` facade (real
- * `connect()` → driver-ready → `_onDriverReady()` → server start → `close()`),
- * including generation fencing of a late `_onDriverReady()`, is characterized
- * in `test/lib/hass/server.test.ts` and the socket production-integration suite.
- */
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { ZWaveError, ZWaveErrorCodes } from '@zwave-js/core'
 
@@ -26,13 +9,11 @@ import type {
 } from '../../../api/lib/zwave/ports.ts'
 import { ZwaveClientStatus } from '../../../api/lib/zwave/ports.ts'
 
-// vi.hoisted holders the mock factories push into, reset in beforeEach
 const hoisted = vi.hoisted(() => ({
 	drivers: [] as any[],
 	destroyOrder: [] as string[],
 	startBehavior: 'resolve' as 'resolve' | 'reject' | 'hang' | 'deferred',
 	startError: new Error('start failed'),
-	/** In 'deferred' mode each start() pushes a controllable settler here so a test can interleave two overlapping connect() calls with no timers */
 	startDeferreds: [] as Array<{
 		resolve: () => void
 		reject: (err: unknown) => void
@@ -40,22 +21,17 @@ const hoisted = vi.hoisted(() => ({
 	startHook: null as null | (() => void),
 	ensureDirHook: null as null | (() => void),
 	destroyRejects: false,
-	/** 'reject' keeps the instance intact/retryable (models a destroy that fails while the driver may still hold the port); 'deferred' lets a test hold teardown open to prove no replacement is built mid-teardown */
 	destroyBehavior: 'resolve' as 'resolve' | 'reject' | 'deferred',
-	/** In 'deferred' mode each destroy() pushes a settler here; resolve() records the teardown effect once, reject() leaves the instance intact/retryable */
 	destroyDeferreds: [] as Array<{
 		resolve: () => void
 		reject: (err?: Error) => void
 	}>,
-	/** Leading destroy() calls that reject before one succeeds, so a test can prove a rejected destroy keeps the owner and a later retry tears it down */
 	destroyRejectCount: 0,
 	destroyInvocations: 0,
 	logTransports: [] as any[],
-	/** Overrides buildLogConfig() for the next connect() to reach enrichment branches the always-populated real config never hits (no logConfig, or a non-string level) */
 	buildLogConfigOverride: null as null | (() => any),
 }))
 
-// zwave-js Driver fake: extends EventEmitter so production wires real handlers; start()/destroy() honour the controllable hoisted behavior
 vi.mock('zwave-js', async () => {
 	const actual = await vi.importActual<any>('zwave-js')
 	const { EventEmitter } = await import('node:events')
@@ -77,9 +53,7 @@ vi.mock('zwave-js', async () => {
 				return Promise.reject(hoisted.startError)
 			}
 			if (hoisted.startBehavior === 'hang') {
-				return new Promise<void>(() => {
-					/* never resolves */
-				})
+				return new Promise<void>(() => {})
 			}
 			if (hoisted.startBehavior === 'deferred') {
 				return new Promise<void>((resolve, reject) => {
@@ -91,7 +65,6 @@ vi.mock('zwave-js', async () => {
 		destroy = vi.fn((): Promise<void> => {
 			hoisted.destroyInvocations++
 
-			// Record the teardown effect at most once per instance, mirroring real zwave-js Driver.destroy() idempotency so a stale-connect teardown racing close() records it exactly once
 			const recordEffect = () => {
 				if (!this._destroyed) {
 					this._destroyed = true
@@ -112,12 +85,10 @@ vi.mock('zwave-js', async () => {
 				})
 			}
 
-			// Already torn down: idempotent clean resolve
 			if (this._destroyed) {
 				return Promise.resolve()
 			}
 
-			// A rejecting destroy must not mark the instance destroyed or record an effect, so the exact owner stays intact and retryable
 			const rejectThis =
 				hoisted.destroyRejects ||
 				hoisted.destroyBehavior === 'reject' ||
@@ -147,7 +118,6 @@ vi.mock('zwave-js', async () => {
 	return { ...actual, Driver: FakeDriver }
 })
 
-// @zwave-js/server stub so the lazy fallback ZwaveServerManager never binds a real port
 vi.mock('@zwave-js/server', async () => {
 	const { EventEmitter } = await import('node:events')
 	class ZwavejsServerMock extends EventEmitter {
@@ -167,7 +137,6 @@ vi.mock('@zwave-js/server', async () => {
 	return { serverVersion: '0.0.0-test', ZwavejsServer: ZwavejsServerMock }
 })
 
-// JSON log transport fake whose `.stream` we can drive to exercise the production stream.on('data') → host.emitDebug wiring
 vi.mock('@zwave-js/log-transport-json', async () => {
 	const { EventEmitter } = await import('node:events')
 	class JSONTransportMock {
@@ -180,7 +149,6 @@ vi.mock('@zwave-js/log-transport-json', async () => {
 	return { JSONTransport: JSONTransportMock }
 })
 
-// Stub only utils.ensureDir to avoid a real mkdir and to hook the generation mid-await; every other util stays real
 vi.mock('../../../api/lib/utils.ts', async () => {
 	const actual = await vi.importActual<any>('../../../api/lib/utils.ts')
 	return {
@@ -197,7 +165,6 @@ vi.mock('../../../api/lib/utils.ts', async () => {
 	}
 })
 
-// Import after the mocks are registered
 const { DriverLifecycle } = await import(
 	'../../../api/lib/zwave/DriverLifecycle.ts'
 )
@@ -292,7 +259,6 @@ function createHarness(cfgOverrides: Partial<ZwaveConfig> = {}) {
 	return { lifecycle, host, state, serverHost }
 }
 
-/** Fake adopted server manager that records its destroy into the order log */
 function fakeManager() {
 	return {
 		create: vi.fn(),
@@ -307,7 +273,6 @@ function fakeManager() {
 
 const flush = () => Promise.resolve()
 
-/** Pump the microtask queue until pred() holds; deterministic since every awaited step resolves synchronously (no timers) */
 async function until(pred: () => boolean, max = 100): Promise<void> {
 	for (let i = 0; i < max; i++) {
 		if (pred()) return
@@ -410,7 +375,6 @@ describe('DriverLifecycle — statistics', () => {
 })
 
 describe('DriverLifecycle — extra log transports', () => {
-	// Connect first so the JSON-socket transport exists; updateLogConfig({transports}) replaces the whole list, so every apply re-sends it plus all current extras
 	async function connectedReadyHarness(cfgOverrides: any = {}) {
 		const harness = createHarness({ serverEnabled: false, ...cfgOverrides })
 		await harness.lifecycle.connect()
@@ -629,7 +593,6 @@ describe('DriverLifecycle — backoff restart coalescing & fencing', () => {
 
 		lifecycle.backoffRestart()
 
-		// Connecting bumps the generation but does not clear the pending timer, so only the generation fence stops the stale restart
 		await lifecycle.connect()
 		expect(lifecycle.generation).toBe(1)
 

--- a/test/lib/zwave/DriverLifecycle.test.ts
+++ b/test/lib/zwave/DriverLifecycle.test.ts
@@ -878,34 +878,120 @@ describe('DriverLifecycle — connect generation fencing', () => {
 })
 
 // ===========================================================================
-// connect() — overlapping-connect ownership (finding 1)
+// connect() — pre-ready reconnect coalescing (re-review finding 1)
 // ===========================================================================
+//
+// A second connect() that lands after driver.start() has resolved (CONNECTED)
+// but before `driver ready` — or while the first connect is still awaiting
+// start() — used to pass the ready-only guard, mint a new generation and
+// construct a REPLACEMENT driver, overwriting the host field and stranding the
+// first, still-live, non-ready driver (unreachable, never torn down, still
+// holding the serial port). connect() now coalesces onto the in-flight connect
+// while a driver is already owned, so no replacement is constructed and nothing
+// leaks. A genuine reconnect (config change / backoff / hard reset) goes through
+// close()/restart(), which nulls the host driver first, so it is never blocked.
 
-describe('DriverLifecycle — overlapping connect ownership', () => {
-	// Deterministically interleave two overlapping connect() calls: the first
-	// (stale) generation's driver.start() is held open via a per-instance
-	// deferred while a second connect() supersedes it and stores a replacement
-	// driver on the host. We then settle the stale start LAST and assert that
-	// only the stale generation's OWN driver is torn down — never the live
-	// replacement — with no leak.
-	async function openTwoOverlappingConnects() {
+describe('DriverLifecycle — pre-ready reconnect coalescing', () => {
+	it('a second connect after start() resolves but before driver ready does NOT construct or leak a replacement', async () => {
+		const { lifecycle, state } = createHarness({ serverEnabled: false })
+
+		// First connect reaches CONNECTED (start resolved) but the driver is NOT
+		// ready yet — driverReady only flips inside onDriverReady().
+		await lifecycle.connect()
+		expect(hoisted.drivers).toHaveLength(1)
+		const driver0 = hoisted.drivers[0]
+		expect(state.driver).toBe(driver0)
+		expect(state.status).toBe(ZwaveClientStatus.CONNECTED)
+		expect(state.driverReady).toBe(false)
+		const genAfterFirst = lifecycle.generation
+
+		// Second connect while driver0 is connecting-but-not-ready.
+		await lifecycle.connect()
+
+		// Coalesced: exactly ONE Driver ever constructed, the host still points
+		// at driver0, it is never destroyed, and the generation did not advance.
+		expect(hoisted.drivers).toHaveLength(1)
+		expect(state.driver).toBe(driver0)
+		expect(driver0.destroy).not.toHaveBeenCalled()
+		expect(lifecycle.generation).toBe(genAfterFirst)
+	})
+
+	it('coalesces a second connect while the first is still awaiting driver.start()', async () => {
+		const { lifecycle, state } = createHarness({ serverEnabled: false })
+		hoisted.startBehavior = 'deferred'
+
+		const first = lifecycle.connect()
+		await until(() => hoisted.startDeferreds.length === 1)
+		expect(hoisted.drivers).toHaveLength(1)
+		const driver0 = hoisted.drivers[0]
+		const gen = lifecycle.generation
+
+		// Second connect while driver0 is mid-start → coalesced: no new Driver
+		// and no second start() call.
+		await lifecycle.connect()
+		expect(hoisted.drivers).toHaveLength(1)
+		expect(hoisted.startDeferreds).toHaveLength(1)
+		expect(state.driver).toBe(driver0)
+		expect(lifecycle.generation).toBe(gen)
+
+		// Let the first connect finish cleanly — still just the one driver.
+		hoisted.startDeferreds[0].resolve()
+		await first
+		expect(state.status).toBe(ZwaveClientStatus.CONNECTED)
+		expect(driver0.destroy).not.toHaveBeenCalled()
+	})
+
+	it('a recovery reconnect after a start failure is NOT coalesced (host cleared) and builds exactly one fresh driver', async () => {
+		const { lifecycle, state } = createHarness({ serverEnabled: false })
+
+		// First connect fails inside start(): driver0 is constructed, then torn
+		// down, and the host field is cleared (a backoff restart is scheduled).
+		hoisted.startBehavior = 'reject'
+		await lifecycle.connect()
+		expect(hoisted.drivers).toHaveLength(1)
+		expect(hoisted.drivers[0].destroy).toHaveBeenCalledTimes(1)
+		expect(state.driver).toBeNull()
+
+		// The real backoff recovery is close()+init()+connect(): close() clears
+		// the pending restart timer and bumps the generation; init() re-opens the
+		// client. Mirror that, then reconnect.
+		await lifecycle.close(true)
+		state.closed = false
+
+		hoisted.startBehavior = 'resolve'
+		await lifecycle.connect()
+
+		// Not coalesced (host field was null): exactly one fresh driver adopted.
+		expect(hoisted.drivers).toHaveLength(2)
+		expect(state.driver).toBe(hoisted.drivers[1])
+		expect(state.status).toBe(ZwaveClientStatus.CONNECTED)
+	})
+
+	// A replacement can only legitimately appear via close()/restart() (which
+	// destroys the current driver and nulls the host field). These two tests
+	// preserve the prior-round ownership guarantee: a stale in-flight start that
+	// settles AFTER such a reconnect tears down only its own driver and never
+	// clobbers the live replacement.
+	async function openCloseReconnectWithStale() {
 		const harness = createHarness({ serverEnabled: false })
 		hoisted.startBehavior = 'deferred'
 
-		// First (soon-to-be-stale) connect: creates driver0, holds at start().
+		// Stale (soon-to-be-superseded) connect: driver0 on host, held at start.
 		const stalePromise = harness.lifecycle.connect()
 		await until(() => hoisted.startDeferreds.length === 1)
-		expect(hoisted.drivers).toHaveLength(1)
+		const driver0 = hoisted.drivers[0]
+		expect(harness.state.driver).toBe(driver0)
 
-		// Second connect supersedes the first (bumps the generation), creates
-		// driver1, stores it on the host and holds at its own start().
+		// close() bumps the generation, destroys driver0 and nulls the host field.
+		await harness.lifecycle.close(true)
+		expect(harness.state.driver).toBeNull()
+		harness.state.closed = false // init() re-opens before the reconnect
+
+		// Reconnect: host field is null → NOT coalesced → builds driver1.
+		hoisted.startBehavior = 'deferred'
 		const freshPromise = harness.lifecycle.connect()
 		await until(() => hoisted.startDeferreds.length === 2)
-		expect(hoisted.drivers).toHaveLength(2)
-
-		const [driver0, driver1] = hoisted.drivers
-
-		// Let the REPLACEMENT finish first so it becomes the live driver.
+		const driver1 = hoisted.drivers[1]
 		hoisted.startDeferreds[1].resolve()
 		await freshPromise
 		expect(harness.state.driver).toBe(driver1)
@@ -914,36 +1000,38 @@ describe('DriverLifecycle — overlapping connect ownership', () => {
 		return { ...harness, stalePromise, driver0, driver1 }
 	}
 
-	it('a stale start that RESOLVES after a replacement tears down only its own driver', async () => {
+	it('a stale start that RESOLVES after a close+reconnect tears down only its own driver', async () => {
 		const { state, stalePromise, driver0, driver1 } =
-			await openTwoOverlappingConnects()
+			await openCloseReconnectWithStale()
 
-		// The stale generation's start finally resolves — it must NOT clobber
-		// the live replacement.
 		hoisted.startDeferreds[0].resolve()
 		await stalePromise
 
-		expect(driver0.destroy).toHaveBeenCalledTimes(1) // stale torn down (no leak)
-		expect(driver1.destroy).not.toHaveBeenCalled() // replacement retained
-		expect(state.driver).toBe(driver1) // host still points at replacement
+		// driver0 was destroyed exactly once (by close(); the stale teardown is
+		// idempotent), the replacement was never destroyed, and the host still
+		// points at it.
+		expect(hoisted.destroyOrder.filter((d) => d === 'driver')).toHaveLength(
+			1,
+		)
+		expect(driver1.destroy).not.toHaveBeenCalled()
+		expect(state.driver).toBe(driver1)
 	})
 
-	it('a stale start that REJECTS after a replacement never destroys the replacement or backs off', async () => {
+	it('a stale start that REJECTS after a close+reconnect never destroys the replacement or backs off', async () => {
 		const { host, state, stalePromise, driver0, driver1 } =
-			await openTwoOverlappingConnects()
+			await openCloseReconnectWithStale()
 
-		// Regression: previously the catch destroyed host.getDriver() BEFORE the
-		// generation check, so a superseded rejected start destroyed the live
-		// replacement. It must now tear down only its own driver and then bail
-		// out on the generation mismatch (no error report, no backoff).
 		hoisted.startDeferreds[0].reject(new Error('late start failure'))
 		await stalePromise
 
-		expect(driver0.destroy).toHaveBeenCalledTimes(1) // stale torn down (no leak)
+		expect(hoisted.destroyOrder.filter((d) => d === 'driver')).toHaveLength(
+			1,
+		)
 		expect(driver1.destroy).not.toHaveBeenCalled() // replacement retained
-		expect(state.driver).toBe(driver1) // host still points at replacement
+		expect(state.driver).toBe(driver1)
 		expect(host.onDriverError).not.toHaveBeenCalled() // stale error swallowed
 		expect(host.restart).not.toHaveBeenCalled() // no stale backoff restart
+		void driver0
 	})
 })
 

--- a/test/lib/zwave/DriverLifecycle.test.ts
+++ b/test/lib/zwave/DriverLifecycle.test.ts
@@ -44,10 +44,21 @@ import { ZwaveClientStatus } from '../../../api/lib/zwave/ports.ts'
 const hoisted = vi.hoisted(() => ({
 	drivers: [] as any[],
 	destroyOrder: [] as string[],
-	/** 'resolve' | 'reject' | 'hang' — how the fake `driver.start()` behaves. */
-	startBehavior: 'resolve' as 'resolve' | 'reject' | 'hang',
+	/** 'resolve' | 'reject' | 'hang' | 'deferred' — how the fake `driver.start()` behaves. */
+	startBehavior: 'resolve' as 'resolve' | 'reject' | 'hang' | 'deferred',
 	/** Error thrown by `driver.start()` when `startBehavior === 'reject'`. */
 	startError: new Error('start failed'),
+	/**
+	 * When `startBehavior === 'deferred'`, each `driver.start()` call pushes a
+	 * controllable `{ resolve, reject }` here (in call order) and returns a
+	 * promise that only settles when the test drives it. Lets a test interleave
+	 * two overlapping `connect()` calls deterministically (old start settling
+	 * after a replacement has taken over) with no timers.
+	 */
+	startDeferreds: [] as Array<{
+		resolve: () => void
+		reject: (err: unknown) => void
+	}>,
 	/** Synchronous hook invoked at the very start of `driver.start()`. */
 	startHook: null as null | (() => void),
 	/** Synchronous hook invoked inside the stubbed `utils.ensureDir`. */
@@ -76,6 +87,7 @@ vi.mock('zwave-js', async () => {
 		controller = new FakeController()
 		port: any
 		options: any
+		private _destroyed = false
 		start = vi.fn(() => {
 			hoisted.startHook?.()
 			if (hoisted.startBehavior === 'reject') {
@@ -86,9 +98,21 @@ vi.mock('zwave-js', async () => {
 					/* never resolves */
 				})
 			}
+			if (hoisted.startBehavior === 'deferred') {
+				return new Promise<void>((resolve, reject) => {
+					hoisted.startDeferreds.push({ resolve, reject })
+				})
+			}
 			return Promise.resolve()
 		})
 		destroy = vi.fn(() => {
+			// The real zwave-js `Driver.destroy()` is idempotent (guarded by an
+			// internal `_destroyPromise`); mirror that so a stale-connect teardown
+			// racing a `close()` records the destroy effect exactly once.
+			if (this._destroyed) {
+				return Promise.resolve()
+			}
+			this._destroyed = true
 			hoisted.destroyOrder.push('driver')
 			if (hoisted.destroyRejects) {
 				return Promise.reject(new Error('destroy failed'))
@@ -274,11 +298,28 @@ function fakeManager() {
 /** Flush pending microtasks. */
 const flush = () => Promise.resolve()
 
+/**
+ * Pump the microtask queue until `pred()` holds (or a bounded number of turns
+ * elapses). Deterministic: every intermediate `await` inside `connect()`
+ * resolves synchronously (mocked `ensureDir`/`hasConnectedClients`), so this
+ * only advances already-settled microtasks — no timers, no wall-clock.
+ */
+async function until(pred: () => boolean, max = 100): Promise<void> {
+	for (let i = 0; i < max; i++) {
+		if (pred()) return
+		await Promise.resolve()
+	}
+	if (!pred()) {
+		throw new Error('until(): condition was not met')
+	}
+}
+
 beforeEach(() => {
 	hoisted.drivers.length = 0
 	hoisted.destroyOrder.length = 0
 	hoisted.startBehavior = 'resolve'
 	hoisted.startError = new Error('start failed')
+	hoisted.startDeferreds.length = 0
 	hoisted.startHook = null
 	hoisted.ensureDirHook = null
 	hoisted.destroyRejects = false
@@ -490,6 +531,64 @@ describe('DriverLifecycle — backoff restart & checkIfDestroyed', () => {
 	it('checkIfDestroyed returns false when not destroyed', () => {
 		const { lifecycle } = createHarness()
 		expect(lifecycle.checkIfDestroyed()).toBe(false)
+	})
+})
+
+// ===========================================================================
+// backoff restart — coalescing & generation fencing (finding 3)
+// ===========================================================================
+
+describe('DriverLifecycle — backoff restart coalescing & fencing', () => {
+	beforeEach(() => vi.useFakeTimers())
+	afterEach(() => vi.useRealTimers())
+
+	it('coalesces two backoff schedules made before firing into a single restart (latest delay wins)', async () => {
+		const { lifecycle, host } = createHarness()
+
+		// Two backoff requests arrive before either timer fires. Previously the
+		// second overwrote `_restartTimeout` and LEAKED the first handle, so BOTH
+		// fired → a double restart. They must now coalesce into ONE pending
+		// restart using the most-recent delay (2^1 * 1000 = 2000ms).
+		lifecycle.backoffRestart() // 1st: 1000ms
+		lifecycle.backoffRestart() // 2nd: 2000ms (clears the 1000ms handle)
+
+		// The leaked first handle must NOT fire at its original 1000ms.
+		await vi.advanceTimersByTimeAsync(1000)
+		expect(host.restart).not.toHaveBeenCalled()
+
+		// Only the single coalesced restart fires at the latest 2000ms delay.
+		await vi.advanceTimersByTimeAsync(1000)
+		expect(host.restart).toHaveBeenCalledTimes(1)
+
+		// And nothing else is left pending afterwards.
+		await vi.advanceTimersByTimeAsync(60000)
+		expect(host.restart).toHaveBeenCalledTimes(1)
+	})
+
+	it('a healthy replacement (new generation) fences a still-pending backoff restart', async () => {
+		const { lifecycle, host } = createHarness({ serverEnabled: false })
+
+		// A backoff restart is scheduled...
+		lifecycle.backoffRestart() // 1000ms, captures generation 0
+
+		// ...then a healthy driver connects, bumping the generation. This does
+		// NOT clear the pending timer, so only the generation fence can stop the
+		// stale restart from firing.
+		await lifecycle.connect()
+		expect(lifecycle.generation).toBe(1)
+
+		await vi.advanceTimersByTimeAsync(60000)
+		expect(host.restart).not.toHaveBeenCalled() // fenced: no stale restart
+	})
+
+	it('close() clears a pending backoff restart so it never fires', async () => {
+		const { lifecycle, host } = createHarness({ serverEnabled: false })
+
+		lifecycle.backoffRestart() // schedule
+		await lifecycle.close() // clears the handle AND bumps the generation
+
+		await vi.advanceTimersByTimeAsync(60000)
+		expect(host.restart).not.toHaveBeenCalled()
 	})
 })
 
@@ -775,6 +874,123 @@ describe('DriverLifecycle — connect generation fencing', () => {
 		await lifecycle.connect()
 		// fenced right after persistConfig — no driver created
 		expect(hoisted.drivers).toHaveLength(0)
+	})
+})
+
+// ===========================================================================
+// connect() — overlapping-connect ownership (finding 1)
+// ===========================================================================
+
+describe('DriverLifecycle — overlapping connect ownership', () => {
+	// Deterministically interleave two overlapping connect() calls: the first
+	// (stale) generation's driver.start() is held open via a per-instance
+	// deferred while a second connect() supersedes it and stores a replacement
+	// driver on the host. We then settle the stale start LAST and assert that
+	// only the stale generation's OWN driver is torn down — never the live
+	// replacement — with no leak.
+	async function openTwoOverlappingConnects() {
+		const harness = createHarness({ serverEnabled: false })
+		hoisted.startBehavior = 'deferred'
+
+		// First (soon-to-be-stale) connect: creates driver0, holds at start().
+		const stalePromise = harness.lifecycle.connect()
+		await until(() => hoisted.startDeferreds.length === 1)
+		expect(hoisted.drivers).toHaveLength(1)
+
+		// Second connect supersedes the first (bumps the generation), creates
+		// driver1, stores it on the host and holds at its own start().
+		const freshPromise = harness.lifecycle.connect()
+		await until(() => hoisted.startDeferreds.length === 2)
+		expect(hoisted.drivers).toHaveLength(2)
+
+		const [driver0, driver1] = hoisted.drivers
+
+		// Let the REPLACEMENT finish first so it becomes the live driver.
+		hoisted.startDeferreds[1].resolve()
+		await freshPromise
+		expect(harness.state.driver).toBe(driver1)
+		expect(harness.state.status).toBe(ZwaveClientStatus.CONNECTED)
+
+		return { ...harness, stalePromise, driver0, driver1 }
+	}
+
+	it('a stale start that RESOLVES after a replacement tears down only its own driver', async () => {
+		const { state, stalePromise, driver0, driver1 } =
+			await openTwoOverlappingConnects()
+
+		// The stale generation's start finally resolves — it must NOT clobber
+		// the live replacement.
+		hoisted.startDeferreds[0].resolve()
+		await stalePromise
+
+		expect(driver0.destroy).toHaveBeenCalledTimes(1) // stale torn down (no leak)
+		expect(driver1.destroy).not.toHaveBeenCalled() // replacement retained
+		expect(state.driver).toBe(driver1) // host still points at replacement
+	})
+
+	it('a stale start that REJECTS after a replacement never destroys the replacement or backs off', async () => {
+		const { host, state, stalePromise, driver0, driver1 } =
+			await openTwoOverlappingConnects()
+
+		// Regression: previously the catch destroyed host.getDriver() BEFORE the
+		// generation check, so a superseded rejected start destroyed the live
+		// replacement. It must now tear down only its own driver and then bail
+		// out on the generation mismatch (no error report, no backoff).
+		hoisted.startDeferreds[0].reject(new Error('late start failure'))
+		await stalePromise
+
+		expect(driver0.destroy).toHaveBeenCalledTimes(1) // stale torn down (no leak)
+		expect(driver1.destroy).not.toHaveBeenCalled() // replacement retained
+		expect(state.driver).toBe(driver1) // host still points at replacement
+		expect(host.onDriverError).not.toHaveBeenCalled() // stale error swallowed
+		expect(host.restart).not.toHaveBeenCalled() // no stale backoff restart
+	})
+})
+
+// ===========================================================================
+// connect() — final logConfig override (finding 4)
+// ===========================================================================
+
+describe('DriverLifecycle — final logConfig override', () => {
+	it('a documented zwave.options.logConfig override still receives the JSON transport, extra transports and bumped level', async () => {
+		// A user-supplied `zwave.options.logConfig` (merged via Object.assign)
+		// REPLACES the log-config object reference. The required JSON transport
+		// (debug-socket forwarding) and every registered extra transport must
+		// still land on that FINAL object, and the most-verbose extra level must
+		// win over the override's level.
+		const { lifecycle } = createHarness({
+			serverEnabled: false,
+			options: { logConfig: { level: 'error' } } as any,
+		})
+		const extra = { id: 'extra-forwarder' }
+		lifecycle.addExtraLogTransport(extra, 'debug')
+
+		await lifecycle.connect()
+
+		const passedLogConfig = hoisted.drivers[0].options.logConfig
+		const jsonTransport = hoisted.logTransports[0]
+		expect(jsonTransport).toBeDefined()
+		// required JSON transport survived the override replacing the object
+		expect(passedLogConfig.transports).toContain(jsonTransport)
+		// registered extra transport survived too
+		expect(passedLogConfig.transports).toContain(extra)
+		// the extra transport's more-verbose 'debug' won over the override 'error'
+		expect(passedLogConfig.level).toBe('debug')
+	})
+
+	it('a zwave.options.logConfig override with no extra transports still receives the JSON transport', async () => {
+		const { lifecycle } = createHarness({
+			serverEnabled: false,
+			options: { logConfig: { level: 'warn' } } as any,
+		})
+
+		await lifecycle.connect()
+
+		const passedLogConfig = hoisted.drivers[0].options.logConfig
+		const jsonTransport = hoisted.logTransports[0]
+		expect(passedLogConfig.transports).toEqual([jsonTransport])
+		// no extra transport → the override's own level is preserved
+		expect(passedLogConfig.level).toBe('warn')
 	})
 })
 

--- a/test/lib/zwave/DriverLifecycle.test.ts
+++ b/test/lib/zwave/DriverLifecycle.test.ts
@@ -19,14 +19,14 @@ import {
 	DriverLifecycle,
 	type DriverLifecycleHost,
 	type DriverLifecycleDeps,
-} from '../../../api/lib/zwave/DriverLifecycle.ts'
-import type ZwaveServerManager from '../../../api/hass/ZwaveServerManager.ts'
-import type { ZwaveServerHost } from '../../../api/hass/ZwaveServerManager.ts'
+} from '#api/lib/zwave/DriverLifecycle.ts'
+import type ZwaveServerManager from '#api/hass/ZwaveServerManager.ts'
+import type { ZwaveServerHost } from '#api/hass/ZwaveServerManager.ts'
 import type {
 	ZwaveConfig,
 	InclusionUserCallbacks,
-} from '../../../api/lib/zwave/ports.ts'
-import { ZwaveClientStatus } from '../../../api/lib/zwave/ports.ts'
+} from '#api/lib/zwave/ports.ts'
+import { ZwaveClientStatus } from '#api/lib/zwave/ports.ts'
 
 type StartBehavior = 'resolve' | 'reject' | 'hang' | 'deferred'
 type DestroyBehavior = 'resolve' | 'reject' | 'deferred'

--- a/test/lib/zwave/DriverLifecycle.test.ts
+++ b/test/lib/zwave/DriverLifecycle.test.ts
@@ -1,0 +1,1050 @@
+/* eslint-disable @typescript-eslint/unbound-method */
+/**
+ * Direct state-machine tests for the extracted {@link DriverLifecycle}
+ * service (`api/lib/zwave/DriverLifecycle.ts`).
+ *
+ * The service owns the low-level lifecycle of a single `zwave-js` `Driver`
+ * on behalf of `ZwaveClient`: driver creation/options, log-transport
+ * injection, the `@zwave-js/server` coordination, retry/backoff timers,
+ * statistics, idempotent teardown, and a monotonic **generation** counter
+ * that fences late `driver ready`/`error`/OTW callbacks from an obsolete
+ * driver so they can never mutate a replacement generation's state.
+ *
+ * Everything the service needs from `ZwaveClient` is reached through the
+ * narrow {@link DriverLifecycleHost} port, so these tests drive the service
+ * with a fully-faked host whose accessors read/write a small mutable state
+ * object — exactly mirroring how the real client is wired. `zwave-js`'s
+ * `Driver` is replaced with a faithful `EventEmitter` fake so the real
+ * `connect()` body runs verbatim (real option building, real event wiring),
+ * and `@zwave-js/server` + `utils.ensureDir` are stubbed so no real server
+ * binds a port and no directory is written to disk.
+ *
+ * The complementary end-to-end flow (real `connect()` → driver-ready →
+ * `_onDriverReady()` → server start → `close()` through the `ZwaveClient`
+ * facade) is characterized in `test/lib/hass/server.test.ts`; the generation
+ * fencing of a late `_onDriverReady()` is additionally exercised through the
+ * facade there and in the socket production-integration suite.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { ZWaveError, ZWaveErrorCodes } from '@zwave-js/core'
+
+import type { DriverLifecycleHost } from '../../../api/lib/zwave/DriverLifecycle.ts'
+import type {
+	ZwaveConfig,
+	InclusionUserCallbacks,
+} from '../../../api/lib/zwave/ports.ts'
+import { ZwaveClientStatus } from '../../../api/lib/zwave/ports.ts'
+
+// ---------------------------------------------------------------------------
+// Module mocks
+// ---------------------------------------------------------------------------
+
+// Plain, class-free holders the (lazy) `vi.mock` factories push into. Reset in
+// `beforeEach`. `vi.hoisted` guarantees they exist before any factory runs.
+const hoisted = vi.hoisted(() => ({
+	drivers: [] as any[],
+	destroyOrder: [] as string[],
+	/** 'resolve' | 'reject' | 'hang' — how the fake `driver.start()` behaves. */
+	startBehavior: 'resolve' as 'resolve' | 'reject' | 'hang',
+	/** Error thrown by `driver.start()` when `startBehavior === 'reject'`. */
+	startError: new Error('start failed'),
+	/** Synchronous hook invoked at the very start of `driver.start()`. */
+	startHook: null as null | (() => void),
+	/** Synchronous hook invoked inside the stubbed `utils.ensureDir`. */
+	ensureDirHook: null as null | (() => void),
+	/** When true, the fake `driver.destroy()` rejects. */
+	destroyRejects: false,
+	/** Every fake JSON log transport constructed (to drive its `data` stream). */
+	logTransports: [] as any[],
+}))
+
+// Faithful `zwave-js` Driver fake. Only `Driver` is replaced; every other
+// named export is preserved via `importActual`. Extends EventEmitter so the
+// production code can wire the real event handlers; `start()` honours the
+// controllable behavior; `destroy()` records teardown order.
+vi.mock('zwave-js', async () => {
+	const actual = await vi.importActual<any>('zwave-js')
+	const { EventEmitter } = await import('node:events')
+
+	class FakeController extends EventEmitter {
+		homeId = 0xcafebabe
+		ownNodeId = 1
+		nodes = new Map()
+	}
+
+	class FakeDriver extends EventEmitter {
+		controller = new FakeController()
+		port: any
+		options: any
+		start = vi.fn(() => {
+			hoisted.startHook?.()
+			if (hoisted.startBehavior === 'reject') {
+				return Promise.reject(hoisted.startError)
+			}
+			if (hoisted.startBehavior === 'hang') {
+				return new Promise<void>(() => {
+					/* never resolves */
+				})
+			}
+			return Promise.resolve()
+		})
+		destroy = vi.fn(() => {
+			hoisted.destroyOrder.push('driver')
+			if (hoisted.destroyRejects) {
+				return Promise.reject(new Error('destroy failed'))
+			}
+			return Promise.resolve()
+		})
+		enableStatistics = vi.fn()
+		disableStatistics = vi.fn()
+		updateLogConfig = vi.fn()
+
+		constructor(port: any, options: any) {
+			super()
+			this.port = port
+			this.options = options
+			hoisted.drivers.push(this)
+		}
+	}
+
+	return { ...actual, Driver: FakeDriver }
+})
+
+// Minimal `@zwave-js/server` stub so the lazily-built fallback
+// `ZwaveServerManager` never constructs a real HTTP server / binds a port.
+vi.mock('@zwave-js/server', async () => {
+	const { EventEmitter } = await import('node:events')
+	class ZwavejsServerMock extends EventEmitter {
+		server: any = undefined
+		start = vi.fn(() => {
+			this.server = {}
+			return Promise.resolve()
+		})
+		destroy = vi.fn(() => Promise.resolve())
+		constructor(
+			public driver: any,
+			public options: any,
+		) {
+			super()
+		}
+	}
+	return { serverVersion: '0.0.0-test', ZwavejsServer: ZwavejsServerMock }
+})
+
+// Fake JSON log transport whose `.stream` is an EventEmitter we can drive, so
+// the production `stream.on('data', ...)` → `host.emitDebug(...)` wiring can be
+// exercised without a real driver logging pipeline.
+vi.mock('@zwave-js/log-transport-json', async () => {
+	const { EventEmitter } = await import('node:events')
+	class JSONTransportMock {
+		format: any = undefined
+		stream = new EventEmitter()
+		constructor() {
+			hoisted.logTransports.push(this)
+		}
+	}
+	return { JSONTransport: JSONTransportMock }
+})
+
+// Stub only `utils.ensureDir` (avoids a real mkdir side effect and gives a
+// hook to fence the generation mid-`await`). Every other util is real.
+vi.mock('../../../api/lib/utils.ts', async () => {
+	const actual = await vi.importActual<any>('../../../api/lib/utils.ts')
+	return {
+		...actual,
+		ensureDir: vi.fn(() => {
+			hoisted.ensureDirHook?.()
+			return Promise.resolve()
+		}),
+	}
+})
+
+// Import AFTER the mocks are registered.
+const { DriverLifecycle } = await import(
+	'../../../api/lib/zwave/DriverLifecycle.ts'
+)
+
+// ---------------------------------------------------------------------------
+// Fake host
+// ---------------------------------------------------------------------------
+
+interface HarnessState {
+	cfg: ZwaveConfig
+	driver: any
+	driverReady: boolean
+	driverReadyRaw: boolean
+	closed: boolean
+	destroyed: boolean
+	status: ZwaveClientStatus | undefined
+	connectedClients: boolean
+	userCallbacks: InclusionUserCallbacks
+}
+
+function createHarness(cfgOverrides: Partial<ZwaveConfig> = {}) {
+	const state: HarnessState = {
+		cfg: {
+			enabled: true,
+			port: 'tcp://localhost:5555',
+			...cfgOverrides,
+		} as ZwaveConfig,
+		driver: null,
+		driverReady: false,
+		driverReadyRaw: false,
+		closed: false,
+		destroyed: false,
+		status: undefined,
+		connectedClients: false,
+		userCallbacks: {} as InclusionUserCallbacks,
+	}
+
+	const serverHost = {
+		getDriver: () => state.driver,
+		getConfig: () => state.cfg,
+		getHasUserCallbacks: () => false,
+		onHardReset: vi.fn(),
+		logger: {
+			error: vi.fn(),
+			warn: vi.fn(),
+			info: vi.fn(),
+			debug: vi.fn(),
+		},
+		serverLogger: {
+			error: vi.fn(),
+			warn: vi.fn(),
+			info: vi.fn(),
+			debug: vi.fn(),
+		},
+	}
+
+	const host: DriverLifecycleHost = {
+		getConfig: () => state.cfg,
+		getDriver: () => state.driver,
+		setDriver: (d) => {
+			state.driver = d
+		},
+		isDriverReady: () => state.driverReady,
+		isDriverReadyRaw: () => state.driverReadyRaw,
+		isClosed: () => state.closed,
+		setClosed: (c) => {
+			state.closed = c
+		},
+		isDestroyed: () => state.destroyed,
+		setStatus: (s) => {
+			state.status = s
+		},
+		setDriverReady: (r) => {
+			state.driverReady = r
+		},
+		hasConnectedClients: vi.fn(() =>
+			Promise.resolve(state.connectedClients),
+		),
+		emitDebug: vi.fn(),
+		getInclusionUserCallbacks: vi.fn(() => state.userCallbacks),
+		installUserCallbacks: vi.fn(),
+		persistConfig: vi.fn(async () => {}),
+		restart: vi.fn(async () => {}),
+		buildServerHost: vi.fn(() => serverHost as any),
+		clearRuntimeOnClose: vi.fn(),
+		finalizeClose: vi.fn(),
+		onDriverReady: vi.fn(async () => {}),
+		onDriverError: vi.fn(),
+		onScanComplete: vi.fn(),
+		onBootLoaderReady: vi.fn(),
+		onOTWFirmwareUpdateProgress: vi.fn(),
+		onOTWFirmwareUpdateFinished: vi.fn(),
+	}
+
+	const lifecycle = new DriverLifecycle(host)
+	return { lifecycle, host, state, serverHost }
+}
+
+/** A fake adopted server manager that records its destroy into the order log. */
+function fakeManager() {
+	return {
+		create: vi.fn(),
+		startIfNeeded: vi.fn(),
+		destroy: vi.fn(() => {
+			hoisted.destroyOrder.push('server')
+			return Promise.resolve()
+		}),
+		server: null as any,
+	}
+}
+
+/** Flush pending microtasks. */
+const flush = () => Promise.resolve()
+
+beforeEach(() => {
+	hoisted.drivers.length = 0
+	hoisted.destroyOrder.length = 0
+	hoisted.startBehavior = 'resolve'
+	hoisted.startError = new Error('start failed')
+	hoisted.startHook = null
+	hoisted.ensureDirHook = null
+	hoisted.destroyRejects = false
+	hoisted.logTransports.length = 0
+	delete process.env.ZWAVE_PORT
+})
+
+// ===========================================================================
+// Server coordination
+// ===========================================================================
+
+describe('DriverLifecycle — @zwave-js/server coordination', () => {
+	it('adoptServerManager stores the manager and serverManager returns it', () => {
+		const { lifecycle } = createHarness()
+		const mgr = fakeManager()
+		expect(lifecycle.serverManager).toBeUndefined()
+		lifecycle.adoptServerManager(mgr as any)
+		expect(lifecycle.serverManager).toBe(mgr)
+		expect(lifecycle.zwaveServer).toBe(mgr)
+	})
+
+	it('zwaveServer lazily builds a fallback manager once and caches it', () => {
+		const { lifecycle, host } = createHarness()
+		const first = lifecycle.zwaveServer
+		expect(first).toBeDefined()
+		// cached — same instance, host.buildServerHost only used once
+		expect(lifecycle.zwaveServer).toBe(first)
+		expect(host.buildServerHost).toHaveBeenCalledTimes(1)
+	})
+
+	it('server get/set delegate through the (lazy) manager', () => {
+		const { lifecycle } = createHarness()
+		const sentinel = {} as any
+		lifecycle.server = sentinel
+		expect(lifecycle.server).toBe(sentinel)
+	})
+
+	it('createServer() calls create() on the current manager', () => {
+		const { lifecycle } = createHarness()
+		const mgr = fakeManager()
+		lifecycle.adoptServerManager(mgr as any)
+		lifecycle.createServer()
+		expect(mgr.create).toHaveBeenCalledTimes(1)
+	})
+})
+
+// ===========================================================================
+// Statistics
+// ===========================================================================
+
+describe('DriverLifecycle — statistics', () => {
+	it('enableStatistics enables on the driver and always warns', () => {
+		const { lifecycle, state } = createHarness({ serverEnabled: false })
+		const driver = { enableStatistics: vi.fn() }
+		state.driver = driver
+		lifecycle.enableStatistics()
+		expect(driver.enableStatistics).toHaveBeenCalledTimes(1)
+		const arg = driver.enableStatistics.mock.calls[0][0]
+		expect(arg.applicationName).not.toContain('zwave-js-server')
+	})
+
+	it('enableStatistics applicationName includes zwave-js-server when serverEnabled', () => {
+		const { lifecycle, state } = createHarness({ serverEnabled: true })
+		const driver = { enableStatistics: vi.fn() }
+		state.driver = driver
+		lifecycle.enableStatistics()
+		const arg = driver.enableStatistics.mock.calls[0][0]
+		expect(arg.applicationName).toContain('zwave-js-server')
+	})
+
+	it('enableStatistics with no driver does not throw', () => {
+		const { lifecycle } = createHarness()
+		expect(() => lifecycle.enableStatistics()).not.toThrow()
+	})
+
+	it('disableStatistics disables on the driver', () => {
+		const { lifecycle, state } = createHarness()
+		const driver = { disableStatistics: vi.fn() }
+		state.driver = driver
+		lifecycle.disableStatistics()
+		expect(driver.disableStatistics).toHaveBeenCalledTimes(1)
+	})
+
+	it('disableStatistics with no driver does not throw', () => {
+		const { lifecycle } = createHarness()
+		expect(() => lifecycle.disableStatistics()).not.toThrow()
+	})
+})
+
+// ===========================================================================
+// Extra log transports
+// ===========================================================================
+
+describe('DriverLifecycle — extra log transports', () => {
+	it('addExtraLogTransport applies immediately when the driver is ready (with level)', () => {
+		const { lifecycle, state } = createHarness()
+		const driver = { updateLogConfig: vi.fn() }
+		state.driver = driver
+		state.driverReadyRaw = true
+		const transport = { id: 't1' }
+		lifecycle.addExtraLogTransport(transport, 'debug')
+		expect(driver.updateLogConfig).toHaveBeenCalledWith({
+			transports: [transport],
+			level: 'debug',
+		})
+	})
+
+	it('addExtraLogTransport without a level omits the level key', () => {
+		const { lifecycle, state } = createHarness()
+		const driver = { updateLogConfig: vi.fn() }
+		state.driver = driver
+		state.driverReadyRaw = true
+		const transport = { id: 't2' }
+		lifecycle.addExtraLogTransport(transport)
+		expect(driver.updateLogConfig).toHaveBeenCalledWith({
+			transports: [transport],
+		})
+	})
+
+	it('addExtraLogTransport does not touch the driver when not ready', () => {
+		const { lifecycle, state } = createHarness()
+		const driver = { updateLogConfig: vi.fn() }
+		state.driver = driver
+		state.driverReadyRaw = false
+		lifecycle.addExtraLogTransport({ id: 't3' })
+		expect(driver.updateLogConfig).not.toHaveBeenCalled()
+	})
+
+	it('removeExtraLogTransport removes a registered transport and clears on the driver', () => {
+		const { lifecycle, state } = createHarness()
+		const driver = { updateLogConfig: vi.fn() }
+		state.driver = driver
+		state.driverReadyRaw = true
+		const transport = { id: 't4' }
+		lifecycle.addExtraLogTransport(transport)
+		driver.updateLogConfig.mockClear()
+		lifecycle.removeExtraLogTransport(transport)
+		expect(driver.updateLogConfig).toHaveBeenCalledWith({ transports: [] })
+	})
+
+	it('removeExtraLogTransport for an unknown transport still clears when ready', () => {
+		const { lifecycle, state } = createHarness()
+		const driver = { updateLogConfig: vi.fn() }
+		state.driver = driver
+		state.driverReadyRaw = true
+		lifecycle.removeExtraLogTransport({ id: 'unknown' })
+		expect(driver.updateLogConfig).toHaveBeenCalledWith({ transports: [] })
+	})
+})
+
+// ===========================================================================
+// Backoff / destroyed helpers
+// ===========================================================================
+
+describe('DriverLifecycle — backoff restart & checkIfDestroyed', () => {
+	beforeEach(() => vi.useFakeTimers())
+	afterEach(() => vi.useRealTimers())
+
+	it('backoffRestart schedules restart with exponential delay and increments the retry', async () => {
+		const { lifecycle, host } = createHarness()
+		lifecycle.backoffRestart()
+		// first retry: 2^0 * 1000 = 1000ms
+		expect(host.restart).not.toHaveBeenCalled()
+		await vi.advanceTimersByTimeAsync(1000)
+		expect(host.restart).toHaveBeenCalledTimes(1)
+
+		lifecycle.backoffRestart()
+		// second retry: 2^1 * 1000 = 2000ms
+		await vi.advanceTimersByTimeAsync(1999)
+		expect(host.restart).toHaveBeenCalledTimes(1)
+		await vi.advanceTimersByTimeAsync(1)
+		expect(host.restart).toHaveBeenCalledTimes(2)
+	})
+
+	it('resetBackoff resets the exponential counter back to the first delay', async () => {
+		const { lifecycle, host } = createHarness()
+		lifecycle.backoffRestart() // retry -> 1
+		await vi.advanceTimersByTimeAsync(1000)
+		lifecycle.backoffRestart() // retry -> 2 (2000ms)
+		await vi.advanceTimersByTimeAsync(2000)
+		expect(host.restart).toHaveBeenCalledTimes(2)
+
+		lifecycle.resetBackoff()
+		lifecycle.backoffRestart()
+		// back to 2^0 * 1000 = 1000ms
+		await vi.advanceTimersByTimeAsync(1000)
+		expect(host.restart).toHaveBeenCalledTimes(3)
+	})
+
+	it('backoffRestart aborts (and closes) when the client is already destroyed', async () => {
+		const { lifecycle, host, state } = createHarness()
+		state.destroyed = true
+		lifecycle.backoffRestart()
+		await vi.advanceTimersByTimeAsync(20000)
+		expect(host.restart).not.toHaveBeenCalled()
+		// checkIfDestroyed() triggers an idempotent close(true)
+		expect(host.setStatus).toBeDefined()
+		expect(state.status).toBe(ZwaveClientStatus.CLOSED)
+	})
+
+	it('checkIfDestroyed returns true and closes when destroyed', () => {
+		const { lifecycle, state, host } = createHarness()
+		state.destroyed = true
+		expect(lifecycle.checkIfDestroyed()).toBe(true)
+		expect(host.setClosed).toBeDefined()
+		expect(state.closed).toBe(true)
+	})
+
+	it('checkIfDestroyed returns false when not destroyed', () => {
+		const { lifecycle } = createHarness()
+		expect(lifecycle.checkIfDestroyed()).toBe(false)
+	})
+})
+
+// ===========================================================================
+// connect() — early-return guards
+// ===========================================================================
+
+describe('DriverLifecycle — connect early returns', () => {
+	it('does nothing when the driver is disabled', async () => {
+		const { lifecycle } = createHarness({ enabled: false })
+		await lifecycle.connect()
+		expect(hoisted.drivers).toHaveLength(0)
+		expect(lifecycle.generation).toBe(0)
+	})
+
+	it('does nothing when a driver is already ready', async () => {
+		const { lifecycle, state } = createHarness()
+		state.driverReady = true
+		await lifecycle.connect()
+		expect(hoisted.drivers).toHaveLength(0)
+	})
+
+	it('does nothing when the client is already closed', async () => {
+		const { lifecycle, state } = createHarness()
+		state.closed = true
+		await lifecycle.connect()
+		expect(hoisted.drivers).toHaveLength(0)
+	})
+
+	it('does nothing when no port is configured', async () => {
+		const { lifecycle } = createHarness({ port: undefined })
+		await lifecycle.connect()
+		expect(hoisted.drivers).toHaveLength(0)
+		expect(lifecycle.generation).toBe(0)
+	})
+
+	it('honours the ZWAVE_PORT env override (force-enables + overrides port)', async () => {
+		process.env.ZWAVE_PORT = 'tcp://override:5555'
+		const { lifecycle, state } = createHarness({ enabled: false })
+		await lifecycle.connect()
+		expect(state.cfg.enabled).toBe(true)
+		expect(state.cfg.port).toBe('tcp://override:5555')
+		expect(hoisted.drivers).toHaveLength(1)
+		expect(hoisted.drivers[0].port).toBe('tcp://override:5555')
+	})
+})
+
+// ===========================================================================
+// connect() — happy path & option building
+// ===========================================================================
+
+describe('DriverLifecycle — connect happy path', () => {
+	it('creates a driver, wires all six events, starts it and sets CONNECTED', async () => {
+		const { lifecycle, state } = createHarness({ serverEnabled: false })
+		await lifecycle.connect()
+
+		expect(lifecycle.generation).toBe(1)
+		expect(hoisted.drivers).toHaveLength(1)
+		const driver = hoisted.drivers[0]
+		expect(driver.start).toHaveBeenCalledTimes(1)
+		expect(state.driver).toBe(driver)
+		expect(state.status).toBe(ZwaveClientStatus.CONNECTED)
+		// six driver events wired
+		for (const evt of [
+			'error',
+			'driver ready',
+			'all nodes ready',
+			'bootloader ready',
+			'firmware update progress',
+			'firmware update finished',
+		]) {
+			expect(driver.listenerCount(evt)).toBe(1)
+		}
+	})
+
+	it('installs user callbacks only when clients are connected', async () => {
+		const { lifecycle, host, state } = createHarness()
+		state.connectedClients = true
+		await lifecycle.connect()
+		expect(host.installUserCallbacks).toHaveBeenCalledTimes(1)
+	})
+
+	it('does NOT install user callbacks when no clients are connected', async () => {
+		const { lifecycle, host, state } = createHarness()
+		state.connectedClients = false
+		await lifecycle.connect()
+		expect(host.installUserCallbacks).not.toHaveBeenCalled()
+	})
+
+	it('creates the server when serverEnabled', async () => {
+		const { lifecycle } = createHarness({ serverEnabled: true })
+		const mgr = fakeManager()
+		lifecycle.adoptServerManager(mgr as any)
+		await lifecycle.connect()
+		expect(mgr.create).toHaveBeenCalledTimes(1)
+	})
+
+	it('enables statistics on connect when configured', async () => {
+		const { lifecycle } = createHarness({
+			serverEnabled: false,
+			enableStatistics: true,
+		})
+		await lifecycle.connect()
+		expect(hoisted.drivers[0].enableStatistics).toHaveBeenCalledTimes(1)
+	})
+
+	it('passes the inclusion user callbacks into driver options when server disabled', async () => {
+		const { lifecycle, host } = createHarness({ serverEnabled: false })
+		await lifecycle.connect()
+		expect(host.getInclusionUserCallbacks).toHaveBeenCalled()
+		expect(hoisted.drivers[0].options.inclusionUserCallbacks).toBeDefined()
+	})
+
+	it('does not pass inclusion user callbacks when the server is enabled', async () => {
+		const { lifecycle } = createHarness({ serverEnabled: true })
+		const mgr = fakeManager()
+		lifecycle.adoptServerManager(mgr as any)
+		await lifecycle.connect()
+		expect(
+			hoisted.drivers[0].options.inclusionUserCallbacks,
+		).toBeUndefined()
+	})
+
+	it('applies the soft-reset feature flag when explicitly configured', async () => {
+		const { lifecycle } = createHarness({
+			serverEnabled: false,
+			enableSoftReset: false,
+		})
+		await lifecycle.connect()
+		expect(hoisted.drivers[0].options.features.softReset).toBe(false)
+	})
+
+	it('maps rf auto power levels when autoPowerlevels is inferred true', async () => {
+		const { lifecycle, host } = createHarness({
+			serverEnabled: false,
+			rf: { region: 1 } as any,
+		})
+		await lifecycle.connect()
+		const rf = hoisted.drivers[0].options.rf
+		expect(rf.region).toBe(1)
+		expect(rf.maxLongRangePowerlevel).toBe('auto')
+		expect(rf.txPower.powerlevel).toBe('auto')
+		// inferred default is persisted
+		expect(host.persistConfig).toHaveBeenCalled()
+	})
+
+	it('maps explicit rf power levels when autoPowerlevels is false', async () => {
+		const { lifecycle } = createHarness({
+			serverEnabled: false,
+			rf: {
+				region: 2,
+				autoPowerlevels: false,
+				maxLongRangePowerlevel: 10,
+				txPower: { powerlevel: 5, measured0dBm: 1 },
+			} as any,
+		})
+		await lifecycle.connect()
+		const rf = hoisted.drivers[0].options.rf
+		expect(rf.maxLongRangePowerlevel).toBe(10)
+		expect(rf.txPower.powerlevel).toBe(5)
+		expect(rf.txPower.measured0dBm).toBe(1)
+	})
+
+	it('migrates a legacy networkKey to securityKeys.S0_Legacy and persists', async () => {
+		const { lifecycle, host, state } = createHarness({
+			serverEnabled: false,
+			networkKey: '0102030405060708090A0B0C0D0E0F10',
+		} as any)
+		await lifecycle.connect()
+		expect(state.cfg.securityKeys?.S0_Legacy).toBe(
+			'0102030405060708090A0B0C0D0E0F10',
+		)
+		expect((state.cfg as any).networkKey).toBeUndefined()
+		expect(host.persistConfig).toHaveBeenCalled()
+	})
+
+	it('merges hidden cfg.options into the driver options', async () => {
+		const { lifecycle } = createHarness({
+			serverEnabled: false,
+			options: { testMarker: 42 } as any,
+		})
+		await lifecycle.connect()
+		expect(hoisted.drivers[0].options.testMarker).toBe(42)
+	})
+})
+
+// ===========================================================================
+// connect() — error handling
+// ===========================================================================
+
+describe('DriverLifecycle — connect error handling', () => {
+	it('on a generic start failure: destroys the driver, reports the error and backs off', async () => {
+		vi.useFakeTimers()
+		try {
+			const { lifecycle, host } = createHarness({ serverEnabled: false })
+			hoisted.startBehavior = 'reject'
+			hoisted.startError = new Error('boom')
+			await lifecycle.connect()
+			expect(hoisted.drivers[0].destroy).toHaveBeenCalled()
+			expect(host.onDriverError).toHaveBeenCalledWith(
+				expect.any(Error),
+				true,
+			)
+			// backoff scheduled
+			await vi.advanceTimersByTimeAsync(1000)
+			expect(host.restart).toHaveBeenCalledTimes(1)
+		} finally {
+			vi.useRealTimers()
+		}
+	})
+
+	it('on Driver_InvalidOptions: reports the error but does NOT back off', async () => {
+		vi.useFakeTimers()
+		try {
+			const { lifecycle, host } = createHarness({ serverEnabled: false })
+			hoisted.startBehavior = 'reject'
+			hoisted.startError = new ZWaveError(
+				'bad options',
+				ZWaveErrorCodes.Driver_InvalidOptions,
+			)
+			await lifecycle.connect()
+			expect(host.onDriverError).toHaveBeenCalledWith(
+				expect.any(ZWaveError),
+				true,
+			)
+			await vi.advanceTimersByTimeAsync(20000)
+			expect(host.restart).not.toHaveBeenCalled()
+		} finally {
+			vi.useRealTimers()
+		}
+	})
+})
+
+// ===========================================================================
+// connect() — generation fencing
+// ===========================================================================
+
+describe('DriverLifecycle — connect generation fencing', () => {
+	it('aborts before driver creation when the generation changes during ensureDir', async () => {
+		const { lifecycle, state } = createHarness()
+		hoisted.ensureDirHook = () => {
+			// simulate a concurrent close() bumping the generation
+			void lifecycle.close()
+		}
+		await lifecycle.connect()
+		// close() ran; no driver was created for the obsolete generation
+		expect(hoisted.drivers).toHaveLength(0)
+		expect(state.status).toBe(ZwaveClientStatus.CLOSED)
+	})
+
+	it('aborts before driver.start when the generation changes during hasConnectedClients', async () => {
+		const { lifecycle, host } = createHarness()
+		;(host.hasConnectedClients as any).mockImplementation(() => {
+			void lifecycle.close()
+			return Promise.resolve(false)
+		})
+		await lifecycle.connect()
+		// driver was constructed but start() never ran (fenced right after)
+		expect(hoisted.drivers).toHaveLength(1)
+		expect(hoisted.drivers[0].start).not.toHaveBeenCalled()
+	})
+
+	it('aborts after driver.start when the generation changes during start()', async () => {
+		const { lifecycle, state } = createHarness({ serverEnabled: false })
+		hoisted.startHook = () => {
+			void lifecycle.close()
+		}
+		await lifecycle.connect()
+		// start ran, but CONNECTED was never set on the obsolete generation
+		expect(hoisted.drivers[0].start).toHaveBeenCalled()
+		expect(state.status).toBe(ZwaveClientStatus.CLOSED)
+	})
+
+	it('aborts when the generation changes during persistConfig', async () => {
+		const { lifecycle, host } = createHarness({
+			serverEnabled: false,
+			rf: { region: 1 } as any, // forces shouldUpdateSettings -> persistConfig
+		})
+		;(host.persistConfig as any).mockImplementation(() => {
+			void lifecycle.close()
+			return Promise.resolve()
+		})
+		await lifecycle.connect()
+		// fenced right after persistConfig — no driver created
+		expect(hoisted.drivers).toHaveLength(0)
+	})
+})
+
+// ===========================================================================
+// close()
+// ===========================================================================
+
+describe('DriverLifecycle — close', () => {
+	it('bumps the generation, transitions to CLOSED and clears runtime state', async () => {
+		const { lifecycle, host, state } = createHarness()
+		await lifecycle.connect()
+		const genBefore = lifecycle.generation
+		await lifecycle.close()
+		expect(lifecycle.generation).toBe(genBefore + 1)
+		expect(state.status).toBe(ZwaveClientStatus.CLOSED)
+		expect(state.closed).toBe(true)
+		expect(state.driverReady).toBe(false)
+		expect(host.clearRuntimeOnClose).toHaveBeenCalledTimes(1)
+		expect(host.finalizeClose).toHaveBeenCalledTimes(1)
+		expect(state.driver).toBeNull()
+	})
+
+	it('destroys the server BEFORE the driver', async () => {
+		const { lifecycle } = createHarness({ serverEnabled: true })
+		const mgr = fakeManager()
+		lifecycle.adoptServerManager(mgr as any)
+		await lifecycle.connect()
+		await lifecycle.close()
+		expect(hoisted.destroyOrder).toEqual(['server', 'driver'])
+	})
+
+	it('does not finalize (keep listeners) when keepListeners is true', async () => {
+		const { lifecycle, host } = createHarness()
+		await lifecycle.connect()
+		await lifecycle.close(true)
+		expect(host.finalizeClose).not.toHaveBeenCalled()
+	})
+
+	it('clears a pending backoff restart timer', async () => {
+		vi.useFakeTimers()
+		try {
+			const { lifecycle, host } = createHarness()
+			lifecycle.backoffRestart()
+			await lifecycle.close()
+			await vi.advanceTimersByTimeAsync(20000)
+			expect(host.restart).not.toHaveBeenCalled()
+		} finally {
+			vi.useRealTimers()
+		}
+	})
+
+	it('is idempotent and safe to call with no driver or server', async () => {
+		const { lifecycle } = createHarness()
+		await expect(lifecycle.close()).resolves.toBeUndefined()
+		await expect(lifecycle.close()).resolves.toBeUndefined()
+		expect(hoisted.destroyOrder).toEqual([])
+	})
+})
+
+// ===========================================================================
+// Generation-guarded driver-event dispatch
+// ===========================================================================
+
+describe('DriverLifecycle — driver-event dispatch', () => {
+	it('forwards every driver event to the host with the current generation', async () => {
+		const { lifecycle, host } = createHarness({ serverEnabled: false })
+		await lifecycle.connect()
+		const driver = hoisted.drivers[0]
+
+		driver.emit('driver ready')
+		await flush()
+		expect(host.onDriverReady).toHaveBeenCalledWith(lifecycle.generation)
+
+		const err = new Error('driver error')
+		driver.emit('error', err)
+		expect(host.onDriverError).toHaveBeenCalledWith(err, false)
+
+		driver.emit('all nodes ready')
+		expect(host.onScanComplete).toHaveBeenCalledTimes(1)
+
+		driver.emit('bootloader ready')
+		expect(host.onBootLoaderReady).toHaveBeenCalledTimes(1)
+
+		const progress = { sentFragments: 1, totalFragments: 10 }
+		driver.emit('firmware update progress', progress)
+		expect(host.onOTWFirmwareUpdateProgress).toHaveBeenCalledWith(progress)
+
+		const result = { success: true }
+		driver.emit('firmware update finished', result)
+		expect(host.onOTWFirmwareUpdateFinished).toHaveBeenCalledWith(result)
+	})
+
+	it('fences a LATE driver-ready from an obsolete generation after close()', async () => {
+		const { lifecycle, host } = createHarness({ serverEnabled: false })
+		await lifecycle.connect()
+		const driver = hoisted.drivers[0]
+		await lifecycle.close() // bumps generation
+
+		host.onDriverReady = vi.fn(async () => {})
+		driver.emit('driver ready')
+		await flush()
+		expect(host.onDriverReady).not.toHaveBeenCalled()
+	})
+
+	it('fences a late error/scan/bootloader/OTW callback after the generation moves on', async () => {
+		const { lifecycle, host } = createHarness({ serverEnabled: false })
+		await lifecycle.connect()
+		const driver = hoisted.drivers[0]
+		await lifecycle.close()
+
+		driver.emit('error', new Error('late'))
+		driver.emit('all nodes ready')
+		driver.emit('bootloader ready')
+		driver.emit('firmware update progress', {})
+		driver.emit('firmware update finished', {})
+
+		expect(host.onDriverError).not.toHaveBeenCalled()
+		expect(host.onScanComplete).not.toHaveBeenCalled()
+		expect(host.onBootLoaderReady).not.toHaveBeenCalled()
+		expect(host.onOTWFirmwareUpdateProgress).not.toHaveBeenCalled()
+		expect(host.onOTWFirmwareUpdateFinished).not.toHaveBeenCalled()
+	})
+})
+
+// ===========================================================================
+// connect() — remaining option/edge coverage
+// ===========================================================================
+
+describe('DriverLifecycle — connect option/edge coverage', () => {
+	it('builds scale preferences from cfg.scales', async () => {
+		const { lifecycle } = createHarness({
+			serverEnabled: false,
+			scales: [{ key: 1, label: 'Celsius' }] as any,
+		})
+		await lifecycle.connect()
+		expect(hoisted.drivers[0].options.preferences).toEqual({
+			scales: { 1: 'Celsius' },
+		})
+	})
+
+	it('injects PkgFsBindings into driver host options when running in a pkg bundle', async () => {
+		const proc = process as NodeJS.Process & { pkg?: unknown }
+		proc.pkg = {}
+		try {
+			const { lifecycle } = createHarness({ serverEnabled: false })
+			await lifecycle.connect()
+			expect(hoisted.drivers[0].options.host?.fs).toBeDefined()
+		} finally {
+			delete proc.pkg
+		}
+	})
+
+	it('merges registered extra log transports and bumps the log level to the most verbose', async () => {
+		const { lifecycle } = createHarness({ serverEnabled: false })
+		const t1 = { id: 'extra-1' }
+		const t2 = { id: 'extra-2' }
+		// register before connect: applied while building driver log options
+		lifecycle.addExtraLogTransport(t1, 'warn')
+		lifecycle.addExtraLogTransport(t2, 'silly')
+		await lifecycle.connect()
+		const logConfig = hoisted.drivers[0].options.logConfig
+		expect(logConfig.transports).toContain(t1)
+		expect(logConfig.transports).toContain(t2)
+		// 'silly' is the most verbose requested level
+		expect(logConfig.level).toBe('silly')
+	})
+
+	it('forwards driver log stream data to host.emitDebug', async () => {
+		const { lifecycle, host } = createHarness({ serverEnabled: false })
+		await lifecycle.connect()
+		const transport = hoisted.logTransports[0]
+		expect(transport).toBeDefined()
+		transport.stream.emit('data', { message: 'hello world' })
+		expect(host.emitDebug).toHaveBeenCalledWith('hello world')
+	})
+
+	it('aborts after start() when the client became destroyed mid-start', async () => {
+		const { lifecycle, state } = createHarness({ serverEnabled: false })
+		hoisted.startHook = () => {
+			state.destroyed = true
+		}
+		await lifecycle.connect()
+		// checkIfDestroyed() fired after start → CONNECTED never set
+		expect(state.status).not.toBe(ZwaveClientStatus.CONNECTED)
+		expect(hoisted.drivers[0].start).toHaveBeenCalled()
+	})
+})
+
+// ===========================================================================
+// connect() — catch-path edge coverage
+// ===========================================================================
+
+describe('DriverLifecycle — connect catch-path edges', () => {
+	it('swallows a driver.destroy() rejection while handling a start failure', async () => {
+		vi.useFakeTimers()
+		try {
+			const { lifecycle, host } = createHarness({ serverEnabled: false })
+			hoisted.startBehavior = 'reject'
+			hoisted.startError = new Error('start boom')
+			hoisted.destroyRejects = true
+			await lifecycle.connect()
+			await flush()
+			// error still reported + backoff still scheduled despite destroy failing
+			expect(host.onDriverError).toHaveBeenCalledWith(
+				expect.any(Error),
+				true,
+			)
+			await vi.advanceTimersByTimeAsync(1000)
+			expect(host.restart).toHaveBeenCalledTimes(1)
+		} finally {
+			vi.useRealTimers()
+		}
+	})
+
+	it('aborts the catch path without reporting when the generation changed', async () => {
+		const { lifecycle, host } = createHarness({ serverEnabled: false })
+		hoisted.startBehavior = 'reject'
+		hoisted.startError = new Error('boom')
+		hoisted.startHook = () => {
+			void lifecycle.close() // bumps generation before the catch runs
+		}
+		await lifecycle.connect()
+		expect(host.onDriverError).not.toHaveBeenCalled()
+	})
+
+	it('aborts the catch path (closing) when the client became destroyed', async () => {
+		const { lifecycle, host, state } = createHarness({
+			serverEnabled: false,
+		})
+		hoisted.startBehavior = 'reject'
+		hoisted.startError = new Error('boom')
+		hoisted.startHook = () => {
+			state.destroyed = true
+		}
+		await lifecycle.connect()
+		// checkIfDestroyed() short-circuits before onDriverError
+		expect(host.onDriverError).not.toHaveBeenCalled()
+		expect(state.closed).toBe(true)
+	})
+})
+
+// ===========================================================================
+// Async failure paths in timers/helpers
+// ===========================================================================
+
+describe('DriverLifecycle — async failure logging', () => {
+	it('logs (and swallows) a restart failure from the backoff timer', async () => {
+		vi.useFakeTimers()
+		try {
+			const { lifecycle, host } = createHarness()
+			;(host.restart as any).mockRejectedValue(new Error('restart boom'))
+			lifecycle.backoffRestart()
+			await vi.advanceTimersByTimeAsync(1000)
+			await flush()
+			expect(host.restart).toHaveBeenCalledTimes(1)
+			// no unhandled rejection — the .catch handled it
+		} finally {
+			vi.useRealTimers()
+		}
+	})
+
+	it('logs (and swallows) a close failure triggered by checkIfDestroyed', async () => {
+		const { lifecycle, state } = createHarness()
+		state.destroyed = true
+		state.driver = {
+			destroy: vi.fn(() => Promise.reject(new Error('destroy boom'))),
+		}
+		expect(lifecycle.checkIfDestroyed()).toBe(true)
+		// let the rejected close() settle; the internal .catch handles it
+		await flush()
+		await flush()
+	})
+})

--- a/test/lib/zwave/DriverLifecycle.test.ts
+++ b/test/lib/zwave/DriverLifecycle.test.ts
@@ -27,14 +27,10 @@ import type {
 	InclusionUserCallbacks,
 } from '#api/lib/zwave/ports.ts'
 import { ZwaveClientStatus } from '#api/lib/zwave/ports.ts'
+import { createDeferred, type Deferred } from './serviceTestSupport.ts'
 
 type StartBehavior = 'resolve' | 'reject' | 'hang' | 'deferred'
 type DestroyBehavior = 'resolve' | 'reject' | 'deferred'
-
-interface Deferred {
-	resolve: () => void
-	reject: (err?: unknown) => void
-}
 
 interface DestroyDeferred {
 	resolve: () => void
@@ -48,7 +44,7 @@ interface World {
 	destroyOrder: string[]
 	startBehavior: StartBehavior
 	startError: Error
-	startDeferreds: Deferred[]
+	startDeferreds: Deferred<void>[]
 	startHook: (() => void) | null
 	ensureDirHook: (() => void) | null
 	destroyBehavior: DestroyBehavior
@@ -83,9 +79,9 @@ class FakeDriver extends EventEmitter {
 				return new Promise<void>(() => {})
 			}
 			if (world.startBehavior === 'deferred') {
-				return new Promise<void>((resolve, reject) => {
-					world.startDeferreds.push({ resolve, reject })
-				})
+				const deferred = createDeferred<void>()
+				world.startDeferreds.push(deferred)
+				return deferred.promise
 			}
 			return Promise.resolve()
 		})
@@ -101,16 +97,16 @@ class FakeDriver extends EventEmitter {
 			}
 
 			if (world.destroyBehavior === 'deferred') {
-				return new Promise<void>((resolve, reject) => {
-					world.destroyDeferreds.push({
-						resolve: () => {
-							recordEffect()
-							resolve()
-						},
-						reject: (err?: Error) =>
-							reject(err ?? new Error('destroy rejected')),
-					})
+				const deferred = createDeferred<void>()
+				world.destroyDeferreds.push({
+					resolve: () => {
+						recordEffect()
+						deferred.resolve()
+					},
+					reject: (err?: Error) =>
+						deferred.reject(err ?? new Error('destroy rejected')),
 				})
+				return deferred.promise
 			}
 
 			if (this._destroyed) {

--- a/test/lib/zwave/DriverLifecycle.test.ts
+++ b/test/lib/zwave/DriverLifecycle.test.ts
@@ -230,7 +230,30 @@ function createHarness(cfgOverrides: Partial<ZwaveConfig> = {}) {
 		userCallbacks: {} as InclusionUserCallbacks,
 	}
 
-	const serverHostStub = {} as unknown as ZwaveServerHost
+	const serverHostStub = {
+		getDriver: () => {
+			if (!state.driver) {
+				throw new Error('Driver is not available')
+			}
+			return state.driver
+		},
+		getConfig: () => state.cfg,
+		getHasUserCallbacks: () => false,
+		onHardReset: vi.fn(),
+		logger: {
+			debug: vi.fn(),
+			info: vi.fn(),
+			warn: vi.fn(),
+			error: vi.fn(),
+			log: vi.fn(),
+		},
+		serverLogger: {
+			debug: vi.fn(),
+			info: vi.fn(),
+			warn: vi.fn(),
+			error: vi.fn(),
+		},
+	} satisfies ZwaveServerHost
 
 	const host = {
 		getConfig: () => state.cfg,
@@ -272,16 +295,6 @@ function createHarness(cfgOverrides: Partial<ZwaveConfig> = {}) {
 
 	const lifecycle = new DriverLifecycle(host, makeDeps(world))
 	return { lifecycle, host, state, world }
-}
-
-async function until(pred: () => boolean, max = 100): Promise<void> {
-	for (let i = 0; i < max; i++) {
-		if (pred()) return
-		await Promise.resolve()
-	}
-	if (!pred()) {
-		throw new Error('until(): condition was not met')
-	}
 }
 
 afterEach(() => {
@@ -902,7 +915,7 @@ describe('DriverLifecycle — pre-ready reconnect coalescing', () => {
 		world.startBehavior = 'deferred'
 
 		const first = lifecycle.connect()
-		await until(() => world.startDeferreds.length === 1)
+		await vi.waitFor(() => expect(world.startDeferreds).toHaveLength(1))
 		expect(world.drivers).toHaveLength(1)
 		const driver0 = world.drivers[0]
 		const gen = lifecycle.generation
@@ -917,7 +930,6 @@ describe('DriverLifecycle — pre-ready reconnect coalescing', () => {
 			secondSettled = true
 		})
 
-		await until(() => world.startDeferreds.length === 1)
 		expect(world.drivers).toHaveLength(1)
 		expect(world.startDeferreds).toHaveLength(1)
 		expect(state.driver).toBe(driver0)
@@ -942,7 +954,7 @@ describe('DriverLifecycle — pre-ready reconnect coalescing', () => {
 		world.startBehavior = 'deferred'
 
 		const first = lifecycle.connect()
-		await until(() => world.startDeferreds.length === 1)
+		await vi.waitFor(() => expect(world.startDeferreds).toHaveLength(1))
 		const driver0 = world.drivers[0]
 
 		let firstSettled = false
@@ -954,7 +966,6 @@ describe('DriverLifecycle — pre-ready reconnect coalescing', () => {
 		void second.then(() => {
 			secondSettled = true
 		})
-		await until(() => world.startDeferreds.length === 1)
 		expect(firstSettled).toBe(false)
 		expect(secondSettled).toBe(false)
 
@@ -1014,7 +1025,7 @@ describe('DriverLifecycle — pre-ready reconnect coalescing', () => {
 		world.startBehavior = 'deferred'
 
 		const stalePromise = harness.lifecycle.connect()
-		await until(() => world.startDeferreds.length === 1)
+		await vi.waitFor(() => expect(world.startDeferreds).toHaveLength(1))
 		const driver0 = world.drivers[0]
 		expect(harness.state.driver).toBe(driver0)
 
@@ -1024,7 +1035,7 @@ describe('DriverLifecycle — pre-ready reconnect coalescing', () => {
 
 		world.startBehavior = 'deferred'
 		const freshPromise = harness.lifecycle.connect()
-		await until(() => world.startDeferreds.length === 2)
+		await vi.waitFor(() => expect(world.startDeferreds).toHaveLength(2))
 		const driver1 = world.drivers[1]
 		world.startDeferreds[1].resolve()
 		await freshPromise
@@ -1074,7 +1085,9 @@ describe('DriverLifecycle — cleanup after a failed connect', () => {
 
 			const connectP = lifecycle.connect()
 
-			await until(() => world.destroyDeferreds.length === 1)
+			await vi.waitFor(() =>
+				expect(world.destroyDeferreds).toHaveLength(1),
+			)
 			expect(world.drivers).toHaveLength(1)
 			const driver0 = world.drivers[0]
 			expect(state.driver).toBe(driver0)
@@ -1082,7 +1095,6 @@ describe('DriverLifecycle — cleanup after a failed connect', () => {
 			expect(host.restart).not.toHaveBeenCalled()
 
 			const concurrent = lifecycle.connect()
-			await until(() => world.destroyDeferreds.length === 1)
 			expect(world.drivers).toHaveLength(1)
 			expect(driver0.start).toHaveBeenCalledTimes(1)
 
@@ -1134,6 +1146,29 @@ describe('DriverLifecycle — cleanup after a failed connect', () => {
 		}
 	})
 
+	it('a non-Error teardown rejection cannot replace the startup failure or prevent a later retry', async () => {
+		const { lifecycle, world, state, host } = createHarness({
+			serverEnabled: false,
+		})
+		const startupError = new Error('start boom')
+		world.startBehavior = 'deferred'
+
+		const connect = lifecycle.connect()
+		await vi.waitFor(() => expect(world.startDeferreds).toHaveLength(1))
+		const driver = world.drivers[0]
+		driver.destroy.mockRejectedValueOnce(undefined)
+		world.startDeferreds[0].reject(startupError)
+		await expect(connect).resolves.toBeUndefined()
+
+		expect(host.onDriverError).toHaveBeenCalledWith(startupError, true)
+		expect(state.driver).toBe(driver)
+		expect(driver.destroy).toHaveBeenCalledTimes(1)
+
+		await expect(lifecycle.close(true)).resolves.toBeUndefined()
+		expect(driver.destroy).toHaveBeenCalledTimes(2)
+		expect(state.driver).toBeNull()
+	})
+
 	it('a stale post-start exit tears down its own driver and never the live replacement', async () => {
 		const { lifecycle, world, state } = createHarness({
 			serverEnabled: false,
@@ -1141,13 +1176,13 @@ describe('DriverLifecycle — cleanup after a failed connect', () => {
 		world.startBehavior = 'deferred'
 
 		const staleP = lifecycle.connect()
-		await until(() => world.startDeferreds.length === 1)
+		await vi.waitFor(() => expect(world.startDeferreds).toHaveLength(1))
 
 		await lifecycle.close(true)
 		state.closed = false
 		world.startBehavior = 'deferred'
 		const freshP = lifecycle.connect()
-		await until(() => world.startDeferreds.length === 2)
+		await vi.waitFor(() => expect(world.startDeferreds).toHaveLength(2))
 		const driver1 = world.drivers[1]
 		world.startDeferreds[1].resolve()
 		await freshP
@@ -1341,7 +1376,7 @@ describe('DriverLifecycle — stale driver events after close', () => {
 		expect(host.onDriverReady).not.toHaveBeenCalled()
 	})
 
-	it('ignores late driver callbacks once the generation has moved on', async () => {
+	it('ignores a late driver error once the generation has moved on', async () => {
 		const { lifecycle, host, world } = createHarness({
 			serverEnabled: false,
 		})
@@ -1350,16 +1385,48 @@ describe('DriverLifecycle — stale driver events after close', () => {
 		await lifecycle.close()
 
 		driver.emit('error', new Error('late'))
-		driver.emit('all nodes ready')
-		driver.emit('bootloader ready')
-		driver.emit('firmware update progress', {})
-		driver.emit('firmware update finished', {})
 
 		expect(host.onDriverError).not.toHaveBeenCalled()
-		expect(host.onScanComplete).not.toHaveBeenCalled()
-		expect(host.onBootLoaderReady).not.toHaveBeenCalled()
-		expect(host.onOTWFirmwareUpdateProgress).not.toHaveBeenCalled()
-		expect(host.onOTWFirmwareUpdateFinished).not.toHaveBeenCalled()
+	})
+})
+
+describe('DriverLifecycle — driver-ready failures', () => {
+	beforeEach(() => vi.useFakeTimers())
+	afterEach(() => vi.useRealTimers())
+
+	it('reports a current driver-ready initialization failure and restarts', async () => {
+		const { lifecycle, host, world } = createHarness({
+			serverEnabled: false,
+		})
+		const readyError = new Error('ready initialization failed')
+		host.onDriverReady.mockRejectedValueOnce(readyError)
+		await lifecycle.connect()
+
+		world.drivers[0].emit('driver ready')
+		await Promise.resolve()
+
+		expect(host.onDriverError).toHaveBeenCalledWith(readyError, true)
+		expect(host.restart).not.toHaveBeenCalled()
+		await vi.advanceTimersByTimeAsync(1000)
+		expect(host.restart).toHaveBeenCalledTimes(1)
+	})
+
+	it('ignores a driver-ready failure after that generation closes', async () => {
+		const { lifecycle, host, world } = createHarness({
+			serverEnabled: false,
+		})
+		const ready = createDeferred<void>()
+		host.onDriverReady.mockReturnValueOnce(ready.promise)
+		await lifecycle.connect()
+
+		world.drivers[0].emit('driver ready')
+		await lifecycle.close()
+		ready.reject(new Error('stale ready failure'))
+		await Promise.resolve()
+
+		expect(host.onDriverError).not.toHaveBeenCalled()
+		await vi.advanceTimersByTimeAsync(60000)
+		expect(host.restart).not.toHaveBeenCalled()
 	})
 })
 
@@ -1367,11 +1434,17 @@ describe('DriverLifecycle — driver options', () => {
 	it('builds scale preferences from cfg.scales', async () => {
 		const { lifecycle, world } = createHarness({
 			serverEnabled: false,
-			scales: [{ key: 1, sensor: 'Air temperature', label: 'Celsius' }],
+			scales: [
+				{
+					key: 'temperature',
+					sensor: 'Air temperature',
+					label: 'Celsius',
+				},
+			],
 		})
 		await lifecycle.connect()
 		expect(world.drivers[0].options.preferences).toEqual({
-			scales: { 1: 'Celsius' },
+			scales: { temperature: 'Celsius' },
 		})
 	})
 

--- a/test/lib/zwave/DriverLifecycle.test.ts
+++ b/test/lib/zwave/DriverLifecycle.test.ts
@@ -1,4 +1,12 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import {
+	describe,
+	it,
+	expect,
+	vi,
+	beforeEach,
+	afterEach,
+	type Mock,
+} from 'vitest'
 import { EventEmitter } from 'node:events'
 import { ZWaveError, ZWaveErrorCodes } from '@zwave-js/core'
 import { RFRegion } from 'zwave-js'
@@ -23,7 +31,7 @@ import { ZwaveClientStatus } from '../../../api/lib/zwave/ports.ts'
 // The lifecycle constructs its Driver, JSON log transport and server manager
 // through injected factories, so every test drives the real production wiring
 // with typed fakes and never module-mocks or reaches into private seams. Casts
-// to the production port types live ONLY at the injection boundary below; the
+// to the production port types live only at the injection boundary below; the
 // `world` recorder keeps the concrete fake types so assertions stay type-safe.
 
 type StartBehavior = 'resolve' | 'reject' | 'hang' | 'deferred'
@@ -62,8 +70,8 @@ class FakeDriver extends EventEmitter {
 	enableStatistics = vi.fn()
 	disableStatistics = vi.fn()
 	updateLogConfig = vi.fn()
-	start!: ReturnType<typeof vi.fn>
-	destroy!: ReturnType<typeof vi.fn>
+	start!: Mock<() => Promise<void>>
+	destroy!: Mock<() => Promise<void>>
 	private _destroyed = false
 
 	constructor(world: World, port: string, options: PartialZWaveOptions) {
@@ -145,7 +153,7 @@ class FakeLogTransport {
 class FakeServerManager {
 	create = vi.fn()
 	startIfNeeded = vi.fn()
-	destroy!: ReturnType<typeof vi.fn>
+	destroy!: Mock<() => Promise<void>>
 	server: ZwavejsServer | null = null
 
 	constructor(world: World) {
@@ -1332,7 +1340,7 @@ describe('DriverLifecycle — driver-event dispatch', () => {
 	})
 })
 
-describe('DriverLifecycle — connect option/edge coverage', () => {
+describe('DriverLifecycle — connect option wiring', () => {
 	it('builds scale preferences from cfg.scales', async () => {
 		const { lifecycle, world } = createHarness({
 			serverEnabled: false,
@@ -1393,7 +1401,7 @@ describe('DriverLifecycle — connect option/edge coverage', () => {
 	})
 })
 
-describe('DriverLifecycle — connect catch-path edges', () => {
+describe('DriverLifecycle — failed connect error reporting', () => {
 	it('swallows a driver.destroy() rejection while handling a start failure', async () => {
 		vi.useFakeTimers()
 		try {
@@ -1416,7 +1424,7 @@ describe('DriverLifecycle — connect catch-path edges', () => {
 		}
 	})
 
-	it('aborts the catch path without reporting when the generation changed', async () => {
+	it('does not report the error when a close bumps the generation during a failed start', async () => {
 		const { lifecycle, host, world } = createHarness({
 			serverEnabled: false,
 		})
@@ -1429,7 +1437,7 @@ describe('DriverLifecycle — connect catch-path edges', () => {
 		expect(host.onDriverError).not.toHaveBeenCalled()
 	})
 
-	it('aborts the catch path (closing) when the client became destroyed', async () => {
+	it('closes without reporting the error when the client is destroyed during a failed start', async () => {
 		const { lifecycle, host, world, state } = createHarness({
 			serverEnabled: false,
 		})

--- a/test/lib/zwave/DriverLifecycle.test.ts
+++ b/test/lib/zwave/DriverLifecycle.test.ts
@@ -1455,6 +1455,27 @@ describe('DriverLifecycle — driver-ready failures', () => {
 		expect(host.restart).not.toHaveBeenCalled()
 	})
 
+	it('ignores pending ready failure after a fatal driver error', async () => {
+		const { lifecycle, host, world } = createHarness({
+			serverEnabled: false,
+		})
+		const ready = createDeferred<void>()
+		host.onDriverReady.mockReturnValueOnce(ready.promise)
+		await lifecycle.connect()
+		const fatalError = new ZWaveError(
+			'driver failed',
+			ZWaveErrorCodes.Driver_Failed,
+		)
+
+		world.drivers[0].emit('driver ready')
+		world.drivers[0].emit('error', fatalError)
+		ready.reject(new Error('superseded ready failure'))
+		await vi.advanceTimersByTimeAsync(60000)
+
+		expect(host.onDriverError).toHaveBeenCalledTimes(1)
+		expect(host.onDriverError).toHaveBeenCalledWith(fatalError, false)
+	})
+
 	it('ignores a driver-ready failure after that generation closes', async () => {
 		const { lifecycle, host, world } = createHarness({
 			serverEnabled: false,

--- a/test/lib/zwave/DriverLifecycle.test.ts
+++ b/test/lib/zwave/DriverLifecycle.test.ts
@@ -65,8 +65,47 @@ const hoisted = vi.hoisted(() => ({
 	ensureDirHook: null as null | (() => void),
 	/** When true, the fake `driver.destroy()` rejects. */
 	destroyRejects: false,
+	/**
+	 * How the fake `driver.destroy()` settles:
+	 *  - 'resolve'  (default): tears down cleanly.
+	 *  - 'reject'   : always rejects WITHOUT recording a teardown effect — the
+	 *                 instance stays intact and retryable (models a destroy that
+	 *                 fails while the driver may still hold the serial port).
+	 *  - 'deferred' : returns a promise the test settles via `destroyDeferreds`,
+	 *                 so a test can hold a teardown open and prove no replacement
+	 *                 Driver is constructed while the old owner is being torn
+	 *                 down (teardown ownership).
+	 */
+	destroyBehavior: 'resolve' as 'resolve' | 'reject' | 'deferred',
+	/**
+	 * When `destroyBehavior === 'deferred'`, each `driver.destroy()` call pushes
+	 * a controllable `{ resolve, reject }` here (in call order). `resolve()`
+	 * records the teardown effect once (like a clean idempotent destroy);
+	 * `reject()` leaves the instance intact/retryable.
+	 */
+	destroyDeferreds: [] as Array<{
+		resolve: () => void
+		reject: (err?: Error) => void
+	}>,
+	/**
+	 * Number of LEADING `driver.destroy()` calls that reject (without recording
+	 * a teardown effect) before one succeeds. Lets a test prove a rejected
+	 * destroy retains the exact owner and that a later retry actually tears it
+	 * down. Decremented on each rejecting call.
+	 */
+	destroyRejectCount: 0,
+	/** Total `driver.destroy()` invocations across all fake drivers. */
+	destroyInvocations: 0,
 	/** Every fake JSON log transport constructed (to drive its `data` stream). */
 	logTransports: [] as any[],
+	/**
+	 * When set, overrides `utils.buildLogConfig(...)` for the next `connect()`
+	 * so a test can exercise the driver-log-config enrichment branches that the
+	 * real (always-populated) config never reaches: a driver built with NO
+	 * `logConfig` at all, or one whose `level` is not a string. Returns whatever
+	 * value the function yields (may be `undefined`). Reset in `beforeEach`.
+	 */
+	buildLogConfigOverride: null as null | (() => any),
 }))
 
 // Faithful `zwave-js` Driver fake. Only `Driver` is replaced; every other
@@ -105,18 +144,55 @@ vi.mock('zwave-js', async () => {
 			}
 			return Promise.resolve()
 		})
-		destroy = vi.fn(() => {
-			// The real zwave-js `Driver.destroy()` is idempotent (guarded by an
-			// internal `_destroyPromise`); mirror that so a stale-connect teardown
-			// racing a `close()` records the destroy effect exactly once.
+		destroy = vi.fn((): Promise<void> => {
+			hoisted.destroyInvocations++
+
+			// Record the teardown EFFECT at most once per instance, mirroring
+			// the real zwave-js `Driver.destroy()` idempotency (`_destroyPromise`):
+			// destroying an already-destroyed driver resolves without re-running
+			// teardown, so a stale-connect teardown racing a `close()` records
+			// the effect exactly once.
+			const recordEffect = () => {
+				if (!this._destroyed) {
+					this._destroyed = true
+					hoisted.destroyOrder.push('driver')
+				}
+			}
+
+			if (hoisted.destroyBehavior === 'deferred') {
+				return new Promise<void>((resolve, reject) => {
+					hoisted.destroyDeferreds.push({
+						resolve: () => {
+							recordEffect()
+							resolve()
+						},
+						reject: (err?: Error) =>
+							reject(err ?? new Error('destroy rejected')),
+					})
+				})
+			}
+
+			// Already torn down → idempotent clean resolve.
 			if (this._destroyed) {
 				return Promise.resolve()
 			}
-			this._destroyed = true
-			hoisted.destroyOrder.push('driver')
-			if (hoisted.destroyRejects) {
+
+			// A rejecting destroy (legacy `destroyRejects`, an explicit
+			// 'reject' behavior, or a leading run of `destroyRejectCount`
+			// failures) does NOT mark the instance destroyed or record an
+			// effect: the exact owner must stay intact and RETRYABLE.
+			const rejectThis =
+				hoisted.destroyRejects ||
+				hoisted.destroyBehavior === 'reject' ||
+				hoisted.destroyRejectCount > 0
+			if (rejectThis) {
+				if (hoisted.destroyRejectCount > 0) {
+					hoisted.destroyRejectCount--
+				}
 				return Promise.reject(new Error('destroy failed'))
 			}
+
+			recordEffect()
 			return Promise.resolve()
 		})
 		enableStatistics = vi.fn()
@@ -180,6 +256,11 @@ vi.mock('../../../api/lib/utils.ts', async () => {
 			hoisted.ensureDirHook?.()
 			return Promise.resolve()
 		}),
+		buildLogConfig: vi.fn((...args: any[]) =>
+			hoisted.buildLogConfigOverride
+				? hoisted.buildLogConfigOverride()
+				: actual.buildLogConfig(...args),
+		),
 	}
 })
 
@@ -323,7 +404,12 @@ beforeEach(() => {
 	hoisted.startHook = null
 	hoisted.ensureDirHook = null
 	hoisted.destroyRejects = false
+	hoisted.destroyBehavior = 'resolve'
+	hoisted.destroyDeferreds.length = 0
+	hoisted.destroyRejectCount = 0
+	hoisted.destroyInvocations = 0
 	hoisted.logTransports.length = 0
+	hoisted.buildLogConfigOverride = null
 	delete process.env.ZWAVE_PORT
 })
 
@@ -414,59 +500,163 @@ describe('DriverLifecycle — statistics', () => {
 // ===========================================================================
 
 describe('DriverLifecycle — extra log transports', () => {
-	it('addExtraLogTransport applies immediately when the driver is ready (with level)', () => {
-		const { lifecycle, state } = createHarness()
-		const driver = { updateLogConfig: vi.fn() }
-		state.driver = driver
-		state.driverReadyRaw = true
-		const transport = { id: 't1' }
-		lifecycle.addExtraLogTransport(transport, 'debug')
+	// These live add/remove tests connect first so the required JSON-socket
+	// transport actually exists for the active generation — the whole point of
+	// the fix is that `updateLogConfig({transports})` REPLACES the driver's
+	// custom transport list, so every runtime apply must re-send the JSON
+	// transport plus ALL current extras (not just the one being added, and
+	// never an empty array), and recompute the level from the configured
+	// baseline. `state.driverReadyRaw` is flipped on to model a ready driver.
+	async function connectedReadyHarness(cfgOverrides: any = {}) {
+		const harness = createHarness({ serverEnabled: false, ...cfgOverrides })
+		await harness.lifecycle.connect()
+		const json = hoisted.logTransports[0]
+		const driver = harness.state.driver
+		harness.state.driverReadyRaw = true
+		driver.updateLogConfig.mockClear()
+		return { ...harness, json, driver }
+	}
+
+	it('addExtraLogTransport sends the COMPLETE transport list (JSON socket + extra) and raises the level', async () => {
+		const { lifecycle, json, driver } = await connectedReadyHarness()
+		const extra = { id: 't1' }
+		lifecycle.addExtraLogTransport(extra, 'debug')
+		// Required JSON socket transport retained FIRST, extra appended, level
+		// raised from the configured 'info' baseline to the extra's 'debug'.
+		expect(driver.updateLogConfig).toHaveBeenCalledTimes(1)
 		expect(driver.updateLogConfig).toHaveBeenCalledWith({
-			transports: [transport],
+			transports: [json, extra],
 			level: 'debug',
 		})
 	})
 
-	it('addExtraLogTransport without a level omits the level key', () => {
-		const { lifecycle, state } = createHarness()
-		const driver = { updateLogConfig: vi.fn() }
-		state.driver = driver
-		state.driverReadyRaw = true
-		const transport = { id: 't2' }
-		lifecycle.addExtraLogTransport(transport)
+	it('addExtraLogTransport without a level keeps the configured baseline level and still retains the JSON transport', async () => {
+		const { lifecycle, json, driver } = await connectedReadyHarness()
+		const extra = { id: 't2' }
+		lifecycle.addExtraLogTransport(extra)
+		// No requested level → the recomputed level is the configured baseline
+		// ('info'), and the JSON socket transport is still present.
 		expect(driver.updateLogConfig).toHaveBeenCalledWith({
-			transports: [transport],
+			transports: [json, extra],
+			level: 'info',
 		})
 	})
 
-	it('addExtraLogTransport does not touch the driver when not ready', () => {
-		const { lifecycle, state } = createHarness()
-		const driver = { updateLogConfig: vi.fn() }
-		state.driver = driver
-		state.driverReadyRaw = false
-		lifecycle.addExtraLogTransport({ id: 't3' })
-		expect(driver.updateLogConfig).not.toHaveBeenCalled()
+	it('multiple extras with different levels: full list retained and the MOST verbose level wins', async () => {
+		const { lifecycle, json, driver } = await connectedReadyHarness()
+		const a = { id: 'a' }
+		const b = { id: 'b' }
+		const c = { id: 'c' }
+		lifecycle.addExtraLogTransport(a, 'warn')
+		lifecycle.addExtraLogTransport(b, 'silly')
+		lifecycle.addExtraLogTransport(c, 'verbose')
+		// Last apply carries ALL three extras (plus JSON) and the most verbose
+		// level requested by any of them ('silly').
+		expect(driver.updateLogConfig).toHaveBeenLastCalledWith({
+			transports: [json, a, b, c],
+			level: 'silly',
+		})
 	})
 
-	it('removeExtraLogTransport removes a registered transport and clears on the driver', () => {
-		const { lifecycle, state } = createHarness()
-		const driver = { updateLogConfig: vi.fn() }
-		state.driver = driver
-		state.driverReadyRaw = true
-		const transport = { id: 't4' }
-		lifecycle.addExtraLogTransport(transport)
+	it('removeExtraLogTransport re-sends the remaining transports (never empties the list) and restores the baseline level', async () => {
+		const { lifecycle, json, driver } = await connectedReadyHarness()
+		const keep = { id: 'keep' }
+		const temp = { id: 'temp-debug' }
+		lifecycle.addExtraLogTransport(keep, 'info')
+		lifecycle.addExtraLogTransport(temp, 'debug')
 		driver.updateLogConfig.mockClear()
-		lifecycle.removeExtraLogTransport(transport)
-		expect(driver.updateLogConfig).toHaveBeenCalledWith({ transports: [] })
+
+		// Removing the verbose extra must keep the other extra AND the JSON
+		// transport, and drop the level back to the configured baseline.
+		lifecycle.removeExtraLogTransport(temp)
+		expect(driver.updateLogConfig).toHaveBeenCalledTimes(1)
+		expect(driver.updateLogConfig).toHaveBeenCalledWith({
+			transports: [json, keep],
+			level: 'info',
+		})
 	})
 
-	it('removeExtraLogTransport for an unknown transport still clears when ready', () => {
-		const { lifecycle, state } = createHarness()
-		const driver = { updateLogConfig: vi.fn() }
-		state.driver = driver
+	it('removing the LAST extra still re-sends the required JSON transport (not an empty array) at the baseline level', async () => {
+		const { lifecycle, json, driver } = await connectedReadyHarness()
+		const temp = { id: 'only' }
+		lifecycle.addExtraLogTransport(temp, 'debug')
+		driver.updateLogConfig.mockClear()
+		lifecycle.removeExtraLogTransport(temp)
+		// The whole point of the fix: the JSON socket transport survives even
+		// when the last extra is removed.
+		expect(driver.updateLogConfig).toHaveBeenCalledWith({
+			transports: [json],
+			level: 'info',
+		})
+	})
+
+	it('removal order does not matter: the level tracks the most verbose REMAINING extra', async () => {
+		const { lifecycle, json, driver } = await connectedReadyHarness()
+		const warnT = { id: 'warn' }
+		const debugT = { id: 'debug' }
+		lifecycle.addExtraLogTransport(warnT, 'warn')
+		lifecycle.addExtraLogTransport(debugT, 'debug')
+
+		// Remove the less verbose one first: 'debug' extra still forces 'debug'.
+		lifecycle.removeExtraLogTransport(warnT)
+		expect(driver.updateLogConfig).toHaveBeenLastCalledWith({
+			transports: [json, debugT],
+			level: 'debug',
+		})
+
+		// Now remove the verbose one: back to the baseline with only JSON.
+		lifecycle.removeExtraLogTransport(debugT)
+		expect(driver.updateLogConfig).toHaveBeenLastCalledWith({
+			transports: [json],
+			level: 'info',
+		})
+	})
+
+	it('a configured non-default level is the floor: adding a LESS verbose extra does not lower it', async () => {
+		const { lifecycle, json, driver } = await connectedReadyHarness({
+			logLevel: 'info',
+			options: { logConfig: { level: 'verbose' } } as any,
+		})
+		const extra = { id: 'quiet' }
+		lifecycle.addExtraLogTransport(extra, 'warn')
+		// Baseline 'verbose' is more verbose than the extra's 'warn' → retained.
+		expect(driver.updateLogConfig).toHaveBeenCalledWith({
+			transports: [json, extra],
+			level: 'verbose',
+		})
+	})
+
+	it('addExtraLogTransport does not touch the driver when it is not ready (registration still persists)', async () => {
+		const { lifecycle, state } = createHarness({ serverEnabled: false })
+		await lifecycle.connect()
+		const driver = state.driver
+		state.driverReadyRaw = false
+		driver.updateLogConfig.mockClear()
+		lifecycle.addExtraLogTransport({ id: 't3' }, 'debug')
+		expect(driver.updateLogConfig).not.toHaveBeenCalled()
+
+		// Registration persisted: it is applied the moment a subsequent
+		// (ready) apply runs — proven by a following remove of an unknown id.
 		state.driverReadyRaw = true
 		lifecycle.removeExtraLogTransport({ id: 'unknown' })
-		expect(driver.updateLogConfig).toHaveBeenCalledWith({ transports: [] })
+		expect(driver.updateLogConfig).toHaveBeenCalledWith({
+			transports: [
+				hoisted.logTransports[0],
+				expect.objectContaining({ id: 't3' }),
+			],
+			level: 'debug',
+		})
+	})
+
+	it('before connect there is no driver and add/remove are inert no-ops', () => {
+		const { lifecycle } = createHarness({ serverEnabled: false })
+		// No driver at all (never connected) → nothing to apply, no throw.
+		expect(() =>
+			lifecycle.addExtraLogTransport({ id: 'pre' }, 'debug'),
+		).not.toThrow()
+		expect(() =>
+			lifecycle.removeExtraLogTransport({ id: 'pre' }),
+		).not.toThrow()
 	})
 })
 
@@ -916,7 +1106,7 @@ describe('DriverLifecycle — pre-ready reconnect coalescing', () => {
 		expect(lifecycle.generation).toBe(genAfterFirst)
 	})
 
-	it('coalesces a second connect while the first is still awaiting driver.start()', async () => {
+	it('coalesces a second connect while the first is still awaiting driver.start(): it stays PENDING until the first settles, then settles together', async () => {
 		const { lifecycle, state } = createHarness({ serverEnabled: false })
 		hoisted.startBehavior = 'deferred'
 
@@ -927,18 +1117,95 @@ describe('DriverLifecycle — pre-ready reconnect coalescing', () => {
 		const gen = lifecycle.generation
 
 		// Second connect while driver0 is mid-start → coalesced: no new Driver
-		// and no second start() call.
-		await lifecycle.connect()
+		// and no second start() call…
+		let firstSettled = false
+		let secondSettled = false
+		void first.then(() => {
+			firstSettled = true
+		})
+		const second = lifecycle.connect()
+		void second.then(() => {
+			secondSettled = true
+		})
+
+		// …and, crucially, the second connect does NOT resolve early. It must
+		// remain pending exactly as long as the first does (the old bug returned
+		// success immediately here, before the driver was ever CONNECTED).
+		await until(() => hoisted.startDeferreds.length === 1)
 		expect(hoisted.drivers).toHaveLength(1)
 		expect(hoisted.startDeferreds).toHaveLength(1)
 		expect(state.driver).toBe(driver0)
 		expect(lifecycle.generation).toBe(gen)
+		expect(driver0.start).toHaveBeenCalledTimes(1)
+		expect(firstSettled).toBe(false)
+		expect(secondSettled).toBe(false)
 
-		// Let the first connect finish cleanly — still just the one driver.
+		// Settle the first startup; BOTH callers resolve together off the same
+		// startup promise, and still just the one driver was ever built.
 		hoisted.startDeferreds[0].resolve()
-		await first
+		await Promise.all([first, second])
+		expect(firstSettled).toBe(true)
+		expect(secondSettled).toBe(true)
 		expect(state.status).toBe(ZwaveClientStatus.CONNECTED)
+		expect(hoisted.drivers).toHaveLength(1)
 		expect(driver0.destroy).not.toHaveBeenCalled()
+	})
+
+	it('a coalesced duplicate connect shares the first connect FAILURE settlement (start rejects) and no second Driver is built', async () => {
+		const { lifecycle, state, host } = createHarness({
+			serverEnabled: false,
+		})
+		hoisted.startBehavior = 'deferred'
+
+		const first = lifecycle.connect()
+		await until(() => hoisted.startDeferreds.length === 1)
+		const driver0 = hoisted.drivers[0]
+
+		let firstSettled = false
+		let secondSettled = false
+		void first.then(() => {
+			firstSettled = true
+		})
+		const second = lifecycle.connect()
+		void second.then(() => {
+			secondSettled = true
+		})
+		await until(() => hoisted.startDeferreds.length === 1)
+		expect(firstSettled).toBe(false)
+		expect(secondSettled).toBe(false)
+
+		// The first startup FAILS. The facade contract is that connect() catches
+		// the failure (reports it + schedules a backoff) and RESOLVES rather than
+		// rejecting — so the coalesced caller resolves at the SAME time with the
+		// SAME (non-throwing) settlement. No second driver was ever constructed
+		// and the failure is reported exactly once.
+		hoisted.startDeferreds[0].reject(new Error('start failed'))
+		await expect(Promise.all([first, second])).resolves.toBeDefined()
+		expect(firstSettled).toBe(true)
+		expect(secondSettled).toBe(true)
+		expect(hoisted.drivers).toHaveLength(1)
+		expect(driver0.destroy).toHaveBeenCalledTimes(1)
+		expect(state.driver).toBeNull() // clean teardown cleared the owner
+		expect(host.onDriverError).toHaveBeenCalledTimes(1)
+	})
+
+	it('a duplicate connect AFTER the first start settled but BEFORE driver ready returns compatibly without a replacement', async () => {
+		const { lifecycle, state } = createHarness({ serverEnabled: false })
+
+		// First connect reaches CONNECTED (start resolved) but not ready yet, so
+		// `_activeConnect` is already cleared — the duplicate falls through to
+		// the compatible host-driver guard instead of coalescing.
+		await lifecycle.connect()
+		const driver0 = hoisted.drivers[0]
+		const gen = lifecycle.generation
+		expect(state.status).toBe(ZwaveClientStatus.CONNECTED)
+		expect(state.driverReady).toBe(false)
+
+		await lifecycle.connect()
+		expect(hoisted.drivers).toHaveLength(1)
+		expect(state.driver).toBe(driver0)
+		expect(driver0.destroy).not.toHaveBeenCalled()
+		expect(lifecycle.generation).toBe(gen)
 	})
 
 	it('a recovery reconnect after a start failure is NOT coalesced (host cleared) and builds exactly one fresh driver', async () => {
@@ -1036,6 +1303,145 @@ describe('DriverLifecycle — pre-ready reconnect coalescing', () => {
 })
 
 // ===========================================================================
+// connect() — failed-connect teardown ownership (HIGH)
+// ===========================================================================
+//
+// A failed connect must AWAIT the destruction of the exact instance it created
+// BEFORE it clears the host field or lets a backoff/retry build a replacement.
+// The old code fired `destroy()` unawaited and cleared the field immediately, so
+// a slow/rejected destroy could let a replacement driver be constructed while
+// the old owner still held the serial port (controller unreachable). These
+// tests drive `destroy()` deterministically (deferred / reject-once) to prove
+// the ownership contract.
+
+describe('DriverLifecycle — failed-connect teardown ownership', () => {
+	it('awaits the failed driver destroy before clearing the host or backing off (no replacement built while the owner is torn down)', async () => {
+		vi.useFakeTimers()
+		try {
+			const { lifecycle, state, host } = createHarness({
+				serverEnabled: false,
+			})
+			hoisted.startBehavior = 'reject'
+			hoisted.startError = new Error('start boom')
+			hoisted.destroyBehavior = 'deferred'
+
+			const connectP = lifecycle.connect()
+
+			// The connect is now suspended inside teardownConnectDriver awaiting
+			// driver0.destroy(). Until that destroy settles:
+			await until(() => hoisted.destroyDeferreds.length === 1)
+			expect(hoisted.drivers).toHaveLength(1)
+			const driver0 = hoisted.drivers[0]
+			// …the host STILL owns the exact failed instance (not cleared)…
+			expect(state.driver).toBe(driver0)
+			// …the error has NOT yet been reported and NO backoff scheduled…
+			expect(host.onDriverError).not.toHaveBeenCalled()
+			expect(host.restart).not.toHaveBeenCalled()
+
+			// …and a concurrent connect coalesces onto the in-flight startup
+			// rather than constructing a replacement Driver while the owner is
+			// still being torn down.
+			const concurrent = lifecycle.connect()
+			await until(() => hoisted.destroyDeferreds.length === 1)
+			expect(hoisted.drivers).toHaveLength(1)
+			expect(driver0.start).toHaveBeenCalledTimes(1)
+
+			// Complete the destroy: only now is the host field cleared and the
+			// error reported + backoff scheduled (serialized behind teardown).
+			hoisted.destroyDeferreds[0].resolve()
+			await connectP
+			await concurrent
+			expect(state.driver).toBeNull()
+			expect(hoisted.destroyOrder).toEqual(['driver'])
+			expect(host.onDriverError).toHaveBeenCalledTimes(1)
+			expect(host.onDriverError).toHaveBeenCalledWith(
+				expect.any(Error),
+				true,
+			)
+			await vi.advanceTimersByTimeAsync(1000)
+			expect(host.restart).toHaveBeenCalledTimes(1)
+			// Still exactly one Driver ever built across the whole sequence.
+			expect(hoisted.drivers).toHaveLength(1)
+		} finally {
+			vi.useRealTimers()
+		}
+	})
+
+	it('retains the exact owner when destroy REJECTS and lets a later close retry the cleanup (no leak, no wrong destroy)', async () => {
+		vi.useFakeTimers()
+		try {
+			const { lifecycle, state, host } = createHarness({
+				serverEnabled: false,
+			})
+			hoisted.startBehavior = 'reject'
+			hoisted.startError = new Error('start boom')
+			// First destroy rejects (owner intact/retryable); a later one succeeds.
+			hoisted.destroyRejectCount = 1
+
+			await lifecycle.connect()
+			const driver0 = hoisted.drivers[0]
+
+			// The rejected destroy did NOT drop the owner: the exact failed
+			// instance is still reachable/owned, nothing was recorded as torn
+			// down, and no replacement was built. The failure is still observable.
+			expect(hoisted.drivers).toHaveLength(1)
+			expect(state.driver).toBe(driver0)
+			expect(hoisted.destroyInvocations).toBe(1)
+			expect(hoisted.destroyOrder).toEqual([]) // no teardown effect yet
+			expect(host.onDriverError).toHaveBeenCalledTimes(1)
+
+			// Retry cleanup via close(): it re-invokes destroy() on the SAME
+			// owner, which now succeeds and clears the field. Exactly that
+			// instance is destroyed — no leak, no wrong/replacement destroy.
+			await lifecycle.close(true)
+			expect(hoisted.destroyInvocations).toBe(2)
+			expect(hoisted.destroyOrder).toEqual(['driver'])
+			expect(state.driver).toBeNull()
+			expect(hoisted.drivers).toHaveLength(1)
+			expect(driver0.destroy).toHaveBeenCalledTimes(2)
+		} finally {
+			vi.useRealTimers()
+		}
+	})
+
+	it('a stale post-start exit awaits teardown of its OWN instance and never destroys the live replacement, even with a delayed destroy', async () => {
+		const { lifecycle, state } = createHarness({ serverEnabled: false })
+		hoisted.startBehavior = 'deferred'
+
+		// Stale connect: driver0 on host, held at start().
+		const staleP = lifecycle.connect()
+		await until(() => hoisted.startDeferreds.length === 1)
+		const driver0 = hoisted.drivers[0]
+
+		// close() bumps the generation, destroys driver0 (clean) and nulls the
+		// host field; then a reconnect builds driver1.
+		await lifecycle.close(true)
+		state.closed = false
+		hoisted.startBehavior = 'deferred'
+		const freshP = lifecycle.connect()
+		await until(() => hoisted.startDeferreds.length === 2)
+		const driver1 = hoisted.drivers[1]
+		hoisted.startDeferreds[1].resolve()
+		await freshP
+		expect(state.driver).toBe(driver1)
+
+		// Now the stale start resolves: its post-start generation check fails,
+		// so it tears down driver0 (idempotent — already destroyed by close).
+		hoisted.startDeferreds[0].resolve()
+		await staleP
+
+		// The replacement was never touched and remains owned; driver0's
+		// teardown recorded exactly once.
+		expect(driver1.destroy).not.toHaveBeenCalled()
+		expect(state.driver).toBe(driver1)
+		expect(hoisted.destroyOrder.filter((d) => d === 'driver')).toHaveLength(
+			1,
+		)
+		void driver0
+	})
+})
+
+// ===========================================================================
 // connect() — final logConfig override (finding 4)
 // ===========================================================================
 
@@ -1079,6 +1485,65 @@ describe('DriverLifecycle — final logConfig override', () => {
 		expect(passedLogConfig.transports).toEqual([jsonTransport])
 		// no extra transport → the override's own level is preserved
 		expect(passedLogConfig.level).toBe('warn')
+	})
+
+	it('a driver built with NO logConfig object connects cleanly and leaves the base level unset', async () => {
+		// `utils.buildLogConfig` yields no logConfig object for an exotic
+		// external configuration. `_startDriver` must still construct and start
+		// the driver (there is no logConfig to enrich), and the captured base
+		// level stays unset — so a later runtime add/remove computes the level
+		// purely from the registered extras, with no configured floor.
+		hoisted.buildLogConfigOverride = () => undefined
+		const { lifecycle, state } = createHarness({ serverEnabled: false })
+
+		await lifecycle.connect()
+
+		// Driver constructed + started, and received no logConfig object at all.
+		expect(hoisted.drivers).toHaveLength(1)
+		expect(hoisted.drivers[0].options.logConfig).toBeUndefined()
+		expect(state.driver).toBe(hoisted.drivers[0])
+
+		// Base level unset: a subsequent extra drives the effective level on its
+		// own (its 'warn' is used verbatim, not merged over a configured floor),
+		// and the required JSON-socket transport is still re-sent first.
+		state.driverReadyRaw = true
+		hoisted.drivers[0].updateLogConfig.mockClear()
+		const extra = { id: 'x' }
+		lifecycle.addExtraLogTransport(extra, 'warn')
+		expect(hoisted.drivers[0].updateLogConfig).toHaveBeenCalledWith({
+			transports: [hoisted.logTransports[0], extra],
+			level: 'warn',
+		})
+	})
+
+	it('a driver logConfig with a non-string level leaves the base level unset and never overwrites it', async () => {
+		// A logConfig whose `level` is not a string must not be captured as the
+		// base level (the `typeof === 'string'` guard falls to `undefined`), and
+		// with no extras the computed runtime level is `undefined`, so the
+		// enrichment must NOT rewrite the driver's own level field.
+		hoisted.buildLogConfigOverride = () => ({ level: 42 })
+		const { lifecycle } = createHarness({ serverEnabled: false })
+
+		await lifecycle.connect()
+
+		const passedLogConfig = hoisted.drivers[0].options.logConfig
+		// The required JSON transport was still injected (the `if (finalLogConfig)`
+		// enrichment ran)...
+		expect(passedLogConfig.transports).toEqual([hoisted.logTransports[0]])
+		// ...but the non-string level was left exactly as-is (computed runtime
+		// level was `undefined`, so `if (level)` never overwrote it).
+		expect(passedLogConfig.level).toBe(42)
+
+		// Base level genuinely unset: adding a levelled extra now sets the level
+		// solely from that extra with no configured floor underneath it.
+		lifecycle['host'].isDriverReadyRaw = () => true
+		hoisted.drivers[0].updateLogConfig.mockClear()
+		const extra = { id: 'y' }
+		lifecycle.addExtraLogTransport(extra, 'silly')
+		expect(hoisted.drivers[0].updateLogConfig).toHaveBeenCalledWith({
+			transports: [hoisted.logTransports[0], extra],
+			level: 'silly',
+		})
 	})
 })
 

--- a/test/lib/zwave/DriverLifecycle.test.ts
+++ b/test/lib/zwave/DriverLifecycle.test.ts
@@ -274,8 +274,6 @@ function createHarness(cfgOverrides: Partial<ZwaveConfig> = {}) {
 	return { lifecycle, host, state, world }
 }
 
-const flush = () => Promise.resolve()
-
 async function until(pred: () => boolean, max = 100): Promise<void> {
 	for (let i = 0; i < max; i++) {
 		if (pred()) return
@@ -1276,7 +1274,7 @@ describe('DriverLifecycle — stale driver events after close', () => {
 
 		host.onDriverReady = vi.fn(async () => {})
 		driver.emit('driver ready')
-		await flush()
+		await Promise.resolve()
 		expect(host.onDriverReady).not.toHaveBeenCalled()
 	})
 

--- a/test/lib/zwave/DriverLifecycle.test.ts
+++ b/test/lib/zwave/DriverLifecycle.test.ts
@@ -1,80 +1,106 @@
-/* eslint-disable @typescript-eslint/unbound-method */
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { EventEmitter } from 'node:events'
 import { ZWaveError, ZWaveErrorCodes } from '@zwave-js/core'
+import { RFRegion } from 'zwave-js'
+import type { Driver, ZWaveOptions, PartialZWaveOptions } from 'zwave-js'
+import type { JSONTransport } from '@zwave-js/log-transport-json'
+import type { ZwavejsServer } from '@zwave-js/server'
+import Transport from 'winston-transport'
 
-import type { DriverLifecycleHost } from '../../../api/lib/zwave/DriverLifecycle.ts'
+import {
+	DriverLifecycle,
+	type DriverLifecycleHost,
+	type DriverLifecycleDeps,
+} from '../../../api/lib/zwave/DriverLifecycle.ts'
+import type ZwaveServerManager from '../../../api/hass/ZwaveServerManager.ts'
+import type { ZwaveServerHost } from '../../../api/hass/ZwaveServerManager.ts'
 import type {
 	ZwaveConfig,
 	InclusionUserCallbacks,
 } from '../../../api/lib/zwave/ports.ts'
 import { ZwaveClientStatus } from '../../../api/lib/zwave/ports.ts'
 
-const hoisted = vi.hoisted(() => ({
-	drivers: [] as any[],
-	destroyOrder: [] as string[],
-	startBehavior: 'resolve' as 'resolve' | 'reject' | 'hang' | 'deferred',
-	startError: new Error('start failed'),
-	startDeferreds: [] as Array<{
-		resolve: () => void
-		reject: (err: unknown) => void
-	}>,
-	startHook: null as null | (() => void),
-	ensureDirHook: null as null | (() => void),
-	destroyRejects: false,
-	destroyBehavior: 'resolve' as 'resolve' | 'reject' | 'deferred',
-	destroyDeferreds: [] as Array<{
-		resolve: () => void
-		reject: (err?: Error) => void
-	}>,
-	destroyRejectCount: 0,
-	destroyInvocations: 0,
-	logTransports: [] as any[],
-	buildLogConfigOverride: null as null | (() => any),
-}))
+// The lifecycle constructs its Driver, JSON log transport and server manager
+// through injected factories, so every test drives the real production wiring
+// with typed fakes and never module-mocks or reaches into private seams. Casts
+// to the production port types live ONLY at the injection boundary below; the
+// `world` recorder keeps the concrete fake types so assertions stay type-safe.
 
-vi.mock('zwave-js', async () => {
-	const actual = await vi.importActual<any>('zwave-js')
-	const { EventEmitter } = await import('node:events')
+type StartBehavior = 'resolve' | 'reject' | 'hang' | 'deferred'
+type DestroyBehavior = 'resolve' | 'reject' | 'deferred'
 
-	class FakeController extends EventEmitter {
-		homeId = 0xcafebabe
-		ownNodeId = 1
-		nodes = new Map()
-	}
+interface Deferred {
+	resolve: () => void
+	reject: (err?: unknown) => void
+}
 
-	class FakeDriver extends EventEmitter {
-		controller = new FakeController()
-		port: any
-		options: any
-		private _destroyed = false
-		start = vi.fn(() => {
-			hoisted.startHook?.()
-			if (hoisted.startBehavior === 'reject') {
-				return Promise.reject(hoisted.startError)
+interface DestroyDeferred {
+	resolve: () => void
+	reject: (err?: Error) => void
+}
+
+interface World {
+	drivers: FakeDriver[]
+	logTransports: FakeLogTransport[]
+	serverManagers: FakeServerManager[]
+	destroyOrder: string[]
+	startBehavior: StartBehavior
+	startError: Error
+	startDeferreds: Deferred[]
+	startHook: (() => void) | null
+	ensureDirHook: (() => void) | null
+	destroyBehavior: DestroyBehavior
+	destroyRejects: boolean
+	destroyDeferreds: DestroyDeferred[]
+	destroyRejectCount: number
+	destroyInvocations: number
+}
+
+class FakeDriver extends EventEmitter {
+	port: string
+	options: PartialZWaveOptions
+	enableStatistics = vi.fn()
+	disableStatistics = vi.fn()
+	updateLogConfig = vi.fn()
+	start!: ReturnType<typeof vi.fn>
+	destroy!: ReturnType<typeof vi.fn>
+	private _destroyed = false
+
+	constructor(world: World, port: string, options: PartialZWaveOptions) {
+		super()
+		this.port = port
+		this.options = options
+		world.drivers.push(this)
+
+		this.start = vi.fn((): Promise<void> => {
+			world.startHook?.()
+			if (world.startBehavior === 'reject') {
+				return Promise.reject(world.startError)
 			}
-			if (hoisted.startBehavior === 'hang') {
+			if (world.startBehavior === 'hang') {
 				return new Promise<void>(() => {})
 			}
-			if (hoisted.startBehavior === 'deferred') {
+			if (world.startBehavior === 'deferred') {
 				return new Promise<void>((resolve, reject) => {
-					hoisted.startDeferreds.push({ resolve, reject })
+					world.startDeferreds.push({ resolve, reject })
 				})
 			}
 			return Promise.resolve()
 		})
-		destroy = vi.fn((): Promise<void> => {
-			hoisted.destroyInvocations++
+
+		this.destroy = vi.fn((): Promise<void> => {
+			world.destroyInvocations++
 
 			const recordEffect = () => {
 				if (!this._destroyed) {
 					this._destroyed = true
-					hoisted.destroyOrder.push('driver')
+					world.destroyOrder.push('driver')
 				}
 			}
 
-			if (hoisted.destroyBehavior === 'deferred') {
+			if (world.destroyBehavior === 'deferred') {
 				return new Promise<void>((resolve, reject) => {
-					hoisted.destroyDeferreds.push({
+					world.destroyDeferreds.push({
 						resolve: () => {
 							recordEffect()
 							resolve()
@@ -89,13 +115,14 @@ vi.mock('zwave-js', async () => {
 				return Promise.resolve()
 			}
 
+			// Keep the failed instance as owner so a later close/retry destroys it again
 			const rejectThis =
-				hoisted.destroyRejects ||
-				hoisted.destroyBehavior === 'reject' ||
-				hoisted.destroyRejectCount > 0
+				world.destroyRejects ||
+				world.destroyBehavior === 'reject' ||
+				world.destroyRejectCount > 0
 			if (rejectThis) {
-				if (hoisted.destroyRejectCount > 0) {
-					hoisted.destroyRejectCount--
+				if (world.destroyRejectCount > 0) {
+					world.destroyRejectCount--
 				}
 				return Promise.reject(new Error('destroy failed'))
 			}
@@ -103,75 +130,76 @@ vi.mock('zwave-js', async () => {
 			recordEffect()
 			return Promise.resolve()
 		})
-		enableStatistics = vi.fn()
-		disableStatistics = vi.fn()
-		updateLogConfig = vi.fn()
-
-		constructor(port: any, options: any) {
-			super()
-			this.port = port
-			this.options = options
-			hoisted.drivers.push(this)
-		}
 	}
+}
 
-	return { ...actual, Driver: FakeDriver }
-})
+class FakeLogTransport {
+	format: unknown = undefined
+	stream = new EventEmitter()
 
-vi.mock('@zwave-js/server', async () => {
-	const { EventEmitter } = await import('node:events')
-	class ZwavejsServerMock extends EventEmitter {
-		server: any = undefined
-		start = vi.fn(() => {
-			this.server = {}
+	constructor(world: World) {
+		world.logTransports.push(this)
+	}
+}
+
+class FakeServerManager {
+	create = vi.fn()
+	startIfNeeded = vi.fn()
+	destroy!: ReturnType<typeof vi.fn>
+	server: ZwavejsServer | null = null
+
+	constructor(world: World) {
+		world.serverManagers.push(this)
+		this.destroy = vi.fn((): Promise<void> => {
+			world.destroyOrder.push('server')
 			return Promise.resolve()
 		})
-		destroy = vi.fn(() => Promise.resolve())
-		constructor(
-			public driver: any,
-			public options: any,
-		) {
-			super()
-		}
 	}
-	return { serverVersion: '0.0.0-test', ZwavejsServer: ZwavejsServerMock }
-})
+}
 
-vi.mock('@zwave-js/log-transport-json', async () => {
-	const { EventEmitter } = await import('node:events')
-	class JSONTransportMock {
-		format: any = undefined
-		stream = new EventEmitter()
-		constructor() {
-			hoisted.logTransports.push(this)
-		}
-	}
-	return { JSONTransport: JSONTransportMock }
-})
-
-vi.mock('../../../api/lib/utils.ts', async () => {
-	const actual = await vi.importActual<any>('../../../api/lib/utils.ts')
+function createWorld(): World {
 	return {
-		...actual,
-		ensureDir: vi.fn(() => {
-			hoisted.ensureDirHook?.()
-			return Promise.resolve()
-		}),
-		buildLogConfig: vi.fn((...args: any[]) =>
-			hoisted.buildLogConfigOverride
-				? hoisted.buildLogConfigOverride()
-				: actual.buildLogConfig(...args),
-		),
+		drivers: [],
+		logTransports: [],
+		serverManagers: [],
+		destroyOrder: [],
+		startBehavior: 'resolve',
+		startError: new Error('start failed'),
+		startDeferreds: [],
+		startHook: null,
+		ensureDirHook: null,
+		destroyBehavior: 'resolve',
+		destroyRejects: false,
+		destroyDeferreds: [],
+		destroyRejectCount: 0,
+		destroyInvocations: 0,
 	}
-})
+}
 
-const { DriverLifecycle } = await import(
-	'../../../api/lib/zwave/DriverLifecycle.ts'
-)
+function makeDeps(world: World): DriverLifecycleDeps {
+	return {
+		createDriver: (port, options) =>
+			new FakeDriver(world, port, options) as unknown as Driver,
+		createLogTransport: () =>
+			new FakeLogTransport(world) as unknown as JSONTransport,
+		createServerManager: () =>
+			new FakeServerManager(world) as unknown as ZwaveServerManager,
+		ensureDir: () => {
+			world.ensureDirHook?.()
+			return Promise.resolve()
+		},
+	}
+}
+
+// The base types `cfg.options` as the full ZWaveOptions, but production only ever
+// Object.assigns partial user overrides, so adapt partial fixtures in one place
+function zwaveOpts(partial: Partial<ZWaveOptions>): ZWaveOptions {
+	return partial as ZWaveOptions
+}
 
 interface HarnessState {
 	cfg: ZwaveConfig
-	driver: any
+	driver: Driver | null
 	driverReady: boolean
 	driverReadyRaw: boolean
 	closed: boolean
@@ -182,6 +210,8 @@ interface HarnessState {
 }
 
 function createHarness(cfgOverrides: Partial<ZwaveConfig> = {}) {
+	const world = createWorld()
+
 	const state: HarnessState = {
 		cfg: {
 			enabled: true,
@@ -198,42 +228,27 @@ function createHarness(cfgOverrides: Partial<ZwaveConfig> = {}) {
 		userCallbacks: {} as InclusionUserCallbacks,
 	}
 
-	const serverHost = {
-		getDriver: () => state.driver,
-		getConfig: () => state.cfg,
-		getHasUserCallbacks: () => false,
-		onHardReset: vi.fn(),
-		logger: {
-			error: vi.fn(),
-			warn: vi.fn(),
-			info: vi.fn(),
-			debug: vi.fn(),
-		},
-		serverLogger: {
-			error: vi.fn(),
-			warn: vi.fn(),
-			info: vi.fn(),
-			debug: vi.fn(),
-		},
-	}
+	// The injected server-manager factory ignores its host arg, so this stub only
+	// has to exist for `buildServerHost()` to return something type-compatible
+	const serverHostStub = {} as unknown as ZwaveServerHost
 
-	const host: DriverLifecycleHost = {
+	const host = {
 		getConfig: () => state.cfg,
 		getDriver: () => state.driver,
-		setDriver: (d) => {
+		setDriver: (d: Driver | null) => {
 			state.driver = d
 		},
 		isDriverReady: () => state.driverReady,
 		isDriverReadyRaw: () => state.driverReadyRaw,
 		isClosed: () => state.closed,
-		setClosed: (c) => {
+		setClosed: (c: boolean) => {
 			state.closed = c
 		},
 		isDestroyed: () => state.destroyed,
-		setStatus: (s) => {
+		setStatus: (s: ZwaveClientStatus) => {
 			state.status = s
 		},
-		setDriverReady: (r) => {
+		setDriverReady: (r: boolean) => {
 			state.driverReady = r
 		},
 		hasConnectedClients: vi.fn(() =>
@@ -244,7 +259,7 @@ function createHarness(cfgOverrides: Partial<ZwaveConfig> = {}) {
 		installUserCallbacks: vi.fn(),
 		persistConfig: vi.fn(async () => {}),
 		restart: vi.fn(async () => {}),
-		buildServerHost: vi.fn(() => serverHost as any),
+		buildServerHost: () => serverHostStub,
 		clearRuntimeOnClose: vi.fn(),
 		finalizeClose: vi.fn(),
 		onDriverReady: vi.fn(async () => {}),
@@ -253,22 +268,10 @@ function createHarness(cfgOverrides: Partial<ZwaveConfig> = {}) {
 		onBootLoaderReady: vi.fn(),
 		onOTWFirmwareUpdateProgress: vi.fn(),
 		onOTWFirmwareUpdateFinished: vi.fn(),
-	}
+	} satisfies DriverLifecycleHost
 
-	const lifecycle = new DriverLifecycle(host)
-	return { lifecycle, host, state, serverHost }
-}
-
-function fakeManager() {
-	return {
-		create: vi.fn(),
-		startIfNeeded: vi.fn(),
-		destroy: vi.fn(() => {
-			hoisted.destroyOrder.push('server')
-			return Promise.resolve()
-		}),
-		server: null as any,
-	}
+	const lifecycle = new DriverLifecycle(host, makeDeps(world))
+	return { lifecycle, host, state, world }
 }
 
 const flush = () => Promise.resolve()
@@ -283,103 +286,51 @@ async function until(pred: () => boolean, max = 100): Promise<void> {
 	}
 }
 
-beforeEach(() => {
-	hoisted.drivers.length = 0
-	hoisted.destroyOrder.length = 0
-	hoisted.startBehavior = 'resolve'
-	hoisted.startError = new Error('start failed')
-	hoisted.startDeferreds.length = 0
-	hoisted.startHook = null
-	hoisted.ensureDirHook = null
-	hoisted.destroyRejects = false
-	hoisted.destroyBehavior = 'resolve'
-	hoisted.destroyDeferreds.length = 0
-	hoisted.destroyRejectCount = 0
-	hoisted.destroyInvocations = 0
-	hoisted.logTransports.length = 0
-	hoisted.buildLogConfigOverride = null
+afterEach(() => {
 	delete process.env.ZWAVE_PORT
 })
 
-describe('DriverLifecycle — @zwave-js/server coordination', () => {
-	it('adoptServerManager stores the manager and serverManager returns it', () => {
-		const { lifecycle } = createHarness()
-		const mgr = fakeManager()
-		expect(lifecycle.serverManager).toBeUndefined()
-		lifecycle.adoptServerManager(mgr as any)
-		expect(lifecycle.serverManager).toBe(mgr)
-		expect(lifecycle.zwaveServer).toBe(mgr)
-	})
-
-	it('zwaveServer lazily builds a fallback manager once and caches it', () => {
-		const { lifecycle, host } = createHarness()
-		const first = lifecycle.zwaveServer
-		expect(first).toBeDefined()
-		expect(lifecycle.zwaveServer).toBe(first)
-		expect(host.buildServerHost).toHaveBeenCalledTimes(1)
-	})
-
-	it('server get/set delegate through the (lazy) manager', () => {
-		const { lifecycle } = createHarness()
-		const sentinel = {} as any
-		lifecycle.server = sentinel
-		expect(lifecycle.server).toBe(sentinel)
-	})
-
-	it('createServer() calls create() on the current manager', () => {
-		const { lifecycle } = createHarness()
-		const mgr = fakeManager()
-		lifecycle.adoptServerManager(mgr as any)
-		lifecycle.createServer()
-		expect(mgr.create).toHaveBeenCalledTimes(1)
-	})
-})
-
 describe('DriverLifecycle — statistics', () => {
-	it('enableStatistics enables on the driver and always warns', () => {
-		const { lifecycle, state } = createHarness({ serverEnabled: false })
-		const driver = { enableStatistics: vi.fn() }
-		state.driver = driver
+	it('enableStatistics enables usage reporting on the driver without the server suffix when the server is disabled', async () => {
+		const { lifecycle, world } = createHarness({ serverEnabled: false })
+		await lifecycle.connect()
 		lifecycle.enableStatistics()
+		const driver = world.drivers[0]
 		expect(driver.enableStatistics).toHaveBeenCalledTimes(1)
 		const arg = driver.enableStatistics.mock.calls[0][0]
 		expect(arg.applicationName).not.toContain('zwave-js-server')
 	})
 
-	it('enableStatistics applicationName includes zwave-js-server when serverEnabled', () => {
-		const { lifecycle, state } = createHarness({ serverEnabled: true })
-		const driver = { enableStatistics: vi.fn() }
-		state.driver = driver
+	it('enableStatistics tags the application name with zwave-js-server when the server is enabled', async () => {
+		const { lifecycle, world } = createHarness({ serverEnabled: true })
+		await lifecycle.connect()
 		lifecycle.enableStatistics()
-		const arg = driver.enableStatistics.mock.calls[0][0]
+		const arg = world.drivers[0].enableStatistics.mock.calls[0][0]
 		expect(arg.applicationName).toContain('zwave-js-server')
 	})
 
-	it('enableStatistics with no driver does not throw', () => {
+	it('disableStatistics disables usage reporting on the driver', async () => {
+		const { lifecycle, world } = createHarness({ serverEnabled: false })
+		await lifecycle.connect()
+		lifecycle.disableStatistics()
+		expect(world.drivers[0].disableStatistics).toHaveBeenCalledTimes(1)
+	})
+
+	it('toggling statistics before the driver exists is a safe no-op', () => {
 		const { lifecycle } = createHarness()
 		expect(() => lifecycle.enableStatistics()).not.toThrow()
-	})
-
-	it('disableStatistics disables on the driver', () => {
-		const { lifecycle, state } = createHarness()
-		const driver = { disableStatistics: vi.fn() }
-		state.driver = driver
-		lifecycle.disableStatistics()
-		expect(driver.disableStatistics).toHaveBeenCalledTimes(1)
-	})
-
-	it('disableStatistics with no driver does not throw', () => {
-		const { lifecycle } = createHarness()
 		expect(() => lifecycle.disableStatistics()).not.toThrow()
 	})
 })
 
 describe('DriverLifecycle — extra log transports', () => {
-	async function connectedReadyHarness(cfgOverrides: any = {}) {
+	async function connectedReadyHarness(
+		cfgOverrides: Partial<ZwaveConfig> = {},
+	) {
 		const harness = createHarness({ serverEnabled: false, ...cfgOverrides })
 		await harness.lifecycle.connect()
-		const json = hoisted.logTransports[0]
-		const driver = harness.state.driver
+		const json = harness.world.logTransports[0]
+		const driver = harness.world.drivers[0]
 		harness.state.driverReadyRaw = true
 		driver.updateLogConfig.mockClear()
 		return { ...harness, json, driver }
@@ -387,7 +338,7 @@ describe('DriverLifecycle — extra log transports', () => {
 
 	it('addExtraLogTransport sends the COMPLETE transport list (JSON socket + extra) and raises the level', async () => {
 		const { lifecycle, json, driver } = await connectedReadyHarness()
-		const extra = { id: 't1' }
+		const extra = new Transport({})
 		lifecycle.addExtraLogTransport(extra, 'debug')
 		expect(driver.updateLogConfig).toHaveBeenCalledTimes(1)
 		expect(driver.updateLogConfig).toHaveBeenCalledWith({
@@ -398,7 +349,7 @@ describe('DriverLifecycle — extra log transports', () => {
 
 	it('addExtraLogTransport without a level keeps the configured baseline level and still retains the JSON transport', async () => {
 		const { lifecycle, json, driver } = await connectedReadyHarness()
-		const extra = { id: 't2' }
+		const extra = new Transport({})
 		lifecycle.addExtraLogTransport(extra)
 		expect(driver.updateLogConfig).toHaveBeenCalledWith({
 			transports: [json, extra],
@@ -408,9 +359,9 @@ describe('DriverLifecycle — extra log transports', () => {
 
 	it('multiple extras with different levels: full list retained and the MOST verbose level wins', async () => {
 		const { lifecycle, json, driver } = await connectedReadyHarness()
-		const a = { id: 'a' }
-		const b = { id: 'b' }
-		const c = { id: 'c' }
+		const a = new Transport({})
+		const b = new Transport({})
+		const c = new Transport({})
 		lifecycle.addExtraLogTransport(a, 'warn')
 		lifecycle.addExtraLogTransport(b, 'silly')
 		lifecycle.addExtraLogTransport(c, 'verbose')
@@ -422,8 +373,8 @@ describe('DriverLifecycle — extra log transports', () => {
 
 	it('removeExtraLogTransport re-sends the remaining transports (never empties the list) and restores the baseline level', async () => {
 		const { lifecycle, json, driver } = await connectedReadyHarness()
-		const keep = { id: 'keep' }
-		const temp = { id: 'temp-debug' }
+		const keep = new Transport({})
+		const temp = new Transport({})
 		lifecycle.addExtraLogTransport(keep, 'info')
 		lifecycle.addExtraLogTransport(temp, 'debug')
 		driver.updateLogConfig.mockClear()
@@ -438,7 +389,7 @@ describe('DriverLifecycle — extra log transports', () => {
 
 	it('removing the LAST extra still re-sends the required JSON transport (not an empty array) at the baseline level', async () => {
 		const { lifecycle, json, driver } = await connectedReadyHarness()
-		const temp = { id: 'only' }
+		const temp = new Transport({})
 		lifecycle.addExtraLogTransport(temp, 'debug')
 		driver.updateLogConfig.mockClear()
 		lifecycle.removeExtraLogTransport(temp)
@@ -450,8 +401,8 @@ describe('DriverLifecycle — extra log transports', () => {
 
 	it('removal order does not matter: the level tracks the most verbose REMAINING extra', async () => {
 		const { lifecycle, json, driver } = await connectedReadyHarness()
-		const warnT = { id: 'warn' }
-		const debugT = { id: 'debug' }
+		const warnT = new Transport({})
+		const debugT = new Transport({})
 		lifecycle.addExtraLogTransport(warnT, 'warn')
 		lifecycle.addExtraLogTransport(debugT, 'debug')
 
@@ -471,9 +422,9 @@ describe('DriverLifecycle — extra log transports', () => {
 	it('a configured non-default level is the floor: adding a LESS verbose extra does not lower it', async () => {
 		const { lifecycle, json, driver } = await connectedReadyHarness({
 			logLevel: 'info',
-			options: { logConfig: { level: 'verbose' } } as any,
+			options: zwaveOpts({ logConfig: { level: 'verbose' } }),
 		})
-		const extra = { id: 'quiet' }
+		const extra = new Transport({})
 		lifecycle.addExtraLogTransport(extra, 'warn')
 		expect(driver.updateLogConfig).toHaveBeenCalledWith({
 			transports: [json, extra],
@@ -482,33 +433,30 @@ describe('DriverLifecycle — extra log transports', () => {
 	})
 
 	it('addExtraLogTransport does not touch the driver when it is not ready (registration still persists)', async () => {
-		const { lifecycle, state } = createHarness({ serverEnabled: false })
+		const { lifecycle, world, state } = createHarness({
+			serverEnabled: false,
+		})
 		await lifecycle.connect()
-		const driver = state.driver
+		const driver = world.drivers[0]
 		state.driverReadyRaw = false
 		driver.updateLogConfig.mockClear()
-		lifecycle.addExtraLogTransport({ id: 't3' }, 'debug')
+		const extra = new Transport({})
+		lifecycle.addExtraLogTransport(extra, 'debug')
 		expect(driver.updateLogConfig).not.toHaveBeenCalled()
 
 		state.driverReadyRaw = true
-		lifecycle.removeExtraLogTransport({ id: 'unknown' })
+		lifecycle.removeExtraLogTransport(new Transport({}))
 		expect(driver.updateLogConfig).toHaveBeenCalledWith({
-			transports: [
-				hoisted.logTransports[0],
-				expect.objectContaining({ id: 't3' }),
-			],
+			transports: [world.logTransports[0], extra],
 			level: 'debug',
 		})
 	})
 
 	it('before connect there is no driver and add/remove are inert no-ops', () => {
 		const { lifecycle } = createHarness({ serverEnabled: false })
-		expect(() =>
-			lifecycle.addExtraLogTransport({ id: 'pre' }, 'debug'),
-		).not.toThrow()
-		expect(() =>
-			lifecycle.removeExtraLogTransport({ id: 'pre' }),
-		).not.toThrow()
+		const t = new Transport({})
+		expect(() => lifecycle.addExtraLogTransport(t, 'debug')).not.toThrow()
+		expect(() => lifecycle.removeExtraLogTransport(t)).not.toThrow()
 	})
 })
 
@@ -550,15 +498,13 @@ describe('DriverLifecycle — backoff restart & checkIfDestroyed', () => {
 		lifecycle.backoffRestart()
 		await vi.advanceTimersByTimeAsync(20000)
 		expect(host.restart).not.toHaveBeenCalled()
-		expect(host.setStatus).toBeDefined()
 		expect(state.status).toBe(ZwaveClientStatus.CLOSED)
 	})
 
 	it('checkIfDestroyed returns true and closes when destroyed', () => {
-		const { lifecycle, state, host } = createHarness()
+		const { lifecycle, state } = createHarness()
 		state.destroyed = true
 		expect(lifecycle.checkIfDestroyed()).toBe(true)
-		expect(host.setClosed).toBeDefined()
 		expect(state.closed).toBe(true)
 	})
 
@@ -613,65 +559,57 @@ describe('DriverLifecycle — backoff restart coalescing & fencing', () => {
 
 describe('DriverLifecycle — connect early returns', () => {
 	it('does nothing when the driver is disabled', async () => {
-		const { lifecycle } = createHarness({ enabled: false })
+		const { lifecycle, world } = createHarness({ enabled: false })
 		await lifecycle.connect()
-		expect(hoisted.drivers).toHaveLength(0)
+		expect(world.drivers).toHaveLength(0)
 		expect(lifecycle.generation).toBe(0)
 	})
 
 	it('does nothing when a driver is already ready', async () => {
-		const { lifecycle, state } = createHarness()
+		const { lifecycle, world, state } = createHarness()
 		state.driverReady = true
 		await lifecycle.connect()
-		expect(hoisted.drivers).toHaveLength(0)
+		expect(world.drivers).toHaveLength(0)
 	})
 
 	it('does nothing when the client is already closed', async () => {
-		const { lifecycle, state } = createHarness()
+		const { lifecycle, world, state } = createHarness()
 		state.closed = true
 		await lifecycle.connect()
-		expect(hoisted.drivers).toHaveLength(0)
+		expect(world.drivers).toHaveLength(0)
 	})
 
 	it('does nothing when no port is configured', async () => {
-		const { lifecycle } = createHarness({ port: undefined })
+		const { lifecycle, world } = createHarness({ port: undefined })
 		await lifecycle.connect()
-		expect(hoisted.drivers).toHaveLength(0)
+		expect(world.drivers).toHaveLength(0)
 		expect(lifecycle.generation).toBe(0)
 	})
 
 	it('honours the ZWAVE_PORT env override (force-enables + overrides port)', async () => {
 		process.env.ZWAVE_PORT = 'tcp://override:5555'
-		const { lifecycle, state } = createHarness({ enabled: false })
+		const { lifecycle, world, state } = createHarness({ enabled: false })
 		await lifecycle.connect()
 		expect(state.cfg.enabled).toBe(true)
 		expect(state.cfg.port).toBe('tcp://override:5555')
-		expect(hoisted.drivers).toHaveLength(1)
-		expect(hoisted.drivers[0].port).toBe('tcp://override:5555')
+		expect(world.drivers).toHaveLength(1)
+		expect(world.drivers[0].port).toBe('tcp://override:5555')
 	})
 })
 
 describe('DriverLifecycle — connect happy path', () => {
-	it('creates a driver, wires all six events, starts it and sets CONNECTED', async () => {
-		const { lifecycle, state } = createHarness({ serverEnabled: false })
+	it('creates a driver, starts it and sets CONNECTED', async () => {
+		const { lifecycle, world, state } = createHarness({
+			serverEnabled: false,
+		})
 		await lifecycle.connect()
 
 		expect(lifecycle.generation).toBe(1)
-		expect(hoisted.drivers).toHaveLength(1)
-		const driver = hoisted.drivers[0]
+		expect(world.drivers).toHaveLength(1)
+		const driver = world.drivers[0]
 		expect(driver.start).toHaveBeenCalledTimes(1)
 		expect(state.driver).toBe(driver)
 		expect(state.status).toBe(ZwaveClientStatus.CONNECTED)
-		for (const evt of [
-			'error',
-			'driver ready',
-			'all nodes ready',
-			'bootloader ready',
-			'firmware update progress',
-			'firmware update finished',
-		]) {
-			expect(driver.listenerCount(evt)).toBe(1)
-		}
 	})
 
 	it('installs user callbacks only when clients are connected', async () => {
@@ -689,98 +627,97 @@ describe('DriverLifecycle — connect happy path', () => {
 	})
 
 	it('creates the server when serverEnabled', async () => {
-		const { lifecycle } = createHarness({ serverEnabled: true })
-		const mgr = fakeManager()
-		lifecycle.adoptServerManager(mgr as any)
+		const { lifecycle, world } = createHarness({ serverEnabled: true })
 		await lifecycle.connect()
-		expect(mgr.create).toHaveBeenCalledTimes(1)
+		expect(world.serverManagers).toHaveLength(1)
+		expect(world.serverManagers[0].create).toHaveBeenCalledTimes(1)
 	})
 
 	it('enables statistics on connect when configured', async () => {
-		const { lifecycle } = createHarness({
+		const { lifecycle, world } = createHarness({
 			serverEnabled: false,
 			enableStatistics: true,
 		})
 		await lifecycle.connect()
-		expect(hoisted.drivers[0].enableStatistics).toHaveBeenCalledTimes(1)
+		expect(world.drivers[0].enableStatistics).toHaveBeenCalledTimes(1)
 	})
 
 	it('passes the inclusion user callbacks into driver options when server disabled', async () => {
-		const { lifecycle, host } = createHarness({ serverEnabled: false })
+		const { lifecycle, host, world } = createHarness({
+			serverEnabled: false,
+		})
 		await lifecycle.connect()
 		expect(host.getInclusionUserCallbacks).toHaveBeenCalled()
-		expect(hoisted.drivers[0].options.inclusionUserCallbacks).toBeDefined()
+		expect(world.drivers[0].options.inclusionUserCallbacks).toBeDefined()
 	})
 
 	it('does not pass inclusion user callbacks when the server is enabled', async () => {
-		const { lifecycle } = createHarness({ serverEnabled: true })
-		const mgr = fakeManager()
-		lifecycle.adoptServerManager(mgr as any)
+		const { lifecycle, world } = createHarness({ serverEnabled: true })
 		await lifecycle.connect()
-		expect(
-			hoisted.drivers[0].options.inclusionUserCallbacks,
-		).toBeUndefined()
+		expect(world.drivers[0].options.inclusionUserCallbacks).toBeUndefined()
 	})
 
 	it('applies the soft-reset feature flag when explicitly configured', async () => {
-		const { lifecycle } = createHarness({
+		const { lifecycle, world } = createHarness({
 			serverEnabled: false,
 			enableSoftReset: false,
 		})
 		await lifecycle.connect()
-		expect(hoisted.drivers[0].options.features.softReset).toBe(false)
+		expect(world.drivers[0].options.features?.softReset).toBe(false)
 	})
 
 	it('maps rf auto power levels when autoPowerlevels is inferred true', async () => {
-		const { lifecycle, host } = createHarness({
+		const { lifecycle, host, world } = createHarness({
 			serverEnabled: false,
-			rf: { region: 1 } as any,
+			rf: { region: RFRegion.USA },
 		})
 		await lifecycle.connect()
-		const rf = hoisted.drivers[0].options.rf
-		expect(rf.region).toBe(1)
-		expect(rf.maxLongRangePowerlevel).toBe('auto')
-		expect(rf.txPower.powerlevel).toBe('auto')
+		const rf = world.drivers[0].options.rf
+		expect(rf?.region).toBe(RFRegion.USA)
+		expect(rf?.maxLongRangePowerlevel).toBe('auto')
+		expect(rf?.txPower?.powerlevel).toBe('auto')
 		expect(host.persistConfig).toHaveBeenCalled()
 	})
 
 	it('maps explicit rf power levels when autoPowerlevels is false', async () => {
-		const { lifecycle } = createHarness({
+		const { lifecycle, world } = createHarness({
 			serverEnabled: false,
 			rf: {
-				region: 2,
+				region: RFRegion.Europe,
 				autoPowerlevels: false,
 				maxLongRangePowerlevel: 10,
 				txPower: { powerlevel: 5, measured0dBm: 1 },
-			} as any,
+			},
 		})
 		await lifecycle.connect()
-		const rf = hoisted.drivers[0].options.rf
-		expect(rf.maxLongRangePowerlevel).toBe(10)
-		expect(rf.txPower.powerlevel).toBe(5)
-		expect(rf.txPower.measured0dBm).toBe(1)
+		const rf = world.drivers[0].options.rf
+		expect(rf?.maxLongRangePowerlevel).toBe(10)
+		expect(rf?.txPower?.powerlevel).toBe(5)
+		expect(rf?.txPower?.measured0dBm).toBe(1)
 	})
 
 	it('migrates a legacy networkKey to securityKeys.S0_Legacy and persists', async () => {
 		const { lifecycle, host, state } = createHarness({
 			serverEnabled: false,
 			networkKey: '0102030405060708090A0B0C0D0E0F10',
-		} as any)
+		})
 		await lifecycle.connect()
 		expect(state.cfg.securityKeys?.S0_Legacy).toBe(
 			'0102030405060708090A0B0C0D0E0F10',
 		)
-		expect((state.cfg as any).networkKey).toBeUndefined()
+		expect(state.cfg.networkKey).toBeUndefined()
 		expect(host.persistConfig).toHaveBeenCalled()
 	})
 
 	it('merges hidden cfg.options into the driver options', async () => {
-		const { lifecycle } = createHarness({
+		const { lifecycle, world } = createHarness({
 			serverEnabled: false,
-			options: { testMarker: 42 } as any,
+			options: zwaveOpts({ emitValueUpdateAfterSetValue: false }),
 		})
 		await lifecycle.connect()
-		expect(hoisted.drivers[0].options.testMarker).toBe(42)
+		expect(world.drivers[0].options.emitValueUpdateAfterSetValue).toBe(
+			false,
+		)
 	})
 })
 
@@ -788,11 +725,13 @@ describe('DriverLifecycle — connect error handling', () => {
 	it('on a generic start failure: destroys the driver, reports the error and backs off', async () => {
 		vi.useFakeTimers()
 		try {
-			const { lifecycle, host } = createHarness({ serverEnabled: false })
-			hoisted.startBehavior = 'reject'
-			hoisted.startError = new Error('boom')
+			const { lifecycle, host, world } = createHarness({
+				serverEnabled: false,
+			})
+			world.startBehavior = 'reject'
+			world.startError = new Error('boom')
 			await lifecycle.connect()
-			expect(hoisted.drivers[0].destroy).toHaveBeenCalled()
+			expect(world.drivers[0].destroy).toHaveBeenCalled()
 			expect(host.onDriverError).toHaveBeenCalledWith(
 				expect.any(Error),
 				true,
@@ -807,9 +746,11 @@ describe('DriverLifecycle — connect error handling', () => {
 	it('on Driver_InvalidOptions: reports the error but does NOT back off', async () => {
 		vi.useFakeTimers()
 		try {
-			const { lifecycle, host } = createHarness({ serverEnabled: false })
-			hoisted.startBehavior = 'reject'
-			hoisted.startError = new ZWaveError(
+			const { lifecycle, host, world } = createHarness({
+				serverEnabled: false,
+			})
+			world.startBehavior = 'reject'
+			world.startError = new ZWaveError(
 				'bad options',
 				ZWaveErrorCodes.Driver_InvalidOptions,
 			)
@@ -828,57 +769,61 @@ describe('DriverLifecycle — connect error handling', () => {
 
 describe('DriverLifecycle — connect generation fencing', () => {
 	it('aborts before driver creation when the generation changes during ensureDir', async () => {
-		const { lifecycle, state } = createHarness()
-		hoisted.ensureDirHook = () => {
+		const { lifecycle, world, state } = createHarness()
+		world.ensureDirHook = () => {
 			void lifecycle.close()
 		}
 		await lifecycle.connect()
-		expect(hoisted.drivers).toHaveLength(0)
+		expect(world.drivers).toHaveLength(0)
 		expect(state.status).toBe(ZwaveClientStatus.CLOSED)
 	})
 
 	it('aborts before driver.start when the generation changes during hasConnectedClients', async () => {
-		const { lifecycle, host } = createHarness()
-		;(host.hasConnectedClients as any).mockImplementation(() => {
+		const { lifecycle, host, world } = createHarness()
+		host.hasConnectedClients.mockImplementation(() => {
 			void lifecycle.close()
 			return Promise.resolve(false)
 		})
 		await lifecycle.connect()
-		expect(hoisted.drivers).toHaveLength(1)
-		expect(hoisted.drivers[0].start).not.toHaveBeenCalled()
+		expect(world.drivers).toHaveLength(1)
+		expect(world.drivers[0].start).not.toHaveBeenCalled()
 	})
 
 	it('aborts after driver.start when the generation changes during start()', async () => {
-		const { lifecycle, state } = createHarness({ serverEnabled: false })
-		hoisted.startHook = () => {
+		const { lifecycle, world, state } = createHarness({
+			serverEnabled: false,
+		})
+		world.startHook = () => {
 			void lifecycle.close()
 		}
 		await lifecycle.connect()
-		expect(hoisted.drivers[0].start).toHaveBeenCalled()
+		expect(world.drivers[0].start).toHaveBeenCalled()
 		expect(state.status).toBe(ZwaveClientStatus.CLOSED)
 	})
 
 	it('aborts when the generation changes during persistConfig', async () => {
-		const { lifecycle, host } = createHarness({
+		const { lifecycle, host, world } = createHarness({
 			serverEnabled: false,
-			rf: { region: 1 } as any,
+			rf: { region: RFRegion.USA },
 		})
-		;(host.persistConfig as any).mockImplementation(() => {
+		host.persistConfig.mockImplementation(() => {
 			void lifecycle.close()
 			return Promise.resolve()
 		})
 		await lifecycle.connect()
-		expect(hoisted.drivers).toHaveLength(0)
+		expect(world.drivers).toHaveLength(0)
 	})
 })
 
 describe('DriverLifecycle — pre-ready reconnect coalescing', () => {
 	it('a second connect after start() resolves but before driver ready does NOT construct or leak a replacement', async () => {
-		const { lifecycle, state } = createHarness({ serverEnabled: false })
+		const { lifecycle, world, state } = createHarness({
+			serverEnabled: false,
+		})
 
 		await lifecycle.connect()
-		expect(hoisted.drivers).toHaveLength(1)
-		const driver0 = hoisted.drivers[0]
+		expect(world.drivers).toHaveLength(1)
+		const driver0 = world.drivers[0]
 		expect(state.driver).toBe(driver0)
 		expect(state.status).toBe(ZwaveClientStatus.CONNECTED)
 		expect(state.driverReady).toBe(false)
@@ -886,20 +831,22 @@ describe('DriverLifecycle — pre-ready reconnect coalescing', () => {
 
 		await lifecycle.connect()
 
-		expect(hoisted.drivers).toHaveLength(1)
+		expect(world.drivers).toHaveLength(1)
 		expect(state.driver).toBe(driver0)
 		expect(driver0.destroy).not.toHaveBeenCalled()
 		expect(lifecycle.generation).toBe(genAfterFirst)
 	})
 
 	it('coalesces a second connect while the first is still awaiting driver.start(): it stays PENDING until the first settles, then settles together', async () => {
-		const { lifecycle, state } = createHarness({ serverEnabled: false })
-		hoisted.startBehavior = 'deferred'
+		const { lifecycle, world, state } = createHarness({
+			serverEnabled: false,
+		})
+		world.startBehavior = 'deferred'
 
 		const first = lifecycle.connect()
-		await until(() => hoisted.startDeferreds.length === 1)
-		expect(hoisted.drivers).toHaveLength(1)
-		const driver0 = hoisted.drivers[0]
+		await until(() => world.startDeferreds.length === 1)
+		expect(world.drivers).toHaveLength(1)
+		const driver0 = world.drivers[0]
 		const gen = lifecycle.generation
 
 		let firstSettled = false
@@ -912,33 +859,33 @@ describe('DriverLifecycle — pre-ready reconnect coalescing', () => {
 			secondSettled = true
 		})
 
-		await until(() => hoisted.startDeferreds.length === 1)
-		expect(hoisted.drivers).toHaveLength(1)
-		expect(hoisted.startDeferreds).toHaveLength(1)
+		await until(() => world.startDeferreds.length === 1)
+		expect(world.drivers).toHaveLength(1)
+		expect(world.startDeferreds).toHaveLength(1)
 		expect(state.driver).toBe(driver0)
 		expect(lifecycle.generation).toBe(gen)
 		expect(driver0.start).toHaveBeenCalledTimes(1)
 		expect(firstSettled).toBe(false)
 		expect(secondSettled).toBe(false)
 
-		hoisted.startDeferreds[0].resolve()
+		world.startDeferreds[0].resolve()
 		await Promise.all([first, second])
 		expect(firstSettled).toBe(true)
 		expect(secondSettled).toBe(true)
 		expect(state.status).toBe(ZwaveClientStatus.CONNECTED)
-		expect(hoisted.drivers).toHaveLength(1)
+		expect(world.drivers).toHaveLength(1)
 		expect(driver0.destroy).not.toHaveBeenCalled()
 	})
 
 	it('a coalesced duplicate connect shares the first connect FAILURE settlement (start rejects) and no second Driver is built', async () => {
-		const { lifecycle, state, host } = createHarness({
+		const { lifecycle, world, state, host } = createHarness({
 			serverEnabled: false,
 		})
-		hoisted.startBehavior = 'deferred'
+		world.startBehavior = 'deferred'
 
 		const first = lifecycle.connect()
-		await until(() => hoisted.startDeferreds.length === 1)
-		const driver0 = hoisted.drivers[0]
+		await until(() => world.startDeferreds.length === 1)
+		const driver0 = world.drivers[0]
 
 		let firstSettled = false
 		let secondSettled = false
@@ -949,74 +896,79 @@ describe('DriverLifecycle — pre-ready reconnect coalescing', () => {
 		void second.then(() => {
 			secondSettled = true
 		})
-		await until(() => hoisted.startDeferreds.length === 1)
+		await until(() => world.startDeferreds.length === 1)
 		expect(firstSettled).toBe(false)
 		expect(secondSettled).toBe(false)
 
-		hoisted.startDeferreds[0].reject(new Error('start failed'))
+		world.startDeferreds[0].reject(new Error('start failed'))
 		await expect(Promise.all([first, second])).resolves.toBeDefined()
 		expect(firstSettled).toBe(true)
 		expect(secondSettled).toBe(true)
-		expect(hoisted.drivers).toHaveLength(1)
+		expect(world.drivers).toHaveLength(1)
 		expect(driver0.destroy).toHaveBeenCalledTimes(1)
 		expect(state.driver).toBeNull()
 		expect(host.onDriverError).toHaveBeenCalledTimes(1)
 	})
 
 	it('a duplicate connect AFTER the first start settled but BEFORE driver ready returns compatibly without a replacement', async () => {
-		const { lifecycle, state } = createHarness({ serverEnabled: false })
+		const { lifecycle, world, state } = createHarness({
+			serverEnabled: false,
+		})
 
 		await lifecycle.connect()
-		const driver0 = hoisted.drivers[0]
+		const driver0 = world.drivers[0]
 		const gen = lifecycle.generation
 		expect(state.status).toBe(ZwaveClientStatus.CONNECTED)
 		expect(state.driverReady).toBe(false)
 
 		await lifecycle.connect()
-		expect(hoisted.drivers).toHaveLength(1)
+		expect(world.drivers).toHaveLength(1)
 		expect(state.driver).toBe(driver0)
 		expect(driver0.destroy).not.toHaveBeenCalled()
 		expect(lifecycle.generation).toBe(gen)
 	})
 
 	it('a recovery reconnect after a start failure is NOT coalesced (host cleared) and builds exactly one fresh driver', async () => {
-		const { lifecycle, state } = createHarness({ serverEnabled: false })
+		const { lifecycle, world, state } = createHarness({
+			serverEnabled: false,
+		})
 
-		hoisted.startBehavior = 'reject'
+		world.startBehavior = 'reject'
 		await lifecycle.connect()
-		expect(hoisted.drivers).toHaveLength(1)
-		expect(hoisted.drivers[0].destroy).toHaveBeenCalledTimes(1)
+		expect(world.drivers).toHaveLength(1)
+		expect(world.drivers[0].destroy).toHaveBeenCalledTimes(1)
 		expect(state.driver).toBeNull()
 
 		await lifecycle.close(true)
 		state.closed = false
 
-		hoisted.startBehavior = 'resolve'
+		world.startBehavior = 'resolve'
 		await lifecycle.connect()
 
-		expect(hoisted.drivers).toHaveLength(2)
-		expect(state.driver).toBe(hoisted.drivers[1])
+		expect(world.drivers).toHaveLength(2)
+		expect(state.driver).toBe(world.drivers[1])
 		expect(state.status).toBe(ZwaveClientStatus.CONNECTED)
 	})
 
 	async function openCloseReconnectWithStale() {
 		const harness = createHarness({ serverEnabled: false })
-		hoisted.startBehavior = 'deferred'
+		const { world } = harness
+		world.startBehavior = 'deferred'
 
 		const stalePromise = harness.lifecycle.connect()
-		await until(() => hoisted.startDeferreds.length === 1)
-		const driver0 = hoisted.drivers[0]
+		await until(() => world.startDeferreds.length === 1)
+		const driver0 = world.drivers[0]
 		expect(harness.state.driver).toBe(driver0)
 
 		await harness.lifecycle.close(true)
 		expect(harness.state.driver).toBeNull()
 		harness.state.closed = false
 
-		hoisted.startBehavior = 'deferred'
+		world.startBehavior = 'deferred'
 		const freshPromise = harness.lifecycle.connect()
-		await until(() => hoisted.startDeferreds.length === 2)
-		const driver1 = hoisted.drivers[1]
-		hoisted.startDeferreds[1].resolve()
+		await until(() => world.startDeferreds.length === 2)
+		const driver1 = world.drivers[1]
+		world.startDeferreds[1].resolve()
 		await freshPromise
 		expect(harness.state.driver).toBe(driver1)
 		expect(harness.state.status).toBe(ZwaveClientStatus.CONNECTED)
@@ -1025,34 +977,29 @@ describe('DriverLifecycle — pre-ready reconnect coalescing', () => {
 	}
 
 	it('a stale start that RESOLVES after a close+reconnect tears down only its own driver', async () => {
-		const { state, stalePromise, driver0, driver1 } =
+		const { world, state, stalePromise, driver1 } =
 			await openCloseReconnectWithStale()
 
-		hoisted.startDeferreds[0].resolve()
+		world.startDeferreds[0].resolve()
 		await stalePromise
 
-		expect(hoisted.destroyOrder.filter((d) => d === 'driver')).toHaveLength(
-			1,
-		)
+		expect(world.destroyOrder.filter((d) => d === 'driver')).toHaveLength(1)
 		expect(driver1.destroy).not.toHaveBeenCalled()
 		expect(state.driver).toBe(driver1)
 	})
 
 	it('a stale start that REJECTS after a close+reconnect never destroys the replacement or backs off', async () => {
-		const { host, state, stalePromise, driver0, driver1 } =
+		const { host, world, state, stalePromise, driver1 } =
 			await openCloseReconnectWithStale()
 
-		hoisted.startDeferreds[0].reject(new Error('late start failure'))
+		world.startDeferreds[0].reject(new Error('late start failure'))
 		await stalePromise
 
-		expect(hoisted.destroyOrder.filter((d) => d === 'driver')).toHaveLength(
-			1,
-		)
+		expect(world.destroyOrder.filter((d) => d === 'driver')).toHaveLength(1)
 		expect(driver1.destroy).not.toHaveBeenCalled()
 		expect(state.driver).toBe(driver1)
 		expect(host.onDriverError).not.toHaveBeenCalled()
 		expect(host.restart).not.toHaveBeenCalled()
-		void driver0
 	})
 })
 
@@ -1060,32 +1007,32 @@ describe('DriverLifecycle — failed-connect teardown ownership', () => {
 	it('awaits the failed driver destroy before clearing the host or backing off (no replacement built while the owner is torn down)', async () => {
 		vi.useFakeTimers()
 		try {
-			const { lifecycle, state, host } = createHarness({
+			const { lifecycle, world, state, host } = createHarness({
 				serverEnabled: false,
 			})
-			hoisted.startBehavior = 'reject'
-			hoisted.startError = new Error('start boom')
-			hoisted.destroyBehavior = 'deferred'
+			world.startBehavior = 'reject'
+			world.startError = new Error('start boom')
+			world.destroyBehavior = 'deferred'
 
 			const connectP = lifecycle.connect()
 
-			await until(() => hoisted.destroyDeferreds.length === 1)
-			expect(hoisted.drivers).toHaveLength(1)
-			const driver0 = hoisted.drivers[0]
+			await until(() => world.destroyDeferreds.length === 1)
+			expect(world.drivers).toHaveLength(1)
+			const driver0 = world.drivers[0]
 			expect(state.driver).toBe(driver0)
 			expect(host.onDriverError).not.toHaveBeenCalled()
 			expect(host.restart).not.toHaveBeenCalled()
 
 			const concurrent = lifecycle.connect()
-			await until(() => hoisted.destroyDeferreds.length === 1)
-			expect(hoisted.drivers).toHaveLength(1)
+			await until(() => world.destroyDeferreds.length === 1)
+			expect(world.drivers).toHaveLength(1)
 			expect(driver0.start).toHaveBeenCalledTimes(1)
 
-			hoisted.destroyDeferreds[0].resolve()
+			world.destroyDeferreds[0].resolve()
 			await connectP
 			await concurrent
 			expect(state.driver).toBeNull()
-			expect(hoisted.destroyOrder).toEqual(['driver'])
+			expect(world.destroyOrder).toEqual(['driver'])
 			expect(host.onDriverError).toHaveBeenCalledTimes(1)
 			expect(host.onDriverError).toHaveBeenCalledWith(
 				expect.any(Error),
@@ -1093,7 +1040,7 @@ describe('DriverLifecycle — failed-connect teardown ownership', () => {
 			)
 			await vi.advanceTimersByTimeAsync(1000)
 			expect(host.restart).toHaveBeenCalledTimes(1)
-			expect(hoisted.drivers).toHaveLength(1)
+			expect(world.drivers).toHaveLength(1)
 		} finally {
 			vi.useRealTimers()
 		}
@@ -1102,27 +1049,27 @@ describe('DriverLifecycle — failed-connect teardown ownership', () => {
 	it('retains the exact owner when destroy REJECTS and lets a later close retry the cleanup (no leak, no wrong destroy)', async () => {
 		vi.useFakeTimers()
 		try {
-			const { lifecycle, state, host } = createHarness({
+			const { lifecycle, world, state, host } = createHarness({
 				serverEnabled: false,
 			})
-			hoisted.startBehavior = 'reject'
-			hoisted.startError = new Error('start boom')
-			hoisted.destroyRejectCount = 1
+			world.startBehavior = 'reject'
+			world.startError = new Error('start boom')
+			world.destroyRejectCount = 1
 
 			await lifecycle.connect()
-			const driver0 = hoisted.drivers[0]
+			const driver0 = world.drivers[0]
 
-			expect(hoisted.drivers).toHaveLength(1)
+			expect(world.drivers).toHaveLength(1)
 			expect(state.driver).toBe(driver0)
-			expect(hoisted.destroyInvocations).toBe(1)
-			expect(hoisted.destroyOrder).toEqual([])
+			expect(world.destroyInvocations).toBe(1)
+			expect(world.destroyOrder).toEqual([])
 			expect(host.onDriverError).toHaveBeenCalledTimes(1)
 
 			await lifecycle.close(true)
-			expect(hoisted.destroyInvocations).toBe(2)
-			expect(hoisted.destroyOrder).toEqual(['driver'])
+			expect(world.destroyInvocations).toBe(2)
+			expect(world.destroyOrder).toEqual(['driver'])
 			expect(state.driver).toBeNull()
-			expect(hoisted.drivers).toHaveLength(1)
+			expect(world.drivers).toHaveLength(1)
 			expect(driver0.destroy).toHaveBeenCalledTimes(2)
 		} finally {
 			vi.useRealTimers()
@@ -1130,163 +1077,141 @@ describe('DriverLifecycle — failed-connect teardown ownership', () => {
 	})
 
 	it('a stale post-start exit awaits teardown of its OWN instance and never destroys the live replacement, even with a delayed destroy', async () => {
-		const { lifecycle, state } = createHarness({ serverEnabled: false })
-		hoisted.startBehavior = 'deferred'
+		const { lifecycle, world, state } = createHarness({
+			serverEnabled: false,
+		})
+		world.startBehavior = 'deferred'
 
 		const staleP = lifecycle.connect()
-		await until(() => hoisted.startDeferreds.length === 1)
-		const driver0 = hoisted.drivers[0]
+		await until(() => world.startDeferreds.length === 1)
 
 		await lifecycle.close(true)
 		state.closed = false
-		hoisted.startBehavior = 'deferred'
+		world.startBehavior = 'deferred'
 		const freshP = lifecycle.connect()
-		await until(() => hoisted.startDeferreds.length === 2)
-		const driver1 = hoisted.drivers[1]
-		hoisted.startDeferreds[1].resolve()
+		await until(() => world.startDeferreds.length === 2)
+		const driver1 = world.drivers[1]
+		world.startDeferreds[1].resolve()
 		await freshP
 		expect(state.driver).toBe(driver1)
 
-		hoisted.startDeferreds[0].resolve()
+		world.startDeferreds[0].resolve()
 		await staleP
 
 		expect(driver1.destroy).not.toHaveBeenCalled()
 		expect(state.driver).toBe(driver1)
-		expect(hoisted.destroyOrder.filter((d) => d === 'driver')).toHaveLength(
-			1,
-		)
-		void driver0
+		expect(world.destroyOrder.filter((d) => d === 'driver')).toHaveLength(1)
 	})
 })
 
 describe('DriverLifecycle — final logConfig override', () => {
 	it('a documented zwave.options.logConfig override still receives the JSON transport, extra transports and bumped level', async () => {
-		const { lifecycle } = createHarness({
+		const { lifecycle, world } = createHarness({
 			serverEnabled: false,
-			options: { logConfig: { level: 'error' } } as any,
+			options: zwaveOpts({ logConfig: { level: 'error' } }),
 		})
-		const extra = { id: 'extra-forwarder' }
+		const extra = new Transport({})
 		lifecycle.addExtraLogTransport(extra, 'debug')
 
 		await lifecycle.connect()
 
-		const passedLogConfig = hoisted.drivers[0].options.logConfig
-		const jsonTransport = hoisted.logTransports[0]
+		const passedLogConfig = world.drivers[0].options.logConfig
+		const jsonTransport = world.logTransports[0]
 		expect(jsonTransport).toBeDefined()
-		expect(passedLogConfig.transports).toContain(jsonTransport)
-		expect(passedLogConfig.transports).toContain(extra)
-		expect(passedLogConfig.level).toBe('debug')
+		expect(passedLogConfig?.transports).toContain(jsonTransport)
+		expect(passedLogConfig?.transports).toContain(extra)
+		expect(passedLogConfig?.level).toBe('debug')
 	})
 
 	it('a zwave.options.logConfig override with no extra transports still receives the JSON transport', async () => {
-		const { lifecycle } = createHarness({
+		const { lifecycle, world } = createHarness({
 			serverEnabled: false,
-			options: { logConfig: { level: 'warn' } } as any,
+			options: zwaveOpts({ logConfig: { level: 'warn' } }),
 		})
 
 		await lifecycle.connect()
 
-		const passedLogConfig = hoisted.drivers[0].options.logConfig
-		const jsonTransport = hoisted.logTransports[0]
-		expect(passedLogConfig.transports).toEqual([jsonTransport])
-		expect(passedLogConfig.level).toBe('warn')
+		const passedLogConfig = world.drivers[0].options.logConfig
+		const jsonTransport = world.logTransports[0]
+		expect(passedLogConfig?.transports).toEqual([jsonTransport])
+		expect(passedLogConfig?.level).toBe('warn')
 	})
 
 	it('a driver built with NO logConfig object connects cleanly and leaves the base level unset', async () => {
-		hoisted.buildLogConfigOverride = () => undefined
-		const { lifecycle, state } = createHarness({ serverEnabled: false })
+		const { lifecycle, world, state } = createHarness({
+			serverEnabled: false,
+			options: zwaveOpts({ logConfig: undefined }),
+		})
 
 		await lifecycle.connect()
 
-		expect(hoisted.drivers).toHaveLength(1)
-		expect(hoisted.drivers[0].options.logConfig).toBeUndefined()
-		expect(state.driver).toBe(hoisted.drivers[0])
+		expect(world.drivers).toHaveLength(1)
+		expect(world.drivers[0].options.logConfig).toBeUndefined()
+		expect(state.driver).toBe(world.drivers[0])
 
 		state.driverReadyRaw = true
-		hoisted.drivers[0].updateLogConfig.mockClear()
-		const extra = { id: 'x' }
+		world.drivers[0].updateLogConfig.mockClear()
+		const extra = new Transport({})
 		lifecycle.addExtraLogTransport(extra, 'warn')
-		expect(hoisted.drivers[0].updateLogConfig).toHaveBeenCalledWith({
-			transports: [hoisted.logTransports[0], extra],
+		expect(world.drivers[0].updateLogConfig).toHaveBeenCalledWith({
+			transports: [world.logTransports[0], extra],
 			level: 'warn',
-		})
-	})
-
-	it('a driver logConfig with a non-string level leaves the base level unset and never overwrites it', async () => {
-		hoisted.buildLogConfigOverride = () => ({ level: 42 })
-		const { lifecycle } = createHarness({ serverEnabled: false })
-
-		await lifecycle.connect()
-
-		const passedLogConfig = hoisted.drivers[0].options.logConfig
-		expect(passedLogConfig.transports).toEqual([hoisted.logTransports[0]])
-		expect(passedLogConfig.level).toBe(42)
-
-		lifecycle['host'].isDriverReadyRaw = () => true
-		hoisted.drivers[0].updateLogConfig.mockClear()
-		const extra = { id: 'y' }
-		lifecycle.addExtraLogTransport(extra, 'silly')
-		expect(hoisted.drivers[0].updateLogConfig).toHaveBeenCalledWith({
-			transports: [hoisted.logTransports[0], extra],
-			level: 'silly',
 		})
 	})
 })
 
 describe('DriverLifecycle — logConfig source isolation', () => {
 	it('does not mutate the persisted cfg.options.logConfig; the driver receives a distinct enriched clone', async () => {
-		const { lifecycle, state } = createHarness({
+		const { lifecycle, world, state } = createHarness({
 			serverEnabled: false,
-			options: {
-				logConfig: { level: 'warn', maxFiles: 5 },
-			} as any,
+			options: zwaveOpts({ logConfig: { level: 'warn', maxFiles: 5 } }),
 		})
-		const source = (state.cfg as any).options.logConfig
+		const source = state.cfg.options?.logConfig
 		const sourceSnapshot = JSON.parse(JSON.stringify(source))
-		const extra = { id: 'debug-forwarder' }
+		const extra = new Transport({})
 		lifecycle.addExtraLogTransport(extra, 'debug')
 
 		await lifecycle.connect()
 
-		const driverLogConfig = hoisted.drivers[0].options.logConfig
+		const driverLogConfig = world.drivers[0].options.logConfig
 		expect(driverLogConfig).not.toBe(source)
-		expect(driverLogConfig.transports).toContain(hoisted.logTransports[0])
-		expect(driverLogConfig.transports).toContain(extra)
-		expect(driverLogConfig.level).toBe('debug')
+		expect(driverLogConfig?.transports).toContain(world.logTransports[0])
+		expect(driverLogConfig?.transports).toContain(extra)
+		expect(driverLogConfig?.level).toBe('debug')
 
-		expect((state.cfg as any).options.logConfig).toBe(source)
+		expect(state.cfg.options?.logConfig).toBe(source)
 		expect(source).toEqual(sourceSnapshot)
-		expect(source.transports).toBeUndefined()
-		expect(source.level).toBe('warn')
+		expect(source?.transports).toBeUndefined()
+		expect(source?.level).toBe('warn')
 	})
 
 	it('removing a debug transport and restarting returns the driver to the configured level without leaking runtime transports', async () => {
-		const { lifecycle, state } = createHarness({
+		const { lifecycle, world, state } = createHarness({
 			serverEnabled: false,
-			options: { logConfig: { level: 'info' } } as any,
+			options: zwaveOpts({ logConfig: { level: 'info' } }),
 		})
-		const source = (state.cfg as any).options.logConfig
+		const source = state.cfg.options?.logConfig
 		const sourceSnapshot = JSON.parse(JSON.stringify(source))
-		const extra = { id: 'temp-debug' }
+		const extra = new Transport({})
 
 		lifecycle.addExtraLogTransport(extra, 'debug')
 		await lifecycle.connect()
-		expect(hoisted.drivers[0].options.logConfig.level).toBe('debug')
+		expect(world.drivers[0].options.logConfig?.level).toBe('debug')
 		expect(source).toEqual(sourceSnapshot)
-		expect((state.cfg as any).options.logConfig).toBe(source)
+		expect(state.cfg.options?.logConfig).toBe(source)
 
 		lifecycle.removeExtraLogTransport(extra)
 		await lifecycle.close()
 		state.closed = false
 		await lifecycle.connect()
 
-		const restarted = hoisted.drivers[1].options.logConfig
-		expect(restarted.level).toBe('info')
-		expect(restarted.transports).toEqual([hoisted.logTransports[1]])
+		const restarted = world.drivers[1].options.logConfig
+		expect(restarted?.level).toBe('info')
+		expect(restarted?.transports).toEqual([world.logTransports[1]])
 
-		expect((state.cfg as any).options.logConfig).toBe(source)
+		expect(state.cfg.options?.logConfig).toBe(source)
 		expect(source).toEqual(sourceSnapshot)
-		expect(source.level).toBe('info')
+		expect(source?.level).toBe('info')
 	})
 })
 
@@ -1306,12 +1231,10 @@ describe('DriverLifecycle — close', () => {
 	})
 
 	it('destroys the server BEFORE the driver', async () => {
-		const { lifecycle } = createHarness({ serverEnabled: true })
-		const mgr = fakeManager()
-		lifecycle.adoptServerManager(mgr as any)
+		const { lifecycle, world } = createHarness({ serverEnabled: true })
 		await lifecycle.connect()
 		await lifecycle.close()
-		expect(hoisted.destroyOrder).toEqual(['server', 'driver'])
+		expect(world.destroyOrder).toEqual(['server', 'driver'])
 	})
 
 	it('does not finalize (keep listeners) when keepListeners is true', async () => {
@@ -1335,18 +1258,20 @@ describe('DriverLifecycle — close', () => {
 	})
 
 	it('is idempotent and safe to call with no driver or server', async () => {
-		const { lifecycle } = createHarness()
+		const { lifecycle, world } = createHarness()
 		await expect(lifecycle.close()).resolves.toBeUndefined()
 		await expect(lifecycle.close()).resolves.toBeUndefined()
-		expect(hoisted.destroyOrder).toEqual([])
+		expect(world.destroyOrder).toEqual([])
 	})
 })
 
 describe('DriverLifecycle — driver-event dispatch', () => {
 	it('forwards every driver event to the host with the current generation', async () => {
-		const { lifecycle, host } = createHarness({ serverEnabled: false })
+		const { lifecycle, host, world } = createHarness({
+			serverEnabled: false,
+		})
 		await lifecycle.connect()
-		const driver = hoisted.drivers[0]
+		const driver = world.drivers[0]
 
 		driver.emit('driver ready')
 		await flush()
@@ -1372,9 +1297,11 @@ describe('DriverLifecycle — driver-event dispatch', () => {
 	})
 
 	it('fences a LATE driver-ready from an obsolete generation after close()', async () => {
-		const { lifecycle, host } = createHarness({ serverEnabled: false })
+		const { lifecycle, host, world } = createHarness({
+			serverEnabled: false,
+		})
 		await lifecycle.connect()
-		const driver = hoisted.drivers[0]
+		const driver = world.drivers[0]
 		await lifecycle.close()
 
 		host.onDriverReady = vi.fn(async () => {})
@@ -1384,9 +1311,11 @@ describe('DriverLifecycle — driver-event dispatch', () => {
 	})
 
 	it('fences a late error/scan/bootloader/OTW callback after the generation moves on', async () => {
-		const { lifecycle, host } = createHarness({ serverEnabled: false })
+		const { lifecycle, host, world } = createHarness({
+			serverEnabled: false,
+		})
 		await lifecycle.connect()
-		const driver = hoisted.drivers[0]
+		const driver = world.drivers[0]
 		await lifecycle.close()
 
 		driver.emit('error', new Error('late'))
@@ -1405,12 +1334,12 @@ describe('DriverLifecycle — driver-event dispatch', () => {
 
 describe('DriverLifecycle — connect option/edge coverage', () => {
 	it('builds scale preferences from cfg.scales', async () => {
-		const { lifecycle } = createHarness({
+		const { lifecycle, world } = createHarness({
 			serverEnabled: false,
-			scales: [{ key: 1, label: 'Celsius' }] as any,
+			scales: [{ key: 1, sensor: 'Air temperature', label: 'Celsius' }],
 		})
 		await lifecycle.connect()
-		expect(hoisted.drivers[0].options.preferences).toEqual({
+		expect(world.drivers[0].options.preferences).toEqual({
 			scales: { 1: 'Celsius' },
 		})
 	})
@@ -1419,44 +1348,48 @@ describe('DriverLifecycle — connect option/edge coverage', () => {
 		const proc = process as NodeJS.Process & { pkg?: unknown }
 		proc.pkg = {}
 		try {
-			const { lifecycle } = createHarness({ serverEnabled: false })
+			const { lifecycle, world } = createHarness({ serverEnabled: false })
 			await lifecycle.connect()
-			expect(hoisted.drivers[0].options.host?.fs).toBeDefined()
+			expect(world.drivers[0].options.host?.fs).toBeDefined()
 		} finally {
 			delete proc.pkg
 		}
 	})
 
 	it('merges registered extra log transports and bumps the log level to the most verbose', async () => {
-		const { lifecycle } = createHarness({ serverEnabled: false })
-		const t1 = { id: 'extra-1' }
-		const t2 = { id: 'extra-2' }
+		const { lifecycle, world } = createHarness({ serverEnabled: false })
+		const t1 = new Transport({})
+		const t2 = new Transport({})
 		lifecycle.addExtraLogTransport(t1, 'warn')
 		lifecycle.addExtraLogTransport(t2, 'silly')
 		await lifecycle.connect()
-		const logConfig = hoisted.drivers[0].options.logConfig
-		expect(logConfig.transports).toContain(t1)
-		expect(logConfig.transports).toContain(t2)
-		expect(logConfig.level).toBe('silly')
+		const logConfig = world.drivers[0].options.logConfig
+		expect(logConfig?.transports).toContain(t1)
+		expect(logConfig?.transports).toContain(t2)
+		expect(logConfig?.level).toBe('silly')
 	})
 
 	it('forwards driver log stream data to host.emitDebug', async () => {
-		const { lifecycle, host } = createHarness({ serverEnabled: false })
+		const { lifecycle, host, world } = createHarness({
+			serverEnabled: false,
+		})
 		await lifecycle.connect()
-		const transport = hoisted.logTransports[0]
+		const transport = world.logTransports[0]
 		expect(transport).toBeDefined()
 		transport.stream.emit('data', { message: 'hello world' })
 		expect(host.emitDebug).toHaveBeenCalledWith('hello world')
 	})
 
 	it('aborts after start() when the client became destroyed mid-start', async () => {
-		const { lifecycle, state } = createHarness({ serverEnabled: false })
-		hoisted.startHook = () => {
+		const { lifecycle, world, state } = createHarness({
+			serverEnabled: false,
+		})
+		world.startHook = () => {
 			state.destroyed = true
 		}
 		await lifecycle.connect()
 		expect(state.status).not.toBe(ZwaveClientStatus.CONNECTED)
-		expect(hoisted.drivers[0].start).toHaveBeenCalled()
+		expect(world.drivers[0].start).toHaveBeenCalled()
 	})
 })
 
@@ -1464,10 +1397,12 @@ describe('DriverLifecycle — connect catch-path edges', () => {
 	it('swallows a driver.destroy() rejection while handling a start failure', async () => {
 		vi.useFakeTimers()
 		try {
-			const { lifecycle, host } = createHarness({ serverEnabled: false })
-			hoisted.startBehavior = 'reject'
-			hoisted.startError = new Error('start boom')
-			hoisted.destroyRejects = true
+			const { lifecycle, host, world } = createHarness({
+				serverEnabled: false,
+			})
+			world.startBehavior = 'reject'
+			world.startError = new Error('start boom')
+			world.destroyRejects = true
 			await lifecycle.connect()
 			await flush()
 			expect(host.onDriverError).toHaveBeenCalledWith(
@@ -1482,10 +1417,12 @@ describe('DriverLifecycle — connect catch-path edges', () => {
 	})
 
 	it('aborts the catch path without reporting when the generation changed', async () => {
-		const { lifecycle, host } = createHarness({ serverEnabled: false })
-		hoisted.startBehavior = 'reject'
-		hoisted.startError = new Error('boom')
-		hoisted.startHook = () => {
+		const { lifecycle, host, world } = createHarness({
+			serverEnabled: false,
+		})
+		world.startBehavior = 'reject'
+		world.startError = new Error('boom')
+		world.startHook = () => {
 			void lifecycle.close()
 		}
 		await lifecycle.connect()
@@ -1493,12 +1430,12 @@ describe('DriverLifecycle — connect catch-path edges', () => {
 	})
 
 	it('aborts the catch path (closing) when the client became destroyed', async () => {
-		const { lifecycle, host, state } = createHarness({
+		const { lifecycle, host, world, state } = createHarness({
 			serverEnabled: false,
 		})
-		hoisted.startBehavior = 'reject'
-		hoisted.startError = new Error('boom')
-		hoisted.startHook = () => {
+		world.startBehavior = 'reject'
+		world.startError = new Error('boom')
+		world.startHook = () => {
 			state.destroyed = true
 		}
 		await lifecycle.connect()
@@ -1512,7 +1449,7 @@ describe('DriverLifecycle — async failure logging', () => {
 		vi.useFakeTimers()
 		try {
 			const { lifecycle, host } = createHarness()
-			;(host.restart as any).mockRejectedValue(new Error('restart boom'))
+			host.restart.mockRejectedValue(new Error('restart boom'))
 			lifecycle.backoffRestart()
 			await vi.advanceTimersByTimeAsync(1000)
 			await flush()
@@ -1523,11 +1460,12 @@ describe('DriverLifecycle — async failure logging', () => {
 	})
 
 	it('logs (and swallows) a close failure triggered by checkIfDestroyed', async () => {
-		const { lifecycle, state } = createHarness()
+		const { lifecycle, world, state } = createHarness({
+			serverEnabled: false,
+		})
+		await lifecycle.connect()
+		world.destroyBehavior = 'reject'
 		state.destroyed = true
-		state.driver = {
-			destroy: vi.fn(() => Promise.reject(new Error('destroy boom'))),
-		}
 		expect(lifecycle.checkIfDestroyed()).toBe(true)
 		await flush()
 		await flush()

--- a/test/lib/zwave/DriverLifecycle.test.ts
+++ b/test/lib/zwave/DriverLifecycle.test.ts
@@ -28,12 +28,6 @@ import type {
 } from '../../../api/lib/zwave/ports.ts'
 import { ZwaveClientStatus } from '../../../api/lib/zwave/ports.ts'
 
-// The lifecycle constructs its Driver, JSON log transport and server manager
-// through injected factories, so every test drives the real production wiring
-// with typed fakes and never module-mocks or reaches into private seams. Casts
-// to the production port types live only at the injection boundary below; the
-// `world` recorder keeps the concrete fake types so assertions stay type-safe.
-
 type StartBehavior = 'resolve' | 'reject' | 'hang' | 'deferred'
 type DestroyBehavior = 'resolve' | 'reject' | 'deferred'
 
@@ -236,8 +230,6 @@ function createHarness(cfgOverrides: Partial<ZwaveConfig> = {}) {
 		userCallbacks: {} as InclusionUserCallbacks,
 	}
 
-	// The injected server-manager factory ignores its host arg, so this stub only
-	// has to exist for `buildServerHost()` to return something type-compatible
 	const serverHostStub = {} as unknown as ZwaveServerHost
 
 	const host = {
@@ -344,7 +336,7 @@ describe('DriverLifecycle — extra log transports', () => {
 		return { ...harness, json, driver }
 	}
 
-	it('addExtraLogTransport sends the COMPLETE transport list (JSON socket + extra) and raises the level', async () => {
+	it('addExtraLogTransport keeps the JSON transport in the list and raises the level', async () => {
 		const { lifecycle, json, driver } = await connectedReadyHarness()
 		const extra = new Transport({})
 		lifecycle.addExtraLogTransport(extra, 'debug')
@@ -365,7 +357,7 @@ describe('DriverLifecycle — extra log transports', () => {
 		})
 	})
 
-	it('multiple extras with different levels: full list retained and the MOST verbose level wins', async () => {
+	it('multiple extras keep every transport and select the most verbose level', async () => {
 		const { lifecycle, json, driver } = await connectedReadyHarness()
 		const a = new Transport({})
 		const b = new Transport({})
@@ -379,7 +371,7 @@ describe('DriverLifecycle — extra log transports', () => {
 		})
 	})
 
-	it('removeExtraLogTransport re-sends the remaining transports (never empties the list) and restores the baseline level', async () => {
+	it('removeExtraLogTransport re-sends the remaining transports and restores the baseline level', async () => {
 		const { lifecycle, json, driver } = await connectedReadyHarness()
 		const keep = new Transport({})
 		const temp = new Transport({})
@@ -395,7 +387,7 @@ describe('DriverLifecycle — extra log transports', () => {
 		})
 	})
 
-	it('removing the LAST extra still re-sends the required JSON transport (not an empty array) at the baseline level', async () => {
+	it('removing the last extra still re-sends the JSON transport at the baseline level', async () => {
 		const { lifecycle, json, driver } = await connectedReadyHarness()
 		const temp = new Transport({})
 		lifecycle.addExtraLogTransport(temp, 'debug')
@@ -407,7 +399,7 @@ describe('DriverLifecycle — extra log transports', () => {
 		})
 	})
 
-	it('removal order does not matter: the level tracks the most verbose REMAINING extra', async () => {
+	it('the level tracks the most verbose remaining extra regardless of removal order', async () => {
 		const { lifecycle, json, driver } = await connectedReadyHarness()
 		const warnT = new Transport({})
 		const debugT = new Transport({})
@@ -427,7 +419,7 @@ describe('DriverLifecycle — extra log transports', () => {
 		})
 	})
 
-	it('a configured non-default level is the floor: adding a LESS verbose extra does not lower it', async () => {
+	it('a less verbose extra does not lower the configured level', async () => {
 		const { lifecycle, json, driver } = await connectedReadyHarness({
 			logLevel: 'info',
 			options: zwaveOpts({ logConfig: { level: 'verbose' } }),
@@ -440,7 +432,7 @@ describe('DriverLifecycle — extra log transports', () => {
 		})
 	})
 
-	it('addExtraLogTransport does not touch the driver when it is not ready (registration still persists)', async () => {
+	it('addExtraLogTransport leaves the driver untouched until it is ready, then applies the registered transport', async () => {
 		const { lifecycle, world, state } = createHarness({
 			serverEnabled: false,
 		})
@@ -460,7 +452,7 @@ describe('DriverLifecycle — extra log transports', () => {
 		})
 	})
 
-	it('before connect there is no driver and add/remove are inert no-ops', () => {
+	it('adding or removing transports before connect is a safe no-op', () => {
 		const { lifecycle } = createHarness({ serverEnabled: false })
 		const t = new Transport({})
 		expect(() => lifecycle.addExtraLogTransport(t, 'debug')).not.toThrow()
@@ -500,7 +492,7 @@ describe('DriverLifecycle — backoff restart & checkIfDestroyed', () => {
 		expect(host.restart).toHaveBeenCalledTimes(3)
 	})
 
-	it('backoffRestart aborts (and closes) when the client is already destroyed', async () => {
+	it('backoffRestart aborts and closes when the client is already destroyed', async () => {
 		const { lifecycle, host, state } = createHarness()
 		state.destroyed = true
 		lifecycle.backoffRestart()
@@ -526,7 +518,7 @@ describe('DriverLifecycle — backoff restart coalescing & fencing', () => {
 	beforeEach(() => vi.useFakeTimers())
 	afterEach(() => vi.useRealTimers())
 
-	it('coalesces two backoff schedules made before firing into a single restart (latest delay wins)', async () => {
+	it('coalesces two backoff schedules into a single restart', async () => {
 		const { lifecycle, host } = createHarness()
 
 		lifecycle.backoffRestart()
@@ -542,7 +534,7 @@ describe('DriverLifecycle — backoff restart coalescing & fencing', () => {
 		expect(host.restart).toHaveBeenCalledTimes(1)
 	})
 
-	it('a healthy replacement (new generation) fences a still-pending backoff restart', async () => {
+	it('a healthy replacement fences a still-pending backoff restart', async () => {
 		const { lifecycle, host } = createHarness({ serverEnabled: false })
 
 		lifecycle.backoffRestart()
@@ -594,7 +586,7 @@ describe('DriverLifecycle — connect early returns', () => {
 		expect(lifecycle.generation).toBe(0)
 	})
 
-	it('honours the ZWAVE_PORT env override (force-enables + overrides port)', async () => {
+	it('honours the ZWAVE_PORT env override by forcing the port on', async () => {
 		process.env.ZWAVE_PORT = 'tcp://override:5555'
 		const { lifecycle, world, state } = createHarness({ enabled: false })
 		await lifecycle.connect()
@@ -627,7 +619,7 @@ describe('DriverLifecycle — connect happy path', () => {
 		expect(host.installUserCallbacks).toHaveBeenCalledTimes(1)
 	})
 
-	it('does NOT install user callbacks when no clients are connected', async () => {
+	it('does not install user callbacks when no clients are connected', async () => {
 		const { lifecycle, host, state } = createHarness()
 		state.connectedClients = false
 		await lifecycle.connect()
@@ -751,7 +743,7 @@ describe('DriverLifecycle — connect error handling', () => {
 		}
 	})
 
-	it('on Driver_InvalidOptions: reports the error but does NOT back off', async () => {
+	it('on Driver_InvalidOptions it reports the error but does not back off', async () => {
 		vi.useFakeTimers()
 		try {
 			const { lifecycle, host, world } = createHarness({
@@ -775,8 +767,8 @@ describe('DriverLifecycle — connect error handling', () => {
 	})
 })
 
-describe('DriverLifecycle — connect generation fencing', () => {
-	it('aborts before driver creation when the generation changes during ensureDir', async () => {
+describe('DriverLifecycle — closing during an in-flight connect', () => {
+	it('a close before the driver is created leaves no driver and ends closed', async () => {
 		const { lifecycle, world, state } = createHarness()
 		world.ensureDirHook = () => {
 			void lifecycle.close()
@@ -786,7 +778,7 @@ describe('DriverLifecycle — connect generation fencing', () => {
 		expect(state.status).toBe(ZwaveClientStatus.CLOSED)
 	})
 
-	it('aborts before driver.start when the generation changes during hasConnectedClients', async () => {
+	it('a close before start leaves the driver unstarted', async () => {
 		const { lifecycle, host, world } = createHarness()
 		host.hasConnectedClients.mockImplementation(() => {
 			void lifecycle.close()
@@ -797,7 +789,7 @@ describe('DriverLifecycle — connect generation fencing', () => {
 		expect(world.drivers[0].start).not.toHaveBeenCalled()
 	})
 
-	it('aborts after driver.start when the generation changes during start()', async () => {
+	it('a close during start ends closed even after the driver was started', async () => {
 		const { lifecycle, world, state } = createHarness({
 			serverEnabled: false,
 		})
@@ -809,7 +801,7 @@ describe('DriverLifecycle — connect generation fencing', () => {
 		expect(state.status).toBe(ZwaveClientStatus.CLOSED)
 	})
 
-	it('aborts when the generation changes during persistConfig', async () => {
+	it('a close while persisting config leaves no driver adopted', async () => {
 		const { lifecycle, host, world } = createHarness({
 			serverEnabled: false,
 			rf: { region: RFRegion.USA },
@@ -824,7 +816,7 @@ describe('DriverLifecycle — connect generation fencing', () => {
 })
 
 describe('DriverLifecycle — pre-ready reconnect coalescing', () => {
-	it('a second connect after start() resolves but before driver ready does NOT construct or leak a replacement', async () => {
+	it('a second connect before driver ready does not build or leak a replacement', async () => {
 		const { lifecycle, world, state } = createHarness({
 			serverEnabled: false,
 		})
@@ -845,7 +837,7 @@ describe('DriverLifecycle — pre-ready reconnect coalescing', () => {
 		expect(lifecycle.generation).toBe(genAfterFirst)
 	})
 
-	it('coalesces a second connect while the first is still awaiting driver.start(): it stays PENDING until the first settles, then settles together', async () => {
+	it('concurrent connect callers coalesce and settle together once the first start settles', async () => {
 		const { lifecycle, world, state } = createHarness({
 			serverEnabled: false,
 		})
@@ -885,7 +877,7 @@ describe('DriverLifecycle — pre-ready reconnect coalescing', () => {
 		expect(driver0.destroy).not.toHaveBeenCalled()
 	})
 
-	it('a coalesced duplicate connect shares the first connect FAILURE settlement (start rejects) and no second Driver is built', async () => {
+	it('concurrent connect callers share the first connect failure and build no second driver', async () => {
 		const { lifecycle, world, state, host } = createHarness({
 			serverEnabled: false,
 		})
@@ -918,7 +910,7 @@ describe('DriverLifecycle — pre-ready reconnect coalescing', () => {
 		expect(host.onDriverError).toHaveBeenCalledTimes(1)
 	})
 
-	it('a duplicate connect AFTER the first start settled but BEFORE driver ready returns compatibly without a replacement', async () => {
+	it('a duplicate connect before driver ready builds no replacement', async () => {
 		const { lifecycle, world, state } = createHarness({
 			serverEnabled: false,
 		})
@@ -936,7 +928,7 @@ describe('DriverLifecycle — pre-ready reconnect coalescing', () => {
 		expect(lifecycle.generation).toBe(gen)
 	})
 
-	it('a recovery reconnect after a start failure is NOT coalesced (host cleared) and builds exactly one fresh driver', async () => {
+	it('a reconnect after a start failure builds exactly one fresh driver', async () => {
 		const { lifecycle, world, state } = createHarness({
 			serverEnabled: false,
 		})
@@ -984,7 +976,7 @@ describe('DriverLifecycle — pre-ready reconnect coalescing', () => {
 		return { ...harness, stalePromise, driver0, driver1 }
 	}
 
-	it('a stale start that RESOLVES after a close+reconnect tears down only its own driver', async () => {
+	it('a stale start that resolves after a reconnect tears down only its own driver', async () => {
 		const { world, state, stalePromise, driver1 } =
 			await openCloseReconnectWithStale()
 
@@ -996,7 +988,7 @@ describe('DriverLifecycle — pre-ready reconnect coalescing', () => {
 		expect(state.driver).toBe(driver1)
 	})
 
-	it('a stale start that REJECTS after a close+reconnect never destroys the replacement or backs off', async () => {
+	it('a stale start that rejects after a reconnect never destroys the replacement or backs off', async () => {
 		const { host, world, state, stalePromise, driver1 } =
 			await openCloseReconnectWithStale()
 
@@ -1011,8 +1003,8 @@ describe('DriverLifecycle — pre-ready reconnect coalescing', () => {
 	})
 })
 
-describe('DriverLifecycle — failed-connect teardown ownership', () => {
-	it('awaits the failed driver destroy before clearing the host or backing off (no replacement built while the owner is torn down)', async () => {
+describe('DriverLifecycle — cleanup after a failed connect', () => {
+	it('no replacement is built until the failed driver finishes tearing down', async () => {
 		vi.useFakeTimers()
 		try {
 			const { lifecycle, world, state, host } = createHarness({
@@ -1054,7 +1046,7 @@ describe('DriverLifecycle — failed-connect teardown ownership', () => {
 		}
 	})
 
-	it('retains the exact owner when destroy REJECTS and lets a later close retry the cleanup (no leak, no wrong destroy)', async () => {
+	it('a rejected destroy is retried by a later close without leaking or destroying the wrong driver', async () => {
 		vi.useFakeTimers()
 		try {
 			const { lifecycle, world, state, host } = createHarness({
@@ -1084,7 +1076,7 @@ describe('DriverLifecycle — failed-connect teardown ownership', () => {
 		}
 	})
 
-	it('a stale post-start exit awaits teardown of its OWN instance and never destroys the live replacement, even with a delayed destroy', async () => {
+	it('a stale post-start exit tears down its own driver and never the live replacement', async () => {
 		const { lifecycle, world, state } = createHarness({
 			serverEnabled: false,
 		})
@@ -1112,8 +1104,8 @@ describe('DriverLifecycle — failed-connect teardown ownership', () => {
 	})
 })
 
-describe('DriverLifecycle — final logConfig override', () => {
-	it('a documented zwave.options.logConfig override still receives the JSON transport, extra transports and bumped level', async () => {
+describe('DriverLifecycle — logConfig override', () => {
+	it('a zwave.options.logConfig override still receives the JSON transport, extra transports and raised level', async () => {
 		const { lifecycle, world } = createHarness({
 			serverEnabled: false,
 			options: zwaveOpts({ logConfig: { level: 'error' } }),
@@ -1145,7 +1137,7 @@ describe('DriverLifecycle — final logConfig override', () => {
 		expect(passedLogConfig?.level).toBe('warn')
 	})
 
-	it('a driver built with NO logConfig object connects cleanly and leaves the base level unset', async () => {
+	it('a driver with no logConfig connects and leaves the level unset, then accepts a later transport', async () => {
 		const { lifecycle, world, state } = createHarness({
 			serverEnabled: false,
 			options: zwaveOpts({ logConfig: undefined }),
@@ -1168,8 +1160,8 @@ describe('DriverLifecycle — final logConfig override', () => {
 	})
 })
 
-describe('DriverLifecycle — logConfig source isolation', () => {
-	it('does not mutate the persisted cfg.options.logConfig; the driver receives a distinct enriched clone', async () => {
+describe('DriverLifecycle — persisted logConfig immutability', () => {
+	it('leaves the persisted logConfig unmutated and passes the driver a distinct clone', async () => {
 		const { lifecycle, world, state } = createHarness({
 			serverEnabled: false,
 			options: zwaveOpts({ logConfig: { level: 'warn', maxFiles: 5 } }),
@@ -1238,14 +1230,14 @@ describe('DriverLifecycle — close', () => {
 		expect(state.driver).toBeNull()
 	})
 
-	it('destroys the server BEFORE the driver', async () => {
+	it('destroys the server before the driver', async () => {
 		const { lifecycle, world } = createHarness({ serverEnabled: true })
 		await lifecycle.connect()
 		await lifecycle.close()
 		expect(world.destroyOrder).toEqual(['server', 'driver'])
 	})
 
-	it('does not finalize (keep listeners) when keepListeners is true', async () => {
+	it('does not finalize when keepListeners is true', async () => {
 		const { lifecycle, host } = createHarness()
 		await lifecycle.connect()
 		await lifecycle.close(true)
@@ -1273,38 +1265,8 @@ describe('DriverLifecycle — close', () => {
 	})
 })
 
-describe('DriverLifecycle — driver-event dispatch', () => {
-	it('forwards every driver event to the host with the current generation', async () => {
-		const { lifecycle, host, world } = createHarness({
-			serverEnabled: false,
-		})
-		await lifecycle.connect()
-		const driver = world.drivers[0]
-
-		driver.emit('driver ready')
-		await flush()
-		expect(host.onDriverReady).toHaveBeenCalledWith(lifecycle.generation)
-
-		const err = new Error('driver error')
-		driver.emit('error', err)
-		expect(host.onDriverError).toHaveBeenCalledWith(err, false)
-
-		driver.emit('all nodes ready')
-		expect(host.onScanComplete).toHaveBeenCalledTimes(1)
-
-		driver.emit('bootloader ready')
-		expect(host.onBootLoaderReady).toHaveBeenCalledTimes(1)
-
-		const progress = { sentFragments: 1, totalFragments: 10 }
-		driver.emit('firmware update progress', progress)
-		expect(host.onOTWFirmwareUpdateProgress).toHaveBeenCalledWith(progress)
-
-		const result = { success: true }
-		driver.emit('firmware update finished', result)
-		expect(host.onOTWFirmwareUpdateFinished).toHaveBeenCalledWith(result)
-	})
-
-	it('fences a LATE driver-ready from an obsolete generation after close()', async () => {
+describe('DriverLifecycle — stale driver events after close', () => {
+	it('ignores a driver-ready from a closed generation', async () => {
 		const { lifecycle, host, world } = createHarness({
 			serverEnabled: false,
 		})
@@ -1318,7 +1280,7 @@ describe('DriverLifecycle — driver-event dispatch', () => {
 		expect(host.onDriverReady).not.toHaveBeenCalled()
 	})
 
-	it('fences a late error/scan/bootloader/OTW callback after the generation moves on', async () => {
+	it('ignores late driver callbacks once the generation has moved on', async () => {
 		const { lifecycle, host, world } = createHarness({
 			serverEnabled: false,
 		})
@@ -1340,7 +1302,7 @@ describe('DriverLifecycle — driver-event dispatch', () => {
 	})
 })
 
-describe('DriverLifecycle — connect option wiring', () => {
+describe('DriverLifecycle — driver options', () => {
 	it('builds scale preferences from cfg.scales', async () => {
 		const { lifecycle, world } = createHarness({
 			serverEnabled: false,
@@ -1352,7 +1314,7 @@ describe('DriverLifecycle — connect option wiring', () => {
 		})
 	})
 
-	it('injects PkgFsBindings into driver host options when running in a pkg bundle', async () => {
+	it('provides driver host filesystem bindings when running in a pkg bundle', async () => {
 		const proc = process as NodeJS.Process & { pkg?: unknown }
 		proc.pkg = {}
 		try {
@@ -1364,7 +1326,7 @@ describe('DriverLifecycle — connect option wiring', () => {
 		}
 	})
 
-	it('merges registered extra log transports and bumps the log level to the most verbose', async () => {
+	it('merges registered extra log transports and raises the log level to the most verbose', async () => {
 		const { lifecycle, world } = createHarness({ serverEnabled: false })
 		const t1 = new Transport({})
 		const t2 = new Transport({})
@@ -1377,7 +1339,7 @@ describe('DriverLifecycle — connect option wiring', () => {
 		expect(logConfig?.level).toBe('silly')
 	})
 
-	it('forwards driver log stream data to host.emitDebug', async () => {
+	it('forwards driver log stream data to the host debug output', async () => {
 		const { lifecycle, host, world } = createHarness({
 			serverEnabled: false,
 		})
@@ -1388,7 +1350,7 @@ describe('DriverLifecycle — connect option wiring', () => {
 		expect(host.emitDebug).toHaveBeenCalledWith('hello world')
 	})
 
-	it('aborts after start() when the client became destroyed mid-start', async () => {
+	it('does not connect when the client is destroyed during start', async () => {
 		const { lifecycle, world, state } = createHarness({
 			serverEnabled: false,
 		})
@@ -1401,30 +1363,8 @@ describe('DriverLifecycle — connect option wiring', () => {
 	})
 })
 
-describe('DriverLifecycle — failed connect error reporting', () => {
-	it('swallows a driver.destroy() rejection while handling a start failure', async () => {
-		vi.useFakeTimers()
-		try {
-			const { lifecycle, host, world } = createHarness({
-				serverEnabled: false,
-			})
-			world.startBehavior = 'reject'
-			world.startError = new Error('start boom')
-			world.destroyRejects = true
-			await lifecycle.connect()
-			await flush()
-			expect(host.onDriverError).toHaveBeenCalledWith(
-				expect.any(Error),
-				true,
-			)
-			await vi.advanceTimersByTimeAsync(1000)
-			expect(host.restart).toHaveBeenCalledTimes(1)
-		} finally {
-			vi.useRealTimers()
-		}
-	})
-
-	it('does not report the error when a close bumps the generation during a failed start', async () => {
+describe('DriverLifecycle — error reporting on a failed connect', () => {
+	it('does not report the error when a close races a failed start', async () => {
 		const { lifecycle, host, world } = createHarness({
 			serverEnabled: false,
 		})
@@ -1449,33 +1389,5 @@ describe('DriverLifecycle — failed connect error reporting', () => {
 		await lifecycle.connect()
 		expect(host.onDriverError).not.toHaveBeenCalled()
 		expect(state.closed).toBe(true)
-	})
-})
-
-describe('DriverLifecycle — async failure logging', () => {
-	it('logs (and swallows) a restart failure from the backoff timer', async () => {
-		vi.useFakeTimers()
-		try {
-			const { lifecycle, host } = createHarness()
-			host.restart.mockRejectedValue(new Error('restart boom'))
-			lifecycle.backoffRestart()
-			await vi.advanceTimersByTimeAsync(1000)
-			await flush()
-			expect(host.restart).toHaveBeenCalledTimes(1)
-		} finally {
-			vi.useRealTimers()
-		}
-	})
-
-	it('logs (and swallows) a close failure triggered by checkIfDestroyed', async () => {
-		const { lifecycle, world, state } = createHarness({
-			serverEnabled: false,
-		})
-		await lifecycle.connect()
-		world.destroyBehavior = 'reject'
-		state.destroyed = true
-		expect(lifecycle.checkIfDestroyed()).toBe(true)
-		await flush()
-		await flush()
 	})
 })

--- a/test/lib/zwave/DriverLifecycle.test.ts
+++ b/test/lib/zwave/DriverLifecycle.test.ts
@@ -1379,6 +1379,32 @@ describe('DriverLifecycle — close', () => {
 		expect(world.destroyOrder).toEqual(['server', 'driver'])
 	})
 
+	it('completes driver cleanup when server teardown fails', async () => {
+		const { lifecycle, host, world, state } = createHarness({
+			serverEnabled: true,
+		})
+		await lifecycle.connect()
+		const server = world.serverManagers[0]
+		const driver = world.drivers[0]
+		const serverError = new Error('server destroy failed')
+		server.destroy
+			.mockRejectedValueOnce(serverError)
+			.mockImplementationOnce(() => {
+				world.destroyOrder.push('server')
+				return Promise.resolve()
+			})
+
+		await expect(lifecycle.close()).rejects.toBe(serverError)
+		expect(driver.destroy).toHaveBeenCalledOnce()
+		expect(state.driver).toBeNull()
+		expect(host.finalizeClose).toHaveBeenCalledOnce()
+		expect(world.destroyOrder).toEqual(['driver'])
+
+		await expect(lifecycle.close(true)).resolves.toBeUndefined()
+		expect(server.destroy).toHaveBeenCalledTimes(2)
+		expect(world.destroyOrder).toEqual(['driver', 'server'])
+	})
+
 	it('does not finalize when keepListeners is true', async () => {
 		const { lifecycle, host } = createHarness()
 		await lifecycle.connect()
@@ -1462,6 +1488,27 @@ describe('DriverLifecycle — driver-ready failures', () => {
 		expect(host.restart).not.toHaveBeenCalled()
 		await vi.advanceTimersByTimeAsync(1000)
 		expect(host.restart).toHaveBeenCalledTimes(1)
+	})
+
+	it('preserves retry backoff until ready initialization succeeds', async () => {
+		const { lifecycle, host, world } = createHarness({
+			serverEnabled: false,
+		})
+		host.onDriverReady.mockRejectedValueOnce(
+			new Error('ready initialization failed'),
+		)
+		lifecycle.backoffRestart()
+		await lifecycle.connect()
+
+		world.drivers[0].emit('driver ready')
+		await Promise.resolve()
+		await Promise.resolve()
+		expect(host.onDriverError).toHaveBeenCalledOnce()
+
+		await vi.advanceTimersByTimeAsync(1999)
+		expect(host.restart).not.toHaveBeenCalled()
+		await vi.advanceTimersByTimeAsync(1)
+		expect(host.restart).toHaveBeenCalledOnce()
 	})
 
 	it('defers scan completion until matching ready initialization succeeds', async () => {

--- a/test/lib/zwave/FirmwareUpdateService.test.ts
+++ b/test/lib/zwave/FirmwareUpdateService.test.ts
@@ -100,7 +100,7 @@ function createNodeStorePort(): FirmwareNodeStorePort & {
 } {
 	const nodes = new Map<number, FirmwareUpdateNodeState>()
 	const store = new Map<number, Partial<FirmwareUpdateNodeState>>()
-	const port = {
+	return {
 		_nodes: nodes,
 		_store: store,
 		getNode: (nodeId: number) => nodes.get(nodeId),
@@ -111,12 +111,7 @@ function createNodeStorePort(): FirmwareNodeStorePort & {
 			}
 			return store.get(nodeId)
 		},
-		getStoreHomeId: () => 'test-home',
 		updateStoreNodes: vi.fn().mockResolvedValue(undefined),
-		runStoreTransaction: vi.fn((operation: () => Promise<void>) =>
-			operation(),
-		),
-		createStoreRestorePoint: vi.fn(),
 		persistStagedNodeUpdates: vi
 			.fn()
 			.mockImplementation(
@@ -126,11 +121,6 @@ function createNodeStorePort(): FirmwareNodeStorePort & {
 			),
 		emitNodeUpdate: vi.fn(),
 	}
-	port.createStoreRestorePoint.mockImplementation(() => {
-		const homeId = port.getStoreHomeId()
-		return () => port.updateStoreNodes(homeId)
-	})
-	return port
 }
 
 function createSocketPort(): FirmwareSocketPort & {
@@ -1697,192 +1687,6 @@ describe('FirmwareUpdateService', () => {
 		})
 	})
 
-	describe('overlapping firmware state writers', () => {
-		it('publishes each node before the next persistence snapshot', async () => {
-			const firstPersistenceStarted = createDeferred<void>()
-			const firstPersistence = createDeferred<void>()
-			const nodeIds = [12, 13] as const
-			const updates = new Map([
-				[
-					nodeIds[0],
-					makeUpdate({
-						version: '7.1.0',
-						normalizedVersion: '7.1.0',
-					}),
-				],
-				[
-					nodeIds[1],
-					makeUpdate({
-						version: '7.2.0',
-						normalizedVersion: '7.2.0',
-					}),
-				],
-			])
-			const driver = createDriverPort({
-				getDriver: () => ({
-					controller: {
-						getAvailableFirmwareUpdates: vi.fn((nodeId: number) => {
-							const update = updates.get(nodeId)
-							return Promise.resolve(update ? [update] : [])
-						}),
-						getAllAvailableFirmwareUpdates: vi.fn(),
-						firmwareUpdateOTA: vi.fn(),
-						nodes: { get: vi.fn() },
-					},
-					firmwareUpdateOTW: vi.fn(),
-				}),
-			})
-			const nodes = createNodeStorePort()
-			for (const nodeId of nodeIds) {
-				nodes._nodes.set(nodeId, { id: nodeId })
-			}
-			let persistenceCall = 0
-			let persistedNodeIds: number[] = []
-			nodes.persistStagedNodeUpdates.mockImplementation(
-				async (staged) => {
-					const snapshot = new Set(nodes._store.keys())
-					for (const entry of staged) {
-						snapshot.add(entry.nodeId)
-					}
-					if (persistenceCall++ === 0) {
-						firstPersistenceStarted.resolve()
-						await firstPersistence.promise
-					}
-					persistedNodeIds = [...snapshot]
-				},
-			)
-			const { service } = createService({ driver, nodes })
-
-			const firstRun = service.checkNodeFirmwareUpdates(nodeIds[0])
-			await firstPersistenceStarted.promise
-			const secondRun = service.checkNodeFirmwareUpdates(nodeIds[1])
-			firstPersistence.resolve()
-			await Promise.all([firstRun, secondRun])
-
-			expect(persistedNodeIds).toEqual([...nodeIds])
-			expect(nodes._store).toHaveLength(2)
-		})
-
-		it('keeps a newer bulk result when an earlier node check finishes later', async () => {
-			const nodeCheck = createDeferred<FirmwareUpdateInfo[]>()
-			const oldUpdate = makeUpdate({
-				version: '5.1.0',
-				normalizedVersion: '5.1.0',
-			})
-			const newUpdate = makeUpdate({
-				version: '5.2.0',
-				normalizedVersion: '5.2.0',
-			})
-			const nodeId = 10
-			const driver = createDriverPort({
-				getDriver: () => ({
-					controller: {
-						getAvailableFirmwareUpdates: vi
-							.fn()
-							.mockReturnValue(nodeCheck.promise),
-						getAllAvailableFirmwareUpdates: vi
-							.fn()
-							.mockResolvedValue(
-								new Map([[nodeId, [newUpdate]]]),
-							),
-						firmwareUpdateOTA: vi.fn(),
-						nodes: { get: vi.fn() },
-					},
-					firmwareUpdateOTW: vi.fn(),
-				}),
-			})
-			const nodes = createNodeStorePort()
-			nodes._nodes.set(nodeId, { id: nodeId })
-			const { service } = createService({ driver, nodes })
-
-			const nodeRun = service.checkNodeFirmwareUpdates(nodeId)
-			await service.checkAllNodesFirmwareUpdates()
-
-			nodeCheck.resolve([oldUpdate])
-			await nodeRun
-
-			expect(nodes._store.get(nodeId)?.availableFirmwareUpdates).toEqual([
-				newUpdate,
-			])
-			expect(nodes._nodes.get(nodeId)?.availableFirmwareUpdates).toEqual([
-				newUpdate,
-			])
-			expect(nodes.persistStagedNodeUpdates).toHaveBeenCalledTimes(1)
-			expect(nodes.emitNodeUpdate).toHaveBeenCalledTimes(1)
-		})
-
-		it('preserves a dismissal made during bulk persistence', async () => {
-			const persistenceStarted = createDeferred<void>()
-			const persistenceBarrier = createDeferred<void>()
-			const update = makeUpdate({
-				version: '6.1.0',
-				normalizedVersion: '6.1.0',
-			})
-			const nodeId = 11
-			const driver = createDriverPort({
-				getDriver: () => ({
-					controller: {
-						getAvailableFirmwareUpdates: vi.fn(),
-						getAllAvailableFirmwareUpdates: vi
-							.fn()
-							.mockResolvedValue(new Map([[nodeId, [update]]])),
-						firmwareUpdateOTA: vi.fn(),
-						nodes: { get: vi.fn() },
-					},
-					firmwareUpdateOTW: vi.fn(),
-				}),
-			})
-			const nodes = createNodeStorePort()
-			nodes._nodes.set(nodeId, {
-				id: nodeId,
-				availableFirmwareUpdates: [update],
-				firmwareUpdatesDismissed: {},
-			})
-			nodes._store.set(nodeId, {
-				availableFirmwareUpdates: [update],
-				firmwareUpdatesDismissed: {},
-			})
-			let persistedDismissals: { [version: string]: boolean } = {}
-			nodes.persistStagedNodeUpdates.mockImplementation(
-				async (staged) => {
-					persistedDismissals = {
-						...staged[0].firmwareUpdatesDismissed,
-					}
-					persistenceStarted.resolve()
-					await persistenceBarrier.promise
-				},
-			)
-			vi.mocked(nodes.updateStoreNodes).mockImplementation(() => {
-				persistedDismissals = {
-					...nodes._store.get(nodeId)?.firmwareUpdatesDismissed,
-				}
-				return Promise.resolve()
-			})
-			const { service } = createService({ driver, nodes })
-
-			const bulkRun = service.checkAllNodesFirmwareUpdates()
-			await persistenceStarted.promise
-			const dismissRun = service.dismissFirmwareUpdate(
-				nodeId,
-				update.version,
-			)
-			persistenceBarrier.resolve()
-
-			await expect(bulkRun).rejects.toBeInstanceOf(
-				FirmwareLifecycleCancelledError,
-			)
-			await expect(dismissRun).resolves.toBe(true)
-
-			expect(nodes._store.get(nodeId)?.firmwareUpdatesDismissed).toEqual({
-				[update.version]: true,
-			})
-			expect(nodes._nodes.get(nodeId)?.firmwareUpdatesDismissed).toEqual({
-				[update.version]: true,
-			})
-			expect(persistedDismissals).toEqual({ [update.version]: true })
-		})
-	})
-
 	describe('firmware operations interrupted by reset', () => {
 		it('does not start OTW updates after reset during backup', async () => {
 			const backupBarrier = createDeferred<void>()
@@ -2347,8 +2151,6 @@ describe('FirmwareUpdateService', () => {
 				}),
 			})
 			const nodes = createNodeStorePort()
-			let storeHomeId: string | undefined = 'test-home'
-			nodes.getStoreHomeId = () => storeHomeId
 			nodes._nodes.set(7, {
 				id: 7,
 				availableFirmwareUpdates: [],
@@ -2380,7 +2182,6 @@ describe('FirmwareUpdateService', () => {
 			const checkPromise = service.checkAllNodesFirmwareUpdates()
 
 			await persistenceStarted.promise
-			storeHomeId = undefined
 			service.resetGeneration()
 			persistenceBarrier.resolve()
 
@@ -2393,7 +2194,6 @@ describe('FirmwareUpdateService', () => {
 			expect(liveNode.lastFirmwareUpdateCheck).toBe(0)
 			expect(persisted?.availableFirmwareUpdates).toEqual([])
 			expect(persisted?.lastFirmwareUpdateCheck).toBe(0)
-			expect(nodes.updateStoreNodes).toHaveBeenCalledWith('test-home')
 
 			expect(restorePersistence).toHaveBeenCalledOnce()
 			expect(nodes.emitNodeUpdate).not.toHaveBeenCalled()
@@ -2687,7 +2487,6 @@ describe('FirmwareUpdateService', () => {
 						node: nodes._nodes.get(3),
 					}),
 				]),
-				'test-home',
 			)
 
 			const liveNode = nodes._nodes.get(3)

--- a/test/lib/zwave/FirmwareUpdateService.test.ts
+++ b/test/lib/zwave/FirmwareUpdateService.test.ts
@@ -113,6 +113,9 @@ function createNodeStorePort(): FirmwareNodeStorePort & {
 		},
 		getStoreHomeId: () => 'test-home',
 		updateStoreNodes: vi.fn().mockResolvedValue(undefined),
+		runStoreTransaction: vi.fn((operation: () => Promise<void>) =>
+			operation(),
+		),
 		createStoreRestorePoint: vi.fn(),
 		persistStagedNodeUpdates: vi
 			.fn()
@@ -1695,6 +1698,71 @@ describe('FirmwareUpdateService', () => {
 	})
 
 	describe('overlapping firmware state writers', () => {
+		it('publishes each node before the next persistence snapshot', async () => {
+			const firstPersistenceStarted = createDeferred<void>()
+			const firstPersistence = createDeferred<void>()
+			const nodeIds = [12, 13] as const
+			const updates = new Map([
+				[
+					nodeIds[0],
+					makeUpdate({
+						version: '7.1.0',
+						normalizedVersion: '7.1.0',
+					}),
+				],
+				[
+					nodeIds[1],
+					makeUpdate({
+						version: '7.2.0',
+						normalizedVersion: '7.2.0',
+					}),
+				],
+			])
+			const driver = createDriverPort({
+				getDriver: () => ({
+					controller: {
+						getAvailableFirmwareUpdates: vi.fn((nodeId: number) => {
+							const update = updates.get(nodeId)
+							return Promise.resolve(update ? [update] : [])
+						}),
+						getAllAvailableFirmwareUpdates: vi.fn(),
+						firmwareUpdateOTA: vi.fn(),
+						nodes: { get: vi.fn() },
+					},
+					firmwareUpdateOTW: vi.fn(),
+				}),
+			})
+			const nodes = createNodeStorePort()
+			for (const nodeId of nodeIds) {
+				nodes._nodes.set(nodeId, { id: nodeId })
+			}
+			let persistenceCall = 0
+			let persistedNodeIds: number[] = []
+			nodes.persistStagedNodeUpdates.mockImplementation(
+				async (staged) => {
+					const snapshot = new Set(nodes._store.keys())
+					for (const entry of staged) {
+						snapshot.add(entry.nodeId)
+					}
+					if (persistenceCall++ === 0) {
+						firstPersistenceStarted.resolve()
+						await firstPersistence.promise
+					}
+					persistedNodeIds = [...snapshot]
+				},
+			)
+			const { service } = createService({ driver, nodes })
+
+			const firstRun = service.checkNodeFirmwareUpdates(nodeIds[0])
+			await firstPersistenceStarted.promise
+			const secondRun = service.checkNodeFirmwareUpdates(nodeIds[1])
+			firstPersistence.resolve()
+			await Promise.all([firstRun, secondRun])
+
+			expect(persistedNodeIds).toEqual([...nodeIds])
+			expect(nodes._store).toHaveLength(2)
+		})
+
 		it('keeps a newer bulk result when an earlier node check finishes later', async () => {
 			const nodeCheck = createDeferred<FirmwareUpdateInfo[]>()
 			const oldUpdate = makeUpdate({

--- a/test/lib/zwave/FirmwareUpdateService.test.ts
+++ b/test/lib/zwave/FirmwareUpdateService.test.ts
@@ -1627,6 +1627,64 @@ describe('FirmwareUpdateService', () => {
 				vi.useRealTimers()
 			}
 		})
+
+		it('keeps a newer manual result when a scheduled check finishes later', async () => {
+			vi.useFakeTimers()
+			const scheduledCheck =
+				createDeferred<Map<number, FirmwareUpdateInfo[]>>()
+			const manualCheck =
+				createDeferred<Map<number, FirmwareUpdateInfo[]>>()
+			const getAllAvailableFirmwareUpdates = vi
+				.fn()
+				.mockReturnValueOnce(scheduledCheck.promise)
+				.mockReturnValueOnce(manualCheck.promise)
+			const driver = createDriverPort({
+				getDriver: () => ({
+					controller: {
+						getAvailableFirmwareUpdates: vi.fn(),
+						getAllAvailableFirmwareUpdates,
+						firmwareUpdateOTA: vi.fn(),
+						nodes: { get: vi.fn() },
+					},
+					firmwareUpdateOTW: vi.fn(),
+				}),
+			})
+			const nodes = createNodeStorePort()
+			const nodeId = 9
+			nodes._nodes.set(nodeId, { id: nodeId })
+			const { service } = createService({ driver, nodes })
+			const scheduledUpdate = makeUpdate({
+				version: '4.1.0',
+				normalizedVersion: '4.1.0',
+			})
+			const manualUpdate = makeUpdate({
+				version: '4.2.0',
+				normalizedVersion: '4.2.0',
+			})
+
+			try {
+				const scheduledRun = service.scheduledFirmwareUpdateCheck()
+				const manualRun = service.checkAllNodesFirmwareUpdates()
+
+				manualCheck.resolve(new Map([[nodeId, [manualUpdate]]]))
+				await manualRun
+
+				scheduledCheck.resolve(new Map([[nodeId, [scheduledUpdate]]]))
+				await scheduledRun
+
+				expect(
+					nodes._store.get(nodeId)?.availableFirmwareUpdates,
+				).toEqual([manualUpdate])
+				expect(
+					nodes._nodes.get(nodeId)?.availableFirmwareUpdates,
+				).toEqual([manualUpdate])
+				expect(nodes.persistStagedNodeUpdates).toHaveBeenCalledTimes(1)
+				expect(nodes.emitNodeUpdate).toHaveBeenCalledTimes(1)
+			} finally {
+				service.resetGeneration()
+				vi.useRealTimers()
+			}
+		})
 	})
 
 	describe('firmware operations interrupted by reset', () => {

--- a/test/lib/zwave/FirmwareUpdateService.test.ts
+++ b/test/lib/zwave/FirmwareUpdateService.test.ts
@@ -1501,6 +1501,134 @@ describe('FirmwareUpdateService', () => {
 		})
 	})
 
+	describe('overlapping scheduled firmware checks', () => {
+		it('publishes only the newest completed check', async () => {
+			vi.useFakeTimers()
+			const firstCheck =
+				createDeferred<Map<number, FirmwareUpdateInfo[]>>()
+			const secondCheck =
+				createDeferred<Map<number, FirmwareUpdateInfo[]>>()
+			const getAllAvailableFirmwareUpdates = vi
+				.fn()
+				.mockReturnValueOnce(firstCheck.promise)
+				.mockReturnValueOnce(secondCheck.promise)
+			const driver = createDriverPort({
+				getDriver: () => ({
+					controller: {
+						getAvailableFirmwareUpdates: vi.fn(),
+						getAllAvailableFirmwareUpdates,
+						firmwareUpdateOTA: vi.fn(),
+						nodes: { get: vi.fn() },
+					},
+					firmwareUpdateOTW: vi.fn(),
+				}),
+			})
+			const nodes = createNodeStorePort()
+			const nodeId = 7
+			nodes._nodes.set(nodeId, { id: nodeId })
+			const { service } = createService({ driver, nodes })
+			const olderUpdate = makeUpdate({
+				version: '2.1.0',
+				normalizedVersion: '2.1.0',
+			})
+			const newerUpdate = makeUpdate({
+				version: '2.2.0',
+				normalizedVersion: '2.2.0',
+			})
+
+			try {
+				const firstRun = service.scheduledFirmwareUpdateCheck()
+				const secondRun = service.scheduledFirmwareUpdateCheck()
+
+				secondCheck.resolve(new Map([[nodeId, [newerUpdate]]]))
+				await secondRun
+
+				firstCheck.resolve(new Map([[nodeId, [olderUpdate]]]))
+				await firstRun
+
+				expect(
+					nodes._store.get(nodeId)?.availableFirmwareUpdates,
+				).toEqual([newerUpdate])
+				expect(
+					nodes._nodes.get(nodeId)?.availableFirmwareUpdates,
+				).toEqual([newerUpdate])
+				expect(nodes.persistStagedNodeUpdates).toHaveBeenCalledTimes(1)
+				expect(nodes.emitNodeUpdate).toHaveBeenCalledTimes(1)
+			} finally {
+				service.resetGeneration()
+				vi.useRealTimers()
+			}
+		})
+
+		it('restores current state when superseded during persistence', async () => {
+			vi.useFakeTimers()
+			const firstCheck =
+				createDeferred<Map<number, FirmwareUpdateInfo[]>>()
+			const secondCheck =
+				createDeferred<Map<number, FirmwareUpdateInfo[]>>()
+			const firstPersistence = createDeferred<void>()
+			const getAllAvailableFirmwareUpdates = vi
+				.fn()
+				.mockReturnValueOnce(firstCheck.promise)
+				.mockReturnValueOnce(secondCheck.promise)
+			const driver = createDriverPort({
+				getDriver: () => ({
+					controller: {
+						getAvailableFirmwareUpdates: vi.fn(),
+						getAllAvailableFirmwareUpdates,
+						firmwareUpdateOTA: vi.fn(),
+						nodes: { get: vi.fn() },
+					},
+					firmwareUpdateOTW: vi.fn(),
+				}),
+			})
+			const nodes = createNodeStorePort()
+			nodes.persistStagedNodeUpdates
+				.mockImplementationOnce(() => firstPersistence.promise)
+				.mockResolvedValueOnce(undefined)
+			const nodeId = 8
+			nodes._nodes.set(nodeId, { id: nodeId })
+			const { service } = createService({ driver, nodes })
+			const olderUpdate = makeUpdate({
+				version: '3.1.0',
+				normalizedVersion: '3.1.0',
+			})
+			const newerUpdate = makeUpdate({
+				version: '3.2.0',
+				normalizedVersion: '3.2.0',
+			})
+
+			try {
+				const firstRun = service.scheduledFirmwareUpdateCheck()
+				firstCheck.resolve(new Map([[nodeId, [olderUpdate]]]))
+				await vi.waitFor(() => {
+					expect(
+						nodes.persistStagedNodeUpdates,
+					).toHaveBeenCalledTimes(1)
+				})
+
+				const secondRun = service.scheduledFirmwareUpdateCheck()
+				secondCheck.resolve(new Map([[nodeId, [newerUpdate]]]))
+				firstPersistence.resolve()
+
+				await Promise.all([firstRun, secondRun])
+
+				expect(nodes.updateStoreNodes).toHaveBeenCalledTimes(1)
+				expect(nodes.persistStagedNodeUpdates).toHaveBeenCalledTimes(2)
+				expect(
+					nodes._store.get(nodeId)?.availableFirmwareUpdates,
+				).toEqual([newerUpdate])
+				expect(
+					nodes._nodes.get(nodeId)?.availableFirmwareUpdates,
+				).toEqual([newerUpdate])
+				expect(nodes.emitNodeUpdate).toHaveBeenCalledTimes(1)
+			} finally {
+				service.resetGeneration()
+				vi.useRealTimers()
+			}
+		})
+	})
+
 	describe('firmware operations interrupted by reset', () => {
 		it('does not start OTW updates after reset during backup', async () => {
 			const backupBarrier = createDeferred<void>()

--- a/test/lib/zwave/FirmwareUpdateService.test.ts
+++ b/test/lib/zwave/FirmwareUpdateService.test.ts
@@ -100,7 +100,7 @@ function createNodeStorePort(): FirmwareNodeStorePort & {
 } {
 	const nodes = new Map<number, FirmwareUpdateNodeState>()
 	const store = new Map<number, Partial<FirmwareUpdateNodeState>>()
-	return {
+	const port = {
 		_nodes: nodes,
 		_store: store,
 		getNode: (nodeId: number) => nodes.get(nodeId),
@@ -111,7 +111,9 @@ function createNodeStorePort(): FirmwareNodeStorePort & {
 			}
 			return store.get(nodeId)
 		},
+		getStoreHomeId: () => 'test-home',
 		updateStoreNodes: vi.fn().mockResolvedValue(undefined),
+		createStoreRestorePoint: vi.fn(),
 		persistStagedNodeUpdates: vi
 			.fn()
 			.mockImplementation(
@@ -121,6 +123,11 @@ function createNodeStorePort(): FirmwareNodeStorePort & {
 			),
 		emitNodeUpdate: vi.fn(),
 	}
+	port.createStoreRestorePoint.mockImplementation(() => {
+		const homeId = port.getStoreHomeId()
+		return () => port.updateStoreNodes(homeId)
+	})
+	return port
 }
 
 function createSocketPort(): FirmwareSocketPort & {
@@ -1687,6 +1694,127 @@ describe('FirmwareUpdateService', () => {
 		})
 	})
 
+	describe('overlapping firmware state writers', () => {
+		it('keeps a newer bulk result when an earlier node check finishes later', async () => {
+			const nodeCheck = createDeferred<FirmwareUpdateInfo[]>()
+			const oldUpdate = makeUpdate({
+				version: '5.1.0',
+				normalizedVersion: '5.1.0',
+			})
+			const newUpdate = makeUpdate({
+				version: '5.2.0',
+				normalizedVersion: '5.2.0',
+			})
+			const nodeId = 10
+			const driver = createDriverPort({
+				getDriver: () => ({
+					controller: {
+						getAvailableFirmwareUpdates: vi
+							.fn()
+							.mockReturnValue(nodeCheck.promise),
+						getAllAvailableFirmwareUpdates: vi
+							.fn()
+							.mockResolvedValue(
+								new Map([[nodeId, [newUpdate]]]),
+							),
+						firmwareUpdateOTA: vi.fn(),
+						nodes: { get: vi.fn() },
+					},
+					firmwareUpdateOTW: vi.fn(),
+				}),
+			})
+			const nodes = createNodeStorePort()
+			nodes._nodes.set(nodeId, { id: nodeId })
+			const { service } = createService({ driver, nodes })
+
+			const nodeRun = service.checkNodeFirmwareUpdates(nodeId)
+			await service.checkAllNodesFirmwareUpdates()
+
+			nodeCheck.resolve([oldUpdate])
+			await nodeRun
+
+			expect(nodes._store.get(nodeId)?.availableFirmwareUpdates).toEqual([
+				newUpdate,
+			])
+			expect(nodes._nodes.get(nodeId)?.availableFirmwareUpdates).toEqual([
+				newUpdate,
+			])
+			expect(nodes.persistStagedNodeUpdates).toHaveBeenCalledTimes(1)
+			expect(nodes.emitNodeUpdate).toHaveBeenCalledTimes(1)
+		})
+
+		it('preserves a dismissal made during bulk persistence', async () => {
+			const persistenceStarted = createDeferred<void>()
+			const persistenceBarrier = createDeferred<void>()
+			const update = makeUpdate({
+				version: '6.1.0',
+				normalizedVersion: '6.1.0',
+			})
+			const nodeId = 11
+			const driver = createDriverPort({
+				getDriver: () => ({
+					controller: {
+						getAvailableFirmwareUpdates: vi.fn(),
+						getAllAvailableFirmwareUpdates: vi
+							.fn()
+							.mockResolvedValue(new Map([[nodeId, [update]]])),
+						firmwareUpdateOTA: vi.fn(),
+						nodes: { get: vi.fn() },
+					},
+					firmwareUpdateOTW: vi.fn(),
+				}),
+			})
+			const nodes = createNodeStorePort()
+			nodes._nodes.set(nodeId, {
+				id: nodeId,
+				availableFirmwareUpdates: [update],
+				firmwareUpdatesDismissed: {},
+			})
+			nodes._store.set(nodeId, {
+				availableFirmwareUpdates: [update],
+				firmwareUpdatesDismissed: {},
+			})
+			let persistedDismissals: { [version: string]: boolean } = {}
+			nodes.persistStagedNodeUpdates.mockImplementation(
+				async (staged) => {
+					persistedDismissals = {
+						...staged[0].firmwareUpdatesDismissed,
+					}
+					persistenceStarted.resolve()
+					await persistenceBarrier.promise
+				},
+			)
+			vi.mocked(nodes.updateStoreNodes).mockImplementation(() => {
+				persistedDismissals = {
+					...nodes._store.get(nodeId)?.firmwareUpdatesDismissed,
+				}
+				return Promise.resolve()
+			})
+			const { service } = createService({ driver, nodes })
+
+			const bulkRun = service.checkAllNodesFirmwareUpdates()
+			await persistenceStarted.promise
+			const dismissRun = service.dismissFirmwareUpdate(
+				nodeId,
+				update.version,
+			)
+			persistenceBarrier.resolve()
+
+			await expect(bulkRun).rejects.toBeInstanceOf(
+				FirmwareLifecycleCancelledError,
+			)
+			await expect(dismissRun).resolves.toBe(true)
+
+			expect(nodes._store.get(nodeId)?.firmwareUpdatesDismissed).toEqual({
+				[update.version]: true,
+			})
+			expect(nodes._nodes.get(nodeId)?.firmwareUpdatesDismissed).toEqual({
+				[update.version]: true,
+			})
+			expect(persistedDismissals).toEqual({ [update.version]: true })
+		})
+	})
+
 	describe('firmware operations interrupted by reset', () => {
 		it('does not start OTW updates after reset during backup', async () => {
 			const backupBarrier = createDeferred<void>()
@@ -2151,6 +2279,8 @@ describe('FirmwareUpdateService', () => {
 				}),
 			})
 			const nodes = createNodeStorePort()
+			let storeHomeId: string | undefined = 'test-home'
+			nodes.getStoreHomeId = () => storeHomeId
 			nodes._nodes.set(7, {
 				id: 7,
 				availableFirmwareUpdates: [],
@@ -2182,6 +2312,7 @@ describe('FirmwareUpdateService', () => {
 			const checkPromise = service.checkAllNodesFirmwareUpdates()
 
 			await persistenceStarted.promise
+			storeHomeId = undefined
 			service.resetGeneration()
 			persistenceBarrier.resolve()
 
@@ -2194,6 +2325,7 @@ describe('FirmwareUpdateService', () => {
 			expect(liveNode.lastFirmwareUpdateCheck).toBe(0)
 			expect(persisted?.availableFirmwareUpdates).toEqual([])
 			expect(persisted?.lastFirmwareUpdateCheck).toBe(0)
+			expect(nodes.updateStoreNodes).toHaveBeenCalledWith('test-home')
 
 			expect(restorePersistence).toHaveBeenCalledOnce()
 			expect(nodes.emitNodeUpdate).not.toHaveBeenCalled()
@@ -2487,6 +2619,7 @@ describe('FirmwareUpdateService', () => {
 						node: nodes._nodes.get(3),
 					}),
 				]),
+				'test-home',
 			)
 
 			const liveNode = nodes._nodes.get(3)


### PR DESCRIPTION
Extracts driver creation, readiness, retry, restart, and teardown orchestration.

- Keeps `ZwaveClient` as the lifecycle facade and preserves Z-Wave server startup ordering.
- Makes driver ownership and stale-generation cleanup explicit.
- Review focus: concurrent connects, failed teardown, timer/listener fencing, and runtime log transport updates.

Part of #4722. Stacked on #4733.