### PR TITLE
ci: stop PR builds from filling the Actions cache

### DIFF
--- a/.github/workflows/cleanup-pr-caches.yml
+++ b/.github/workflows/cleanup-pr-caches.yml
@@ -6,33 +6,69 @@ name: Cleanup PR caches
 # dead weight that keeps evicting the shared ones. GitHub never removes them on
 # its own, so do it here.
 #
-# `pull_request_target` (not `pull_request`) so the run gets a writable token for
-# PRs from forks too. Nothing from the PR is checked out or executed.
+# A scheduled sweep rather than a `pull_request_target: closed` hook: closing a
+# PR does not cancel its in-flight runs, and those keep saving caches on the
+# same ref for minutes afterwards, which a close-triggered job would miss and
+# never revisit. Sweeping also reclaims PRs that were already closed before this
+# workflow existed, PRs targeting long-lived branches, and anything an earlier
+# pass failed to delete.
 
 on:
-  pull_request_target:
-    types: [closed]
+  schedule:
+    - cron: '0 5 * * *'
+  workflow_dispatch:
 
 permissions:
   actions: write
+  pull-requests: read
 
 jobs:
   cleanup:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
 
     steps:
-      - name: Delete caches for the closed PR
+      - name: Delete caches left behind by closed PRs
         env:
           GH_TOKEN: ${{ github.token }}
           GH_REPO: ${{ github.repository }}
-          REF: refs/pull/${{ github.event.pull_request.number }}/merge
         run: |
           set -euo pipefail
-          # `gh cache list` caps out at 100 per page, a single PR can hold more
-          while :; do
-            ids=$(gh cache list --ref "$REF" --limit 100 --json id --jq '.[].id' || true)
-            [ -n "$ids" ] || break
-            for id in $ids; do
-              gh cache delete "$id"
+
+          # Deliberately unguarded: a failure here means the API is unhappy, and
+          # that must not be mistaken for "nothing to clean up"
+          all_refs=$(gh api "repos/$GH_REPO/actions/caches?per_page=100" \
+            --paginate --jq '.actions_caches[].ref' | sort -u)
+          # grep exits 1 when no PR holds caches, which is not an error
+          refs=$(printf '%s\n' "$all_refs" | grep '^refs/pull/' || true)
+
+          deleted=0
+          for ref in $refs; do
+            number=${ref#refs/pull/}
+            number=${number%%/*}
+
+            # Only ever delete on an explicit closed/merged answer, so a
+            # transient lookup failure cannot wipe an open PR's caches
+            state=$(gh pr view "$number" --json state --jq .state || echo UNKNOWN)
+            case "$state" in
+              CLOSED|MERGED) ;;
+              *) continue ;;
+            esac
+
+            # `gh cache list` returns at most 100 entries, a busy PR holds more
+            while :; do
+              ids=$(gh cache list --ref "$ref" --limit 100 --json id --jq '.[].id')
+              [ -n "$ids" ] || break
+              before=$deleted
+              for id in $ids; do
+                # An entry evicted between the list and the delete is not worth
+                # aborting the sweep for
+                gh cache delete "$id" >/dev/null || continue
+                deleted=$((deleted + 1))
+              done
+              # A pass that deleted nothing would loop forever
+              [ "$deleted" -gt "$before" ] || break
             done
           done
+
+          echo "Deleted $deleted cache entries"

--- a/.github/workflows/cleanup-pr-caches.yml
+++ b/.github/workflows/cleanup-pr-caches.yml
@@ -1,0 +1,38 @@
+name: Cleanup PR caches
+
+# Actions caches are capped at 10 GB per repository, and once the cap is hit
+# GitHub evicts the least recently used entries. A cache written on a PR ref can
+# only ever be read back by that same PR, so after it closes the entries are
+# dead weight that keeps evicting the shared ones. GitHub never removes them on
+# its own, so do it here.
+#
+# `pull_request_target` (not `pull_request`) so the run gets a writable token for
+# PRs from forks too. Nothing from the PR is checked out or executed.
+
+on:
+  pull_request_target:
+    types: [closed]
+
+permissions:
+  actions: write
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Delete caches for the closed PR
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          REF: refs/pull/${{ github.event.pull_request.number }}/merge
+        run: |
+          set -euo pipefail
+          # `gh cache list` caps out at 100 per page, a single PR can hold more
+          while :; do
+            ids=$(gh cache list --ref "$REF" --limit 100 --json id --jq '.[].id' || true)
+            [ -n "$ids" ] || break
+            for id in $ids; do
+              gh cache delete "$id"
+            done
+          done

--- a/.github/workflows/docker-release-test.yml
+++ b/.github/workflows/docker-release-test.yml
@@ -62,6 +62,8 @@ jobs:
           file: docker/Dockerfile
           context: . # without this it will use master instead of the selected branch
           cache-from: type=gha,scope=zwave-js-ui
+          # Shared with docker-release.yml and read by docker-test.yml on every
+          # PR, so an on-demand run from any branch redefines what PR CI reads
           cache-to: type=gha,mode=max,scope=zwave-js-ui
           push: true
           tags: ${{ steps.docker_meta.outputs.tags }}

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -95,6 +95,8 @@ jobs:
           file: docker/Dockerfile
           context: . # without this it will clone master branch instead of using local
           cache-from: type=gha,scope=zwave-js-ui
+          # docker-test.yml reads this scope for every PR build - renaming it
+          # silently makes PR CI cold instead of failing
           cache-to: type=gha,mode=max,scope=zwave-js-ui
           push: true
           tags: ${{ steps.docker_meta.outputs.tags }}

--- a/.github/workflows/docker-test.yml
+++ b/.github/workflows/docker-test.yml
@@ -55,6 +55,11 @@ jobs:
           # could ever reuse, while evicting the shared caches (the bot's
           # docs/posts embeddings indexes among them). Reading the release scope
           # instead also gives a new PR a warm cache from master.
+          #
+          # The trade: pushes within one PR no longer warm each other, so a PR
+          # that invalidates an early layer rebuilds it on every push. Do not
+          # "fix" that by re-adding `cache-to` - it is what filled the cache.
+          # docker-release.yml owns this scope; keep the names in sync.
           cache-from: type=gha,scope=zwave-js-ui
           push: false
           tags: ${{ steps.docker_meta.outputs.tags }}

--- a/.github/workflows/docker-test.yml
+++ b/.github/workflows/docker-test.yml
@@ -50,7 +50,11 @@ jobs:
         with:
           platforms: ${{ matrix.platform }}
           file: docker/Dockerfile
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          # Read-only on purpose: a cache saved on a PR ref is readable only by
+          # that same PR, so `cache-to` wrote ~1 GB per PR that nothing else
+          # could ever reuse, while evicting the shared caches (the bot's
+          # docs/posts embeddings indexes among them). Reading the release scope
+          # instead also gives a new PR a warm cache from master.
+          cache-from: type=gha,scope=zwave-js-ui
           push: false
           tags: ${{ steps.docker_meta.outputs.tags }}


### PR DESCRIPTION
## Problem

The repository's Actions cache is over its 10 GB cap and permanently evicting entries:

```
active_caches_size_in_bytes: 10,695,169,546   (cap 10 GB)
active_caches_count:         597
```

Broken down by ref, almost all of it is unreachable by anything:

| ref | entries | size |
|---|---:|---:|
| `refs/pull/4727/merge` | 124 | 1387 MB |
| `refs/pull/4751/merge` | 104 | 1284 MB |
| `refs/pull/4734/merge` | 62 | 1237 MB |
| `refs/pull/4732/merge` | 62 | 1237 MB |
| `refs/pull/4733/merge` | 57 | 1229 MB |
| `refs/pull/4735/merge` | 59 | 1189 MB |
| `refs/pull/4741/merge` | 59 | 1189 MB |
| `refs/pull/4742/merge` | 57 | 1185 MB |
| **`refs/heads/master`** | **16** | **262 MB** |

8.3 GB of that is buildkit blobs written by `docker-test.yml`'s `cache-to: type=gha,mode=max`, which runs on every pull request.

A cache saved on a PR ref **can only be read back by that same PR**. So each PR wrote roughly a gigabyte no other PR and no master build could ever use, and it stayed until eviction. `docker-test.yml` also used the unscoped default scope while the release builds use `scope=zwave-js-ui`, so it never shared with them either: every new PR started cold and every new PR made things worse.

Being over the cap, GitHub evicts least-recently-used entries. The visible casualty is the docs answer bot from #4743, whose 1–2 MB indexes vanish within hours. Direct evidence — the nightly `docs-embeddings` run missed the cache **it had saved itself the previous morning under the identical key**:

```
2026-07-17T05:58:52Z  Cache not found for input keys: docs-embeddings-v2-4d1349a..., docs-embeddings-v2-
2026-07-17T05:59:11Z  Cache saved with key:           docs-embeddings-v2-4d1349a...
```

## Changes

**`docker-test.yml` — read the cache, don't write it.** `cache-to` is dropped and `cache-from` now points at `scope=zwave-js-ui`, the scope the release builds populate on master. PR builds stop writing ~1 GB apiece and start warm from master, which they never did before.

The trade, recorded in a comment so nobody "fixes" it by re-adding `cache-to`: pushes within one PR no longer warm each other, so a PR that invalidates an early layer rebuilds it on every push.

**New `cleanup-pr-caches.yml` — a daily sweep** over refs that still hold caches, deleting those whose PR is closed or merged. GitHub never does this itself, and those entries can never be read again by anyone.

A scheduled sweep rather than a `pull_request_target: closed` hook, because closing a PR does not cancel its in-flight runs — `ci.yml`, `test-application.yml` and `docker-test.yml` (120 min timeout) keep saving on the same ref for minutes afterwards, and a close-triggered job never fires again for that PR. Sweeping also reclaims PRs closed before this workflow existed, PRs targeting long-lived branches, and anything an earlier pass failed to delete. It needs no `pull_request_target`, so there is no fork-token or re-trigger surface at all.

Deletion requires an explicit `CLOSED`/`MERGED` answer, so a transient lookup failure cannot wipe an open PR's caches. `gh cache list` is deliberately unguarded — an API failure must not be mistaken for "nothing to clean up" — while individual deletes are tolerant, since an entry evicted between the list and the delete is not worth aborting the sweep for. The loop stops when a pass makes no progress, and success reports how many entries it removed.

**Scope ownership recorded** at both `cache-to` sites in `docker-release.yml` and `docker-release-test.yml`: PR CI now reads that scope, and renaming it would silently make PR builds cold rather than failing.

## Measured effect

PR 4752's own ref holds **1 cache entry**. PR #4753's, opened the same day against the same base and without this change, holds **61**.

Build times for the identical Dockerfile, same hour: **1m26–1m42 with this change**, 2m21–3m12 without — the release-scope read is a net speedup, not just a quota fix.

Dry-run of the sweep against the live repo correctly selected only the merged PR and left all eight open ones alone:

```
refs/pull/4727/merge     MERGED   100 entries  -> DELETE
refs/pull/4734/merge     OPEN      26 entries  -> keep
refs/pull/4735/merge     OPEN      59 entries  -> keep
...
```

## Not addressed here

`docker-test.yml` declares its matrix as `platforms:` but the build reads `${{ matrix.platform }}` (singular), so all three matrix jobs build the runner's native platform instead of amd64/arm64/armv7. Real bug, but fixing it means enabling two emulated builds per PR — worth its own PR and its own decision. It also caps this PR's payoff, since the arm64/armv7 layers in the release scope are never actually pulled.

The bot's dependence on a cache that can be evicted at any time is fixed separately in #4753.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
