### PR TITLE
fix(bot): keep the answer bot working when its index cache is evicted

### DIFF
--- a/.github/actions/restore-bot-index/action.yml
+++ b/.github/actions/restore-bot-index/action.yml
@@ -1,92 +1,179 @@
 name: Restore bot index
 description: >-
-  Restore an embeddings index directory (containing index.json) from the Actions
-  cache, falling back to the artifact uploaded by the workflow that builds it.
+  Restore the docs or posts embeddings index from the Actions cache, falling
+  back to the artifact uploaded by the workflow that builds it.
 
 # The Actions cache is capped per repository and evicted least-recently-used, so
 # a 1-2 MB index regularly disappears within hours of being written. Artifacts
-# are not evicted, so they are what makes the restore actually dependable.
+# are not evicted, so they are what makes the restore dependable.
+#
+# Each index lives in a fixed directory (.docs-index / .posts-index) holding a
+# single index.json, and is published under a fixed artifact name, so the caller
+# only has to say which one it wants.
 
 inputs:
-  path:
-    description: Directory to restore the index into
-    required: true
-  cache-key:
-    description: Primary Actions cache key
-    required: true
-  cache-restore-keys:
-    description: Newline separated cache key prefixes to fall back to
-    required: false
-    default: ''
-  artifact-name:
-    description: Artifact uploaded by the building workflow
-    required: true
-  workflow:
-    description: Workflow file that builds and uploads the artifact
+  index:
+    description: Which index to restore - "docs" or "posts"
     required: true
   github-token:
-    description: Token with actions read scope, used to list runs and download the artifact
+    description: Token with actions read scope, used to find and download the artifact
     required: true
+  max-age-days:
+    description: Warn when the restored index is older than this many days
+    required: false
+    default: '3'
 
 outputs:
   found:
     description: '"true" when the index is available afterwards'
-    value: ${{ steps.check.outputs.found }}
+    value: ${{ steps.report.outputs.found }}
 
 runs:
   using: composite
 
   steps:
-    - name: Restore from cache
-      id: cache
+    - name: Resolve the index
+      id: cfg
+      shell: bash
+      env:
+        INDEX: ${{ inputs.index }}
+      run: |
+        set -euo pipefail
+        case "$INDEX" in
+          docs|posts) ;;
+          *) echo "::error::Unknown index '$INDEX' - expected 'docs' or 'posts'"; exit 1 ;;
+        esac
+        echo "path=.$INDEX-index" >> "$GITHUB_OUTPUT"
+        echo "artifact=$INDEX-index" >> "$GITHUB_OUTPUT"
+
+    - name: Restore the docs index from cache
+      if: inputs.index == 'docs'
       uses: actions/cache/restore@v6
       with:
-        path: ${{ inputs.path }}
-        key: ${{ inputs.cache-key }}
-        restore-keys: ${{ inputs.cache-restore-keys }}
+        path: .docs-index
+        key: docs-embeddings-v2-${{ hashFiles('docs/**/*.md', '.github/bot-scripts/buildDocsIndex.cjs', '.github/bot-scripts/docsIndex.cjs', '.github/bot-scripts/modelsApi.cjs') }}
+        restore-keys: docs-embeddings-v2-
 
-    - name: Find the latest run that uploaded the index
-      id: run
-      if: steps.cache.outputs.cache-matched-key == ''
+    - name: Restore the posts index from cache
+      if: inputs.index == 'posts'
+      uses: actions/cache/restore@v6
+      with:
+        path: .posts-index
+        # There is no exact key to match, the newest index is picked
+        # via the prefix
+        key: posts-embeddings-v1-
+        restore-keys: posts-embeddings-v1-
+
+    # Decide on the file, not on the cache key: a prefix match can restore an
+    # entry that was saved while its build was still writing it
+    - name: Check what the cache gave us
+      id: cached
+      shell: bash
+      env:
+        INDEX_FILE: ${{ steps.cfg.outputs.path }}/index.json
+      run: |
+        set -euo pipefail
+        if [ -s "$INDEX_FILE" ] && jq -e . "$INDEX_FILE" >/dev/null 2>&1; then
+          echo "ok=true" >> "$GITHUB_OUTPUT"
+          echo "Cache hit: $INDEX_FILE"
+        else
+          echo "ok=false" >> "$GITHUB_OUTPUT"
+          echo "Cache did not yield a usable $INDEX_FILE"
+        fi
+
+    # Selecting on the artifact rather than on a run's conclusion matters: the
+    # index is produced by build-index alone, so an unrelated evaluate/feedback
+    # failure would otherwise hide a perfectly good artifact.
+    - name: Find the newest usable index artifact
+      id: artifact
+      if: steps.cached.outputs.ok != 'true'
+      # A lookup failure degrades to "no index" for the caller to handle, it
+      # must not take down a job triggered by someone opening an issue
+      continue-on-error: true
       shell: bash
       env:
         GH_TOKEN: ${{ inputs.github-token }}
         GH_REPO: ${{ github.repository }}
-        WORKFLOW: ${{ inputs.workflow }}
+        ARTIFACT: ${{ steps.cfg.outputs.artifact }}
         BRANCH: ${{ github.event.repository.default_branch }}
       run: |
         set -euo pipefail
-        id=$(gh run list --workflow "$WORKFLOW" --branch "$BRANCH" --status success \
-          --limit 1 --json databaseId --jq '.[0].databaseId // empty')
+        if [ -z "$BRANCH" ]; then
+          echo "::error::default_branch is empty - cannot establish artifact provenance"
+          exit 1
+        fi
+        # Newest first. Pinned to a non-expired artifact built on the default
+        # branch of this repository itself, so neither a fork PR (whose
+        # head_branch can also be "master") nor an expired entry can be picked.
+        id=$(gh api "repos/$GH_REPO/actions/artifacts?name=$ARTIFACT&per_page=100" \
+          --jq '[ .artifacts[]
+                  | select(.expired == false)
+                  | select(.workflow_run.head_branch == env.BRANCH)
+                  | select(.workflow_run.head_repository_id == .workflow_run.repository_id) ]
+                | .[0].workflow_run.id // empty')
+        if [ -n "$id" ]; then
+          echo "Newest usable $ARTIFACT artifact comes from run $id"
+        else
+          echo "No unexpired $ARTIFACT artifact built on $BRANCH"
+        fi
         echo "id=$id" >> "$GITHUB_OUTPUT"
 
+    # A partial cache restore must not be mixed with the artifact contents
+    - name: Clear the target directory
+      if: steps.artifact.outputs.id != ''
+      shell: bash
+      env:
+        DIR: ${{ steps.cfg.outputs.path }}
+      run: rm -rf "$DIR"
+
     - name: Download the index artifact
-      # A run predating the artifact upload, or one whose artifact has expired,
-      # is not an error here - the caller decides what a missing index means
+      id: download
+      if: steps.artifact.outputs.id != ''
       continue-on-error: true
-      if: steps.run.outputs.id != ''
       uses: actions/download-artifact@v8
       with:
-        name: ${{ inputs.artifact-name }}
-        path: ${{ inputs.path }}
-        run-id: ${{ steps.run.outputs.id }}
+        name: ${{ steps.cfg.outputs.artifact }}
+        path: ${{ steps.cfg.outputs.path }}
+        run-id: ${{ steps.artifact.outputs.id }}
         github-token: ${{ inputs.github-token }}
 
     - name: Report what was restored
-      id: check
+      id: report
       shell: bash
       env:
-        INDEX: ${{ inputs.path }}/index.json
-        FROM_CACHE: ${{ steps.cache.outputs.cache-matched-key }}
+        INDEX_FILE: ${{ steps.cfg.outputs.path }}/index.json
+        ARTIFACT: ${{ steps.cfg.outputs.artifact }}
+        FROM_CACHE: ${{ steps.cached.outputs.ok }}
+        ARTIFACT_RUN: ${{ steps.artifact.outputs.id }}
+        LOOKUP: ${{ steps.artifact.outcome }}
+        DOWNLOAD: ${{ steps.download.outcome }}
+        MAX_AGE_DAYS: ${{ inputs.max-age-days }}
       run: |
         set -euo pipefail
-        if [ ! -f "$INDEX" ]; then
+
+        if [ ! -s "$INDEX_FILE" ]; then
           echo "found=false" >> "$GITHUB_OUTPUT"
-          echo "No index at $INDEX"
-        elif [ -n "$FROM_CACHE" ]; then
-          echo "found=true" >> "$GITHUB_OUTPUT"
-          echo "Restored $INDEX from cache $FROM_CACHE"
+          # Name the leg that failed - an expired artifact and a misconfigured
+          # lookup look identical from the outside otherwise
+          echo "::warning::No $INDEX_FILE (cache: miss, artifact lookup: ${LOOKUP:-skipped}, download: ${DOWNLOAD:-skipped}, run: ${ARTIFACT_RUN:-none})"
+          exit 0
+        fi
+
+        echo "found=true" >> "$GITHUB_OUTPUT"
+        if [ "$FROM_CACHE" = "true" ]; then
+          echo "Using $INDEX_FILE from the Actions cache"
         else
-          echo "found=true" >> "$GITHUB_OUTPUT"
-          echo "Cache miss, restored $INDEX from run ${{ steps.run.outputs.id }}"
+          echo "Using $INDEX_FILE from the $ARTIFACT artifact of run $ARTIFACT_RUN"
+        fi
+
+        # Without this the bot answers happily off a month-old index whenever
+        # the nightly rebuild has been failing, then hard-fails the day the
+        # artifact expires, with no warning in between
+        created=$(jq -r '.createdAt // empty' "$INDEX_FILE")
+        if [ -n "$created" ]; then
+          age=$(( ( $(date -u +%s) - $(date -u -d "$created" +%s) ) / 86400 ))
+          echo "Index built $created ($age day(s) ago)"
+          if [ "$age" -gt "$MAX_AGE_DAYS" ]; then
+            echo "::warning::$ARTIFACT is $age days old (limit $MAX_AGE_DAYS) - the nightly rebuild may be failing"
+          fi
         fi

--- a/.github/actions/restore-bot-index/action.yml
+++ b/.github/actions/restore-bot-index/action.yml
@@ -1,0 +1,92 @@
+name: Restore bot index
+description: >-
+  Restore an embeddings index directory (containing index.json) from the Actions
+  cache, falling back to the artifact uploaded by the workflow that builds it.
+
+# The Actions cache is capped per repository and evicted least-recently-used, so
+# a 1-2 MB index regularly disappears within hours of being written. Artifacts
+# are not evicted, so they are what makes the restore actually dependable.
+
+inputs:
+  path:
+    description: Directory to restore the index into
+    required: true
+  cache-key:
+    description: Primary Actions cache key
+    required: true
+  cache-restore-keys:
+    description: Newline separated cache key prefixes to fall back to
+    required: false
+    default: ''
+  artifact-name:
+    description: Artifact uploaded by the building workflow
+    required: true
+  workflow:
+    description: Workflow file that builds and uploads the artifact
+    required: true
+  github-token:
+    description: Token with actions read scope, used to list runs and download the artifact
+    required: true
+
+outputs:
+  found:
+    description: '"true" when the index is available afterwards'
+    value: ${{ steps.check.outputs.found }}
+
+runs:
+  using: composite
+
+  steps:
+    - name: Restore from cache
+      id: cache
+      uses: actions/cache/restore@v6
+      with:
+        path: ${{ inputs.path }}
+        key: ${{ inputs.cache-key }}
+        restore-keys: ${{ inputs.cache-restore-keys }}
+
+    - name: Find the latest run that uploaded the index
+      id: run
+      if: steps.cache.outputs.cache-matched-key == ''
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.github-token }}
+        GH_REPO: ${{ github.repository }}
+        WORKFLOW: ${{ inputs.workflow }}
+        BRANCH: ${{ github.event.repository.default_branch }}
+      run: |
+        set -euo pipefail
+        id=$(gh run list --workflow "$WORKFLOW" --branch "$BRANCH" --status success \
+          --limit 1 --json databaseId --jq '.[0].databaseId // empty')
+        echo "id=$id" >> "$GITHUB_OUTPUT"
+
+    - name: Download the index artifact
+      # A run predating the artifact upload, or one whose artifact has expired,
+      # is not an error here - the caller decides what a missing index means
+      continue-on-error: true
+      if: steps.run.outputs.id != ''
+      uses: actions/download-artifact@v8
+      with:
+        name: ${{ inputs.artifact-name }}
+        path: ${{ inputs.path }}
+        run-id: ${{ steps.run.outputs.id }}
+        github-token: ${{ inputs.github-token }}
+
+    - name: Report what was restored
+      id: check
+      shell: bash
+      env:
+        INDEX: ${{ inputs.path }}/index.json
+        FROM_CACHE: ${{ steps.cache.outputs.cache-matched-key }}
+      run: |
+        set -euo pipefail
+        if [ ! -f "$INDEX" ]; then
+          echo "found=false" >> "$GITHUB_OUTPUT"
+          echo "No index at $INDEX"
+        elif [ -n "$FROM_CACHE" ]; then
+          echo "found=true" >> "$GITHUB_OUTPUT"
+          echo "Restored $INDEX from cache $FROM_CACHE"
+        else
+          echo "found=true" >> "$GITHUB_OUTPUT"
+          echo "Cache miss, restored $INDEX from run ${{ steps.run.outputs.id }}"
+        fi

--- a/.github/bot-scripts/updateEvalTrackingIssue.cjs
+++ b/.github/bot-scripts/updateEvalTrackingIssue.cjs
@@ -15,6 +15,12 @@
 //   genuine Models API/network error, or e.g. zero eval cases), which
 //   is an infrastructure problem rather than a retrieval quality miss
 //   and is reported differently so it isn't mistaken for a docs gap.
+// - TRACKING_ISSUE_BODY: optional. Replaces the generated body, for
+//   callers that are not a daily eval (the answer bot reports an index
+//   outage through the same tracking-issue mechanism).
+// - TRACKING_ISSUE_QUIET: optional. When "true", an already-open issue
+//   is left alone instead of collecting another comment. Callers that
+//   run per user post need this - a daily eval does not.
 
 /**
  * @param {{github: Github, context: Context}} param
@@ -46,7 +52,7 @@ async function main(param) {
 
 	const runUrl =
 		`${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
-	const body = isInfraFailure
+	const generatedBody = isInfraFailure
 		? `The daily evaluation of the ${process.env.EVAL_NAME} failed to run to completion (an infrastructure error - e.g. a Models API/network failure - not a retrieval quality regression).
 
 See the [workflow run](${runUrl}) for details.`
@@ -55,6 +61,14 @@ See the [workflow run](${runUrl}) for details.`
 ${summary || "(no summary available)"}
 
 See the [workflow run](${runUrl}) for details.`;
+	const body = process.env.TRACKING_ISSUE_BODY
+		? `${process.env.TRACKING_ISSUE_BODY}
+
+See the [workflow run](${runUrl}) for details.`
+		: generatedBody;
+	// Callers firing once per user post would otherwise pile up one comment
+	// per event for the whole duration of an outage
+	const quiet = process.env.TRACKING_ISSUE_QUIET === "true";
 
 	if (failed) {
 		if (!tracking) {
@@ -74,7 +88,7 @@ See the [workflow run](${runUrl}) for details.`;
 				issue_number: tracking.number,
 				body,
 			});
-		} else {
+		} else if (!quiet) {
 			await github.rest.issues.createComment({
 				...context.repo,
 				issue_number: tracking.number,
@@ -85,8 +99,10 @@ See the [workflow run](${runUrl}) for details.`;
 		await github.rest.issues.createComment({
 			...context.repo,
 			issue_number: tracking.number,
+			// Phrased around EVAL_NAME rather than "the evaluation", since
+			// not every caller is one - the answer bot reports index outages
 			body:
-				`The evaluation passed again in the latest [workflow run](${runUrl}). Closing.`,
+				`The ${process.env.EVAL_NAME} is healthy again in the latest [workflow run](${runUrl}). Closing.`,
 		});
 		await github.rest.issues.update({
 			...context.repo,

--- a/.github/bot-scripts/updateEvalTrackingIssue.test.cjs
+++ b/.github/bot-scripts/updateEvalTrackingIssue.test.cjs
@@ -1,0 +1,139 @@
+// @ts-check
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import updateEvalTrackingIssue from "./updateEvalTrackingIssue.cjs";
+
+const TITLE = "tracking title";
+
+const context = {
+	repo: { owner: "zwave-js", repo: "zwave-js-ui" },
+	serverUrl: "https://github.com",
+	runId: 42,
+};
+
+/** Records every write the script attempts against a given set of issues */
+function githubWith(issues) {
+	const calls = [];
+	return {
+		calls,
+		github: {
+			paginate: async () => issues,
+			rest: {
+				issues: {
+					listForRepo: {},
+					create: async (a) => calls.push({ op: "create", ...a }),
+					update: async (a) => calls.push({ op: "update", ...a }),
+					createComment: async (a) =>
+						calls.push({ op: "comment", ...a }),
+				},
+			},
+		},
+	};
+}
+
+const run = (issues) => {
+	const m = githubWith(issues);
+	return updateEvalTrackingIssue({ github: m.github, context }).then(
+		() => m.calls,
+	);
+};
+
+describe("updateEvalTrackingIssue", () => {
+	const saved = { ...process.env };
+
+	beforeEach(() => {
+		process.env.TRACKING_ISSUE_TITLE = TITLE;
+		process.env.EVAL_NAME = "answer bot index restore";
+	});
+
+	afterEach(() => {
+		process.env = { ...saved };
+	});
+
+	describe("TRACKING_ISSUE_BODY", () => {
+		it("replaces the generated eval body", async () => {
+			process.env.EVAL_OUTCOME = "failure";
+			process.env.TRACKING_ISSUE_BODY = "the index could not be restored";
+
+			const [created] = await run([]);
+			expect(created.op).toBe("create");
+			expect(created.title).toBe(TITLE);
+			expect(created.body).toContain("the index could not be restored");
+			expect(created.body).not.toContain("hit rate");
+			// The run link is appended for every caller
+			expect(created.body).toContain("/actions/runs/42");
+		});
+
+		it("leaves the eval body alone when unset", async () => {
+			process.env.EVAL_OUTCOME = "failure";
+			process.env.EVAL_SUMMARY = "hit rate 40%";
+
+			const [created] = await run([]);
+			expect(created.body).toContain("did not meet the required hit rate");
+			expect(created.body).toContain("hit rate 40%");
+		});
+	});
+
+	describe("TRACKING_ISSUE_QUIET", () => {
+		it("does not comment again on an already-open issue", async () => {
+			process.env.EVAL_OUTCOME = "failure";
+			process.env.TRACKING_ISSUE_QUIET = "true";
+
+			const calls = await run([
+				{ title: TITLE, state: "open", number: 7 },
+			]);
+			expect(calls).toEqual([]);
+		});
+
+		it("still reopens and explains a closed issue", async () => {
+			process.env.EVAL_OUTCOME = "failure";
+			process.env.TRACKING_ISSUE_QUIET = "true";
+			process.env.TRACKING_ISSUE_BODY = "outage";
+
+			const calls = await run([
+				{ title: TITLE, state: "closed", number: 7 },
+			]);
+			expect(calls.map((c) => c.op)).toEqual(["update", "comment"]);
+			expect(calls[0].state).toBe("open");
+			expect(calls[1].body).toContain("outage");
+		});
+
+		it("comments on an already-open issue when unset", async () => {
+			process.env.EVAL_OUTCOME = "failure";
+
+			const calls = await run([
+				{ title: TITLE, state: "open", number: 7 },
+			]);
+			expect(calls.map((c) => c.op)).toEqual(["comment"]);
+		});
+	});
+
+	describe("recovery", () => {
+		it("closes an open issue and names the caller, not 'the evaluation'", async () => {
+			process.env.EVAL_OUTCOME = "success";
+			process.env.TRACKING_ISSUE_QUIET = "true";
+
+			const calls = await run([
+				{ title: TITLE, state: "open", number: 7 },
+			]);
+			expect(calls.map((c) => c.op)).toEqual(["comment", "update"]);
+			expect(calls[0].body).toContain(
+				"The answer bot index restore is healthy again",
+			);
+			expect(calls[1].state).toBe("closed");
+		});
+
+		it("does nothing when there is no tracking issue", async () => {
+			process.env.EVAL_OUTCOME = "success";
+
+			expect(await run([])).toEqual([]);
+		});
+	});
+
+	it("refuses to run without a title", async () => {
+		delete process.env.TRACKING_ISSUE_TITLE;
+		process.env.EVAL_OUTCOME = "failure";
+
+		await expect(run([])).rejects.toThrow("TRACKING_ISSUE_TITLE");
+	});
+});

--- a/.github/workflows/docs-embeddings.yml
+++ b/.github/workflows/docs-embeddings.yml
@@ -64,6 +64,13 @@ jobs:
         name: docs-index
         path: .docs-index
         retention-days: 30
+        # .docs-index is a dot-directory and the glob skips hidden entries by
+        # default, search root included - without this the upload matches zero
+        # files and silently produces no artifact at all
+        include-hidden-files: true
+        # The answer bot depends on this artifact existing, so an empty upload
+        # is a failure, not a warning
+        if-no-files-found: error
 
   evaluate:
     needs: build-index

--- a/.github/workflows/docs-embeddings.yml
+++ b/.github/workflows/docs-embeddings.yml
@@ -54,6 +54,17 @@ jobs:
         GITHUB_TOKEN: ${{ github.token }}
       run: node .github/bot-scripts/buildDocsIndex.cjs docs .docs-index/index.json
 
+    # The cache entry is regularly evicted before the answer bot gets to use it
+    # (the repository cache is capped and evicted least-recently-used), so keep
+    # a durable copy it can fall back to. Runs on a cache hit too - the index
+    # ends up in .docs-index either way.
+    - name: Upload index artifact
+      uses: actions/upload-artifact@v7
+      with:
+        name: docs-index
+        path: .docs-index
+        retention-days: 30
+
   evaluate:
     needs: build-index
     runs-on: [ubuntu-latest]

--- a/.github/workflows/posts-embeddings.yml
+++ b/.github/workflows/posts-embeddings.yml
@@ -73,6 +73,13 @@ jobs:
         name: posts-index
         path: .posts-index
         retention-days: 30
+        # .posts-index is a dot-directory and the glob skips hidden entries by
+        # default, search root included - without this the upload matches zero
+        # files and silently produces no artifact at all
+        include-hidden-files: true
+        # The answer bot depends on this artifact existing, so an empty upload
+        # is a failure, not a warning
+        if-no-files-found: error
 
   evaluate:
     needs: build-index

--- a/.github/workflows/posts-embeddings.yml
+++ b/.github/workflows/posts-embeddings.yml
@@ -64,6 +64,16 @@ jobs:
         path: .posts-index
         key: posts-embeddings-v1-${{ github.run_id }}
 
+    # The cache entry is regularly evicted before the answer bot gets to use it
+    # (the repository cache is capped and evicted least-recently-used), so keep
+    # a durable copy it can fall back to.
+    - name: Upload index artifact
+      uses: actions/upload-artifact@v7
+      with:
+        name: posts-index
+        path: .posts-index
+        retention-days: 30
+
   evaluate:
     needs: build-index
     runs-on: [ubuntu-latest]

--- a/.github/workflows/zwave-js-bot_post.yml
+++ b/.github/workflows/zwave-js-bot_post.yml
@@ -77,6 +77,7 @@ jobs:
     runs-on: [ubuntu-latest]
     timeout-minutes: 10
     permissions:
+      actions: read
       contents: read
       models: read
 
@@ -85,27 +86,32 @@ jobs:
       uses: actions/checkout@v7
 
     - name: Restore docs index
-      id: restore-index
-      uses: actions/cache/restore@v6
+      id: docs-index
+      uses: ./.github/actions/restore-bot-index
       with:
         path: .docs-index
-        key: docs-embeddings-v2-${{ hashFiles('docs/**/*.md', '.github/bot-scripts/buildDocsIndex.cjs', '.github/bot-scripts/docsIndex.cjs', '.github/bot-scripts/modelsApi.cjs') }}
-        restore-keys: |
-          docs-embeddings-v2-
+        cache-key: docs-embeddings-v2-${{ hashFiles('docs/**/*.md', '.github/bot-scripts/buildDocsIndex.cjs', '.github/bot-scripts/docsIndex.cjs', '.github/bot-scripts/modelsApi.cjs') }}
+        cache-restore-keys: docs-embeddings-v2-
+        artifact-name: docs-index
+        workflow: docs-embeddings.yml
+        github-token: ${{ github.token }}
 
     - name: Restore posts index
-      id: restore-posts-index
-      uses: actions/cache/restore@v6
+      id: posts-index
+      uses: ./.github/actions/restore-bot-index
       with:
         path: .posts-index
         # There is no exact key to match, the newest index is picked
         # via the prefix
-        key: posts-embeddings-v1-
-        restore-keys: |
-          posts-embeddings-v1-
+        cache-key: posts-embeddings-v1-
+        cache-restore-keys: posts-embeddings-v1-
+        artifact-name: posts-index
+        workflow: posts-embeddings.yml
+        github-token: ${{ github.token }}
 
     # Downvoted answers collected by the docs-embeddings workflow.
-    # A missing cache just means no suppression is applied.
+    # A missing cache just means no suppression is applied, so unlike the
+    # indexes this one deliberately has no artifact fallback.
     - name: Restore answer feedback
       uses: actions/cache/restore@v6
       with:
@@ -114,15 +120,16 @@ jobs:
         restore-keys: |
           docs-feedback-v1-
 
-    - name: Warn if neither index is available
-      if: steps.restore-index.outputs.cache-matched-key == '' && steps.restore-posts-index.outputs.cache-matched-key == ''
-      uses: actions/github-script@v9
-      with:
-        script: |
-          core.warning('Neither the docs index nor the posts index cache is available yet - skipping the docs answer bot for this post. This is expected until the first docs-embeddings/posts-embeddings workflow run has completed.');
+    - name: Fail if neither index is available
+      # Both the cache entry and the artifact of the latest embeddings run
+      # would have to be missing for this to fire. Failing the job keeps a
+      # permanently broken bot from reporting green run after run.
+      if: steps.docs-index.outputs.found != 'true' && steps.posts-index.outputs.found != 'true'
+      run: |
+        echo "::error::Neither the docs index nor the posts index could be restored, from cache or from the latest embeddings run - the answer bot cannot run"
+        exit 1
 
     - name: Answer from documentation
-      if: steps.restore-index.outputs.cache-matched-key != '' || steps.restore-posts-index.outputs.cache-matched-key != ''
       uses: actions/github-script@v9
       env:
         MODELS_TOKEN: ${{ github.token }}
@@ -144,6 +151,7 @@ jobs:
     runs-on: [ubuntu-latest]
     timeout-minutes: 10
     permissions:
+      actions: read
       contents: read
       models: read
     if: github.event.action == 'opened' || github.event.action == 'created'
@@ -153,26 +161,28 @@ jobs:
       uses: actions/checkout@v7
 
     - name: Restore posts index
-      id: restore-posts-index
-      uses: actions/cache/restore@v6
+      id: posts-index
+      uses: ./.github/actions/restore-bot-index
       with:
         path: .posts-index
         # There is no exact key to match, the newest index is picked
         # via the prefix
-        key: posts-embeddings-v1-
-        restore-keys: |
-          posts-embeddings-v1-
+        cache-key: posts-embeddings-v1-
+        cache-restore-keys: posts-embeddings-v1-
+        artifact-name: posts-index
+        workflow: posts-embeddings.yml
+        github-token: ${{ github.token }}
 
-    - name: Warn if no posts index is available
-      if: steps.restore-posts-index.outputs.cache-matched-key == ''
-      uses: actions/github-script@v9
-      with:
-        script: |
-          core.warning('No posts index cache is available yet - skipping the incremental posts index update for this post. This is expected until the first posts-embeddings workflow run has completed.');
+    - name: Fail if no posts index is available
+      # Restoring from the artifact and re-saving the cache below is also how
+      # an evicted cache entry heals itself between two nightly rebuilds
+      if: steps.posts-index.outputs.found != 'true'
+      run: |
+        echo "::error::The posts index could not be restored, from cache or from the latest posts-embeddings run - this post will only be indexed by the next nightly rebuild"
+        exit 1
 
     - name: Add post to index
       id: update
-      if: steps.restore-posts-index.outputs.cache-matched-key != ''
       uses: actions/github-script@v9
       env:
         MODELS_TOKEN: ${{ github.token }}

--- a/.github/workflows/zwave-js-bot_post.yml
+++ b/.github/workflows/zwave-js-bot_post.yml
@@ -79,6 +79,7 @@ jobs:
     permissions:
       actions: read
       contents: read
+      issues: write
       models: read
 
     steps:
@@ -89,24 +90,14 @@ jobs:
       id: docs-index
       uses: ./.github/actions/restore-bot-index
       with:
-        path: .docs-index
-        cache-key: docs-embeddings-v2-${{ hashFiles('docs/**/*.md', '.github/bot-scripts/buildDocsIndex.cjs', '.github/bot-scripts/docsIndex.cjs', '.github/bot-scripts/modelsApi.cjs') }}
-        cache-restore-keys: docs-embeddings-v2-
-        artifact-name: docs-index
-        workflow: docs-embeddings.yml
+        index: docs
         github-token: ${{ github.token }}
 
     - name: Restore posts index
       id: posts-index
       uses: ./.github/actions/restore-bot-index
       with:
-        path: .posts-index
-        # There is no exact key to match, the newest index is picked
-        # via the prefix
-        cache-key: posts-embeddings-v1-
-        cache-restore-keys: posts-embeddings-v1-
-        artifact-name: posts-index
-        workflow: posts-embeddings.yml
+        index: posts
         github-token: ${{ github.token }}
 
     # Downvoted answers collected by the docs-embeddings workflow.
@@ -120,13 +111,46 @@ jobs:
         restore-keys: |
           docs-feedback-v1-
 
+    # One missing index still answers, just worse - say so instead of
+    # letting a half-working bot look healthy
+    - name: Warn about a partial outage
+      if: |
+        (steps.docs-index.outputs.found == 'true') !=
+        (steps.posts-index.outputs.found == 'true')
+      run: |
+        echo "::warning::Only one of the two indexes was restored (docs: ${{ steps.docs-index.outputs.found }}, posts: ${{ steps.posts-index.outputs.found }}) - answers will be degraded"
+
+    # This workflow is triggered by whoever opened the issue or discussion, so
+    # a failed run notifies them, not the maintainers. Route the outage to the
+    # same tracking issue the nightly evaluations use, and let a later healthy
+    # run close it again.
+    - name: Track index availability
+      # Reporting the outage must never be what breaks the run
+      continue-on-error: true
+      uses: actions/github-script@v9
+      env:
+        TRACKING_ISSUE_TITLE: "🚨 Answer bot cannot restore its search index"
+        EVAL_NAME: answer bot index restore
+        EVAL_OUTCOME: ${{ (steps.docs-index.outputs.found != 'true' && steps.posts-index.outputs.found != 'true') && 'failure' || 'success' }}
+        TRACKING_ISSUE_BODY: |
+          Neither the docs index nor the posts index could be restored - not from the Actions cache, and not from the latest artifact of the embeddings workflows. The answer bot cannot run until this is fixed.
+
+          Check that `docs-embeddings.yml` and `posts-embeddings.yml` are still succeeding and still uploading their `docs-index` / `posts-index` artifacts.
+        # Fires once per new issue or discussion, so an open outage must not
+        # collect a comment every time
+        TRACKING_ISSUE_QUIET: 'true'
+      with:
+        script: |
+          const bot = require(`${process.env.GITHUB_WORKSPACE}/.github/bot-scripts/index.cjs`);
+          await bot.updateEvalTrackingIssue({github, context});
+
     - name: Fail if neither index is available
-      # Both the cache entry and the artifact of the latest embeddings run
-      # would have to be missing for this to fire. Failing the job keeps a
-      # permanently broken bot from reporting green run after run.
+      # Both the cache entry and the newest unexpired artifact would have to be
+      # missing for this to fire. Failing the job keeps a permanently broken
+      # bot from reporting green run after run.
       if: steps.docs-index.outputs.found != 'true' && steps.posts-index.outputs.found != 'true'
       run: |
-        echo "::error::Neither the docs index nor the posts index could be restored, from cache or from the latest embeddings run - the answer bot cannot run"
+        echo "::error::Neither the docs index nor the posts index could be restored, from cache or from artifacts - the answer bot cannot run"
         exit 1
 
     - name: Answer from documentation
@@ -160,29 +184,27 @@ jobs:
     - name: Checkout master branch
       uses: actions/checkout@v7
 
+    # Restoring from the artifact and re-saving the cache below is also how an
+    # evicted cache entry heals itself between two nightly rebuilds
     - name: Restore posts index
       id: posts-index
       uses: ./.github/actions/restore-bot-index
       with:
-        path: .posts-index
-        # There is no exact key to match, the newest index is picked
-        # via the prefix
-        cache-key: posts-embeddings-v1-
-        cache-restore-keys: posts-embeddings-v1-
-        artifact-name: posts-index
-        workflow: posts-embeddings.yml
+        index: posts
         github-token: ${{ github.token }}
 
-    - name: Fail if no posts index is available
-      # Restoring from the artifact and re-saving the cache below is also how
-      # an evicted cache entry heals itself between two nightly rebuilds
+    - name: Warn if no posts index is available
+      # Only a warning: this append is best effort, the 04:30 rebuild picks the
+      # post up either way. answer-from-docs is where an outage is worth a red
+      # run - failing here too would just paint every community post red for
+      # something that self-corrects.
       if: steps.posts-index.outputs.found != 'true'
       run: |
-        echo "::error::The posts index could not be restored, from cache or from the latest posts-embeddings run - this post will only be indexed by the next nightly rebuild"
-        exit 1
+        echo "::warning::The posts index could not be restored, from cache or from artifacts - this post will only be indexed by the next nightly rebuild"
 
     - name: Add post to index
       id: update
+      if: steps.posts-index.outputs.found == 'true'
       uses: actions/github-script@v9
       env:
         MODELS_TOKEN: ${{ github.token }}


### PR DESCRIPTION
## Problem

The answer bot from #4743 has never posted an answer. Its docs and posts embeddings indexes live only in the Actions cache, which is capped at 10 GB per repository and evicted least-recently-used once full. At 1–2 MB apiece those indexes lose that race constantly.

The only run since the feature landed — [29531097992](https://github.com/zwave-js/zwave-js-ui/actions/runs/29531097992), discussion 4749 — restored nothing:

```
Cache not found for input keys: docs-embeddings-v2-4d1349a..., docs-embeddings-v2-
Cache not found for input keys: posts-embeddings-v1-, posts-embeddings-v1-
Cache not found for input keys: docs-feedback-v1-, docs-feedback-v1-
→ "Answer from documentation"  skipped
→ "Add post to index"          skipped
✓ run reported success
```

All three had been written by green workflow runs ten hours earlier that same morning.

It isn't a scoping or key problem. The nightly `docs-embeddings` run missed the cache **it had saved itself the previous morning, under the byte-identical key**:

```
2026-07-17T05:58:52Z  Cache not found for input keys: docs-embeddings-v2-4d1349a..., docs-embeddings-v2-
2026-07-17T05:59:11Z  Cache saved with key:           docs-embeddings-v2-4d1349a...
```

Today not a single embeddings or feedback cache written before Jul 18 survives.

And the failure mode was invisible: a missing index produced `core.warning` plus a skipped step, and the run went green. A bot that has never worked looked exactly like a healthy one.

## Changes

**Both embeddings workflows upload their index as an artifact** (30 day retention). Artifacts are not LRU-evicted, so they are the dependable source. `include-hidden-files: true` is required and load-bearing — `.docs-index` / `.posts-index` are dot-directories, and the upload glob skips hidden entries by default including the search root, so without it the upload matches zero files and produces no artifact while still reporting success. `if-no-files-found: error` makes that guarantee enforced rather than advisory.

**New composite action `.github/actions/restore-bot-index`**, used at three call sites. It takes the index name and a token:

```yaml
- uses: ./.github/actions/restore-bot-index
  with:
    index: docs
    github-token: ${{ github.token }}
```

It restores from the cache, then falls back to the artifact. Two details that matter:

- It selects the **newest unexpired artifact by name**, not the newest run with a successful conclusion. The index is produced by `build-index` alone, so an unrelated `evaluate`/`feedback` failure would otherwise hide a perfectly good artifact.
- Provenance is pinned to the default branch of this repository (`head_repository_id == repository_id`). A fork PR's `head_branch` can also be `master`, so a branch-name check alone would not be a trust boundary.

The fallback decides on a readable `index.json`, not on the cache key — a prefix match can restore an entry saved while its build was still writing — and clears the directory before extracting so the two sources cannot mix. The lookup is `continue-on-error`, so a transient API blip degrades to "no index" instead of taking down a job that someone triggered by opening an issue.

**Failures now reach a maintainer.** These runs are triggered by whoever opened the issue or discussion, so a red run notifies *them*. An index outage now opens the same kind of tracking issue the nightly evaluations already use, and a later healthy run closes it again. `updateEvalTrackingIssue.cjs` gains two optional env knobs (`TRACKING_ISSUE_BODY`, `TRACKING_ISSUE_QUIET`) for callers that aren't a daily eval and that fire once per user post; both default to today's behaviour.

**Loudness now matches severity.** `answer-from-docs` still fails hard when no index can be restored — that outage is user-visible and total. `update-posts-index` warns and skips instead: its own message says the post is picked up by the next nightly rebuild, so failing it would paint every community post red for something that self-corrects. A partial outage (one index of two) warns rather than passing silently.

**Staleness is checked.** A restored index older than `max-age-days` (default 3) warns, so a broken nightly surfaces before the artifact expires rather than the day after.

The downvote suppression list keeps cache-only restore with no fallback: a missing one just means no suppression is applied, which is already the documented behaviour.

## Verification

- Reproduced the hidden-directory upload bug directly against `@actions/glob`: `excludeHiddenFiles=true → []`, `false → [.docs-index, .docs-index/index.json]`.
- Exercised the artifact-selection jq against the live API — returns empty when no artifact exists, returns the right run id when one does.
- `updateEvalTrackingIssue.cjs` had no test coverage; this PR adds `updateEvalTrackingIssue.test.cjs` (8 cases) covering both new knobs, the recovery-close path, and that the existing eval behaviour is unchanged. Full bot-scripts suite: 125 tests, 9 files.

## Notes

Merging touches both `docs-embeddings.yml` and `posts-embeddings.yml`, which are in their own workflows' push path filters, so both rebuild and upload their first artifact on merge. There is a ~15–20 minute window before that completes during which a new issue would find no artifact; combined with an evicted cache, `answer-from-docs` would fail once.

The incremental `update-posts-index` job also heals itself now: on an evicted cache it restores from the artifact, appends, and re-saves the cache, instead of waiting for the nightly rebuild.

The cache pressure that causes the eviction is addressed separately in #4752 — 10.2 GB of the repository's 10.7 GB sits on PR refs where nothing can ever read it. This PR makes the bot survive eviction regardless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
