### PR TITLE
fix(bot): measure index staleness by upload time, not content age

### DIFF
--- a/.github/actions/report-index-status/action.yml
+++ b/.github/actions/report-index-status/action.yml
@@ -1,0 +1,91 @@
+name: Report bot index status
+description: >-
+  Open, update or close the tracking issue that records whether the answer bot
+  can restore its search indexes.
+
+# This owns the tracking issue title, which updateEvalTrackingIssue.cjs uses as
+# the lookup key. Every reporter must spell it identically or one alarm silently
+# becomes two issues that can flap each other open and closed, so the string
+# lives here once instead of in each calling workflow.
+#
+# The health predicate lives here too, for the same reason: the bot workflow and
+# the scheduled self-check must agree on what "degraded" means even though they
+# differ on what is worth failing a run over.
+
+inputs:
+  docs:
+    description: '"true" when the docs index was restored'
+    required: true
+  posts:
+    description: '"true" when the posts index was restored'
+    required: true
+  docs-stale:
+    description: '"true" when the docs pipeline looks dead'
+    required: false
+    default: 'false'
+  posts-stale:
+    description: '"true" when the posts pipeline looks dead'
+    required: false
+    default: 'false'
+  quiet:
+    description: >-
+      When "true", an already-open issue is left alone rather than collecting
+      another comment. Set it on reporters that fire once per user post.
+    required: false
+    default: 'true'
+
+outputs:
+  healthy:
+    description: '"true" when both indexes are present and freshly published'
+    value: ${{ steps.assess.outputs.healthy }}
+
+runs:
+  using: composite
+
+  steps:
+    - name: Assess
+      id: assess
+      shell: bash
+      env:
+        DOCS: ${{ inputs.docs }}
+        POSTS: ${{ inputs.posts }}
+        DOCS_STALE: ${{ inputs.docs-stale }}
+        POSTS_STALE: ${{ inputs.posts-stale }}
+      run: |
+        set -euo pipefail
+
+        problems=""
+        [ "$DOCS" = "true" ]  || problems="${problems}- The docs index could not be restored, from cache or from artifacts.\n"
+        [ "$POSTS" = "true" ] || problems="${problems}- The posts index could not be restored, from cache or from artifacts.\n"
+        [ "$DOCS_STALE" = "true" ]  && [ "$DOCS" = "true" ]  && problems="${problems}- The docs index is being served from a pipeline that has not published recently.\n"
+        [ "$POSTS_STALE" = "true" ] && [ "$POSTS" = "true" ] && problems="${problems}- The posts index is being served from a pipeline that has not published recently.\n"
+
+        if [ -z "$problems" ]; then
+          echo "healthy=true" >> "$GITHUB_OUTPUT"
+          echo "outcome=success" >> "$GITHUB_OUTPUT"
+        else
+          echo "healthy=false" >> "$GITHUB_OUTPUT"
+          echo "outcome=failure" >> "$GITHUB_OUTPUT"
+        fi
+        {
+          echo 'body<<TRACKING_EOF'
+          printf 'The answer bot'"'"'s search index is degraded:\n\n'
+          printf '%b' "$problems"
+          printf '\nCheck that `docs-embeddings.yml` and `posts-embeddings.yml` are still succeeding and still uploading their `docs-index` / `posts-index` artifacts.\n'
+          echo 'TRACKING_EOF'
+        } >> "$GITHUB_OUTPUT"
+
+    # Reporting a problem must never be what breaks the run
+    - name: Update the tracking issue
+      continue-on-error: true
+      uses: actions/github-script@v9
+      env:
+        TRACKING_ISSUE_TITLE: "🚨 Answer bot search index is degraded"
+        EVAL_NAME: answer bot index restore
+        EVAL_OUTCOME: ${{ steps.assess.outputs.outcome }}
+        TRACKING_ISSUE_BODY: ${{ steps.assess.outputs.body }}
+        TRACKING_ISSUE_QUIET: ${{ inputs.quiet }}
+      with:
+        script: |
+          const bot = require(`${process.env.GITHUB_WORKSPACE}/.github/bot-scripts/index.cjs`);
+          await bot.updateEvalTrackingIssue({github, context});

--- a/.github/actions/restore-bot-index/action.yml
+++ b/.github/actions/restore-bot-index/action.yml
@@ -81,12 +81,14 @@ runs:
           echo "Cache did not yield a usable $INDEX_FILE"
         fi
 
+    # Runs even on a cache hit, because its upload time is also the only honest
+    # "is the nightly still running" signal - see the staleness check below.
+    #
     # Selecting on the artifact rather than on a run's conclusion matters: the
     # index is produced by build-index alone, so an unrelated evaluate/feedback
     # failure would otherwise hide a perfectly good artifact.
     - name: Find the newest usable index artifact
       id: artifact
-      if: steps.cached.outputs.ok != 'true'
       # A lookup failure degrades to "no index" for the caller to handle, it
       # must not take down a job triggered by someone opening an issue
       continue-on-error: true
@@ -95,7 +97,10 @@ runs:
         GH_TOKEN: ${{ inputs.github-token }}
         GH_REPO: ${{ github.repository }}
         ARTIFACT: ${{ steps.cfg.outputs.artifact }}
-        BRANCH: ${{ github.event.repository.default_branch }}
+        # `schedule` and `workflow_dispatch` payloads are thinner than the
+        # issues/discussion ones, so fall back to the ref the run is on - these
+        # workflows only ever run on the default branch anyway
+        BRANCH: ${{ github.event.repository.default_branch || github.ref_name }}
       run: |
         set -euo pipefail
         if [ -z "$BRANCH" ]; then
@@ -105,22 +110,25 @@ runs:
         # Newest first. Pinned to a non-expired artifact built on the default
         # branch of this repository itself, so neither a fork PR (whose
         # head_branch can also be "master") nor an expired entry can be picked.
-        id=$(gh api "repos/$GH_REPO/actions/artifacts?name=$ARTIFACT&per_page=100" \
+        newest=$(gh api "repos/$GH_REPO/actions/artifacts?name=$ARTIFACT&per_page=100" \
           --jq '[ .artifacts[]
                   | select(.expired == false)
                   | select(.workflow_run.head_branch == env.BRANCH)
                   | select(.workflow_run.head_repository_id == .workflow_run.repository_id) ]
-                | .[0].workflow_run.id // empty')
-        if [ -n "$id" ]; then
-          echo "Newest usable $ARTIFACT artifact comes from run $id"
+                | .[0] // empty')
+        if [ -n "$newest" ]; then
+          id=$(printf '%s' "$newest" | jq -r '.workflow_run.id')
+          created=$(printf '%s' "$newest" | jq -r '.created_at')
+          echo "Newest usable $ARTIFACT artifact comes from run $id, uploaded $created"
+          echo "id=$id" >> "$GITHUB_OUTPUT"
+          echo "created=$created" >> "$GITHUB_OUTPUT"
         else
           echo "No unexpired $ARTIFACT artifact built on $BRANCH"
         fi
-        echo "id=$id" >> "$GITHUB_OUTPUT"
 
     # A partial cache restore must not be mixed with the artifact contents
     - name: Clear the target directory
-      if: steps.artifact.outputs.id != ''
+      if: steps.cached.outputs.ok != 'true' && steps.artifact.outputs.id != ''
       shell: bash
       env:
         DIR: ${{ steps.cfg.outputs.path }}
@@ -128,7 +136,7 @@ runs:
 
     - name: Download the index artifact
       id: download
-      if: steps.artifact.outputs.id != ''
+      if: steps.cached.outputs.ok != 'true' && steps.artifact.outputs.id != ''
       continue-on-error: true
       uses: actions/download-artifact@v8
       with:
@@ -145,6 +153,7 @@ runs:
         ARTIFACT: ${{ steps.cfg.outputs.artifact }}
         FROM_CACHE: ${{ steps.cached.outputs.ok }}
         ARTIFACT_RUN: ${{ steps.artifact.outputs.id }}
+        ARTIFACT_CREATED: ${{ steps.artifact.outputs.created }}
         LOOKUP: ${{ steps.artifact.outcome }}
         DOWNLOAD: ${{ steps.download.outcome }}
         MAX_AGE_DAYS: ${{ inputs.max-age-days }}
@@ -166,14 +175,22 @@ runs:
           echo "Using $INDEX_FILE from the $ARTIFACT artifact of run $ARTIFACT_RUN"
         fi
 
-        # Without this the bot answers happily off a month-old index whenever
-        # the nightly rebuild has been failing, then hard-fails the day the
-        # artifact expires, with no warning in between
-        created=$(jq -r '.createdAt // empty' "$INDEX_FILE")
-        if [ -n "$created" ]; then
-          age=$(( ( $(date -u +%s) - $(date -u -d "$created" +%s) ) / 86400 ))
-          echo "Index built $created ($age day(s) ago)"
+        # Content age is informational only: docs-embeddings skips the rebuild
+        # on a cache hit, so an index whose docs have not changed in a month is
+        # perfectly healthy and its own createdAt says nothing about the
+        # pipeline. The upload time does - the nightly re-uploads either way.
+        built=$(jq -r '.createdAt // empty' "$INDEX_FILE")
+        [ -n "$built" ] && echo "Index content built $built"
+
+        # Without this the bot answers happily off a month-old artifact whenever
+        # the nightly has been failing, then hard-fails the day it expires, with
+        # no warning in between
+        if [ -n "$ARTIFACT_CREATED" ]; then
+          age=$(( ( $(date -u +%s) - $(date -u -d "$ARTIFACT_CREATED" +%s) ) / 86400 ))
+          echo "Newest $ARTIFACT artifact uploaded $ARTIFACT_CREATED ($age day(s) ago)"
           if [ "$age" -gt "$MAX_AGE_DAYS" ]; then
-            echo "::warning::$ARTIFACT is $age days old (limit $MAX_AGE_DAYS) - the nightly rebuild may be failing"
+            echo "::warning::The newest $ARTIFACT artifact is $age days old (limit $MAX_AGE_DAYS) - the nightly rebuild may be failing"
           fi
+        else
+          echo "::warning::Could not determine when $ARTIFACT was last published (lookup: ${LOOKUP:-skipped})"
         fi

--- a/.github/actions/restore-bot-index/action.yml
+++ b/.github/actions/restore-bot-index/action.yml
@@ -19,7 +19,11 @@ inputs:
     description: Token with actions read scope, used to find and download the artifact
     required: true
   max-age-days:
-    description: Warn when the restored index is older than this many days
+    description: >-
+      Report the index as stale once the newest artifact is at least this many
+      days old. Both producers run on a daily cron (docs-embeddings 03:30,
+      posts-embeddings 04:30), so the default tolerates two missed nights -
+      raise it here if either cron is ever moved to a slower cadence.
     required: false
     default: '3'
 
@@ -27,6 +31,16 @@ outputs:
   found:
     description: '"true" when the index is available afterwards'
     value: ${{ steps.report.outputs.found }}
+  stale:
+    description: >-
+      '"true" when the index is usable but the pipeline that publishes it looks
+      dead - no unexpired artifact at all, or the newest one is older than
+      max-age-days. Callers that are health checks should treat this as a
+      failure; callers serving a user should keep going.'
+    value: ${{ steps.report.outputs.stale }}
+  age-days:
+    description: 'Age of the newest artifact in whole days, or "" if unknown'
+    value: ${{ steps.report.outputs.age-days }}
 
 runs:
   using: composite
@@ -73,7 +87,10 @@ runs:
         INDEX_FILE: ${{ steps.cfg.outputs.path }}/index.json
       run: |
         set -euo pipefail
-        if [ -s "$INDEX_FILE" ] && jq -e . "$INDEX_FILE" >/dev/null 2>&1; then
+        # Parseable JSON is not enough: a truncated embeddings response or an
+        # interrupted write leaves a file that loads fine and retrieves nothing
+        if [ -s "$INDEX_FILE" ] \
+          && jq -e '((.chunks // .posts) | length) > 0' "$INDEX_FILE" >/dev/null 2>&1; then
           echo "ok=true" >> "$GITHUB_OUTPUT"
           echo "Cache hit: $INDEX_FILE"
         else
@@ -97,34 +114,45 @@ runs:
         GH_TOKEN: ${{ inputs.github-token }}
         GH_REPO: ${{ github.repository }}
         ARTIFACT: ${{ steps.cfg.outputs.artifact }}
-        # `schedule` and `workflow_dispatch` payloads are thinner than the
-        # issues/discussion ones, so fall back to the ref the run is on - these
-        # workflows only ever run on the default branch anyway
-        BRANCH: ${{ github.event.repository.default_branch || github.ref_name }}
       run: |
         set -euo pipefail
+
+        # The branch pin is half of the provenance guarantee, so read it from an
+        # authority that does not vary by trigger. `github.event.repository` is
+        # absent from some payloads and `github.ref_name` is only usually equal
+        # to the default branch - neither belongs in a trust boundary.
+        BRANCH=$(gh api "repos/$GH_REPO" --jq '.default_branch')
         if [ -z "$BRANCH" ]; then
-          echo "::error::default_branch is empty - cannot establish artifact provenance"
+          echo "::error::Could not resolve the default branch - refusing to select an artifact"
           exit 1
         fi
+
         # Newest first. Pinned to a non-expired artifact built on the default
         # branch of this repository itself, so neither a fork PR (whose
         # head_branch can also be "master") nor an expired entry can be picked.
-        newest=$(gh api "repos/$GH_REPO/actions/artifacts?name=$ARTIFACT&per_page=100" \
+        newest=$(BRANCH="$BRANCH" gh api "repos/$GH_REPO/actions/artifacts?name=$ARTIFACT&per_page=100" \
           --jq '[ .artifacts[]
                   | select(.expired == false)
                   | select(.workflow_run.head_branch == env.BRANCH)
                   | select(.workflow_run.head_repository_id == .workflow_run.repository_id) ]
                 | .[0] // empty')
-        if [ -n "$newest" ]; then
-          id=$(printf '%s' "$newest" | jq -r '.workflow_run.id')
-          created=$(printf '%s' "$newest" | jq -r '.created_at')
-          echo "Newest usable $ARTIFACT artifact comes from run $id, uploaded $created"
-          echo "id=$id" >> "$GITHUB_OUTPUT"
-          echo "created=$created" >> "$GITHUB_OUTPUT"
-        else
+
+        # Reaching here at all means the API answered, which is what separates
+        # "nothing published" (an outage) from "could not ask" (unknown)
+        echo "searched=true" >> "$GITHUB_OUTPUT"
+
+        if [ -z "$newest" ]; then
           echo "No unexpired $ARTIFACT artifact built on $BRANCH"
+          exit 0
         fi
+
+        id=$(printf '%s' "$newest" | jq -r '.workflow_run.id // empty')
+        # created_at is nullable in the REST schema, and `jq -r` renders null as
+        # the string "null", which would sail past a -n test and blow up `date`
+        created=$(printf '%s' "$newest" | jq -r '.created_at // empty')
+        echo "Newest usable $ARTIFACT artifact comes from run ${id:-?}, uploaded ${created:-unknown}"
+        echo "id=$id" >> "$GITHUB_OUTPUT"
+        echo "created=$created" >> "$GITHUB_OUTPUT"
 
     # A partial cache restore must not be mixed with the artifact contents
     - name: Clear the target directory
@@ -154,21 +182,26 @@ runs:
         FROM_CACHE: ${{ steps.cached.outputs.ok }}
         ARTIFACT_RUN: ${{ steps.artifact.outputs.id }}
         ARTIFACT_CREATED: ${{ steps.artifact.outputs.created }}
+        SEARCHED: ${{ steps.artifact.outputs.searched }}
         LOOKUP: ${{ steps.artifact.outcome }}
         DOWNLOAD: ${{ steps.download.outcome }}
         MAX_AGE_DAYS: ${{ inputs.max-age-days }}
       run: |
         set -euo pipefail
 
+        emit() { echo "$1=$2" >> "$GITHUB_OUTPUT"; }
+
         if [ ! -s "$INDEX_FILE" ]; then
-          echo "found=false" >> "$GITHUB_OUTPUT"
+          emit found false
+          emit stale true
+          emit age-days ""
           # Name the leg that failed - an expired artifact and a misconfigured
           # lookup look identical from the outside otherwise
           echo "::warning::No $INDEX_FILE (cache: miss, artifact lookup: ${LOOKUP:-skipped}, download: ${DOWNLOAD:-skipped}, run: ${ARTIFACT_RUN:-none})"
           exit 0
         fi
 
-        echo "found=true" >> "$GITHUB_OUTPUT"
+        emit found true
         if [ "$FROM_CACHE" = "true" ]; then
           echo "Using $INDEX_FILE from the Actions cache"
         else
@@ -182,15 +215,34 @@ runs:
         built=$(jq -r '.createdAt // empty' "$INDEX_FILE")
         [ -n "$built" ] && echo "Index content built $built"
 
-        # Without this the bot answers happily off a month-old artifact whenever
-        # the nightly has been failing, then hard-fails the day it expires, with
-        # no warning in between
+        # Staleness is what catches a dead nightly while the cache still serves
+        # a usable index - including the case where this very check keeps the
+        # cache entry warm past the 7-day eviction window and so never misses.
+        age=""
+        stale=false
         if [ -n "$ARTIFACT_CREATED" ]; then
-          age=$(( ( $(date -u +%s) - $(date -u -d "$ARTIFACT_CREATED" +%s) ) / 86400 ))
-          echo "Newest $ARTIFACT artifact uploaded $ARTIFACT_CREATED ($age day(s) ago)"
-          if [ "$age" -gt "$MAX_AGE_DAYS" ]; then
-            echo "::warning::The newest $ARTIFACT artifact is $age days old (limit $MAX_AGE_DAYS) - the nightly rebuild may be failing"
+          # A bad timestamp must not abort a step the bot's hot path depends on
+          if created_epoch=$(date -u -d "$ARTIFACT_CREATED" +%s 2>/dev/null); then
+            age=$(( ( $(date -u +%s) - created_epoch ) / 86400 ))
+            echo "Newest $ARTIFACT artifact uploaded $ARTIFACT_CREATED ($age day(s) ago)"
+            if [ "$age" -ge "$MAX_AGE_DAYS" ]; then
+              stale=true
+              echo "::warning::The newest $ARTIFACT artifact is $age day(s) old (limit $MAX_AGE_DAYS) - the nightly rebuild may be failing"
+            fi
+          else
+            stale=true
+            echo "::warning::Unreadable upload timestamp for $ARTIFACT ('$ARTIFACT_CREATED')"
           fi
+        elif [ "$SEARCHED" = "true" ]; then
+          # The API answered and there is nothing published: an outage, not a
+          # gap in our knowledge. Only reachable on a cache hit, since a miss
+          # with no artifact cannot produce an index at all.
+          stale=true
+          echo "::warning::No unexpired $ARTIFACT artifact exists - serving a cached index off a pipeline that has published nothing"
         else
-          echo "::warning::Could not determine when $ARTIFACT was last published (lookup: ${LOOKUP:-skipped})"
+          stale=true
+          echo "::warning::Could not reach the artifacts API for $ARTIFACT (lookup: ${LOOKUP:-skipped}) - publication state unknown"
         fi
+
+        emit stale "$stale"
+        emit age-days "$age"

--- a/.github/workflows/bot-index-selfcheck.yml
+++ b/.github/workflows/bot-index-selfcheck.yml
@@ -1,0 +1,71 @@
+name: Bot index self-check
+
+# The answer bot only runs when someone opens an issue or discussion, and this
+# repository can go weeks between those - long enough for a broken index
+# pipeline to sit unnoticed, which is exactly how the original outage went
+# undetected. This exercises the same restore path on a schedule instead.
+#
+# A scheduled workflow that fails notifies the account the schedule runs under,
+# so unlike a failure on someone else's issue this one actually reaches a
+# maintainer.
+
+on:
+  schedule:
+    # After both nightly rebuilds (03:30 docs, 04:30 posts)
+    - cron: '0 8 * * *'
+  workflow_dispatch:
+
+permissions:
+  actions: read
+  contents: read
+  issues: write
+
+jobs:
+  restore:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+    - name: Checkout master branch
+      uses: actions/checkout@v7
+
+    - name: Restore docs index
+      id: docs-index
+      uses: ./.github/actions/restore-bot-index
+      with:
+        index: docs
+        github-token: ${{ github.token }}
+
+    - name: Restore posts index
+      id: posts-index
+      uses: ./.github/actions/restore-bot-index
+      with:
+        index: posts
+        github-token: ${{ github.token }}
+
+    # Deliberately the same condition and the same tracking issue the bot uses,
+    # so the two cannot disagree about whether there is an outage and flap the
+    # issue open and closed against each other
+    - name: Track index availability
+      continue-on-error: true
+      uses: actions/github-script@v9
+      env:
+        TRACKING_ISSUE_TITLE: "🚨 Answer bot cannot restore its search index"
+        EVAL_NAME: answer bot index restore
+        EVAL_OUTCOME: ${{ (steps.docs-index.outputs.found != 'true' && steps.posts-index.outputs.found != 'true') && 'failure' || 'success' }}
+        TRACKING_ISSUE_BODY: |
+          The scheduled self-check could restore neither the docs index nor the posts index - not from the Actions cache, and not from the latest artifact of the embeddings workflows. The answer bot cannot run until this is fixed.
+
+          Check that `docs-embeddings.yml` and `posts-embeddings.yml` are still succeeding and still uploading their `docs-index` / `posts-index` artifacts.
+      with:
+        script: |
+          const bot = require(`${process.env.GITHUB_WORKSPACE}/.github/bot-scripts/index.cjs`);
+          await bot.updateEvalTrackingIssue({github, context});
+
+    # Stricter than the bot, which degrades to one index: a health check should
+    # go red on a partial outage rather than wait for a total one
+    - name: Fail if either index is missing
+      if: steps.docs-index.outputs.found != 'true' || steps.posts-index.outputs.found != 'true'
+      run: |
+        echo "::error::Index restore failed (docs: ${{ steps.docs-index.outputs.found }}, posts: ${{ steps.posts-index.outputs.found }})"
+        exit 1

--- a/.github/workflows/bot-index-selfcheck.yml
+++ b/.github/workflows/bot-index-selfcheck.yml
@@ -2,18 +2,29 @@ name: Bot index self-check
 
 # The answer bot only runs when someone opens an issue or discussion, and this
 # repository can go weeks between those - long enough for a broken index
-# pipeline to sit unnoticed, which is exactly how the original outage went
-# undetected. This exercises the same restore path on a schedule instead.
+# pipeline to sit unnoticed, which is how the original outage went undetected.
+# This exercises the same restore path on a schedule instead.
 #
-# A scheduled workflow that fails notifies the account the schedule runs under,
-# so unlike a failure on someone else's issue this one actually reaches a
-# maintainer.
+# It is not a duplicate of the nightly embeddings workflows' own failure signal.
+# Those cover the *build*; this covers the *restore* - artifact expiry, the
+# provenance filter, token scope, and a schedule that stopped firing at all,
+# none of which a producer can detect about itself.
+#
+# A failed scheduled run notifies whoever last edited the cron (with Actions
+# notifications enabled), which is a weak channel - the tracking issue below is
+# the signal meant to be noticed.
 
 on:
   schedule:
     # After both nightly rebuilds (03:30 docs, 04:30 posts)
     - cron: '0 8 * * *'
   workflow_dispatch:
+
+# The tracking issue is found by title, so two overlapping runs could both miss
+# it and open duplicates
+concurrency:
+  group: bot-index-selfcheck
+  cancel-in-progress: false
 
 permissions:
   actions: read
@@ -43,29 +54,26 @@ jobs:
         index: posts
         github-token: ${{ github.token }}
 
-    # Deliberately the same condition and the same tracking issue the bot uses,
-    # so the two cannot disagree about whether there is an outage and flap the
-    # issue open and closed against each other
-    - name: Track index availability
-      continue-on-error: true
-      uses: actions/github-script@v9
-      env:
-        TRACKING_ISSUE_TITLE: "🚨 Answer bot cannot restore its search index"
-        EVAL_NAME: answer bot index restore
-        EVAL_OUTCOME: ${{ (steps.docs-index.outputs.found != 'true' && steps.posts-index.outputs.found != 'true') && 'failure' || 'success' }}
-        TRACKING_ISSUE_BODY: |
-          The scheduled self-check could restore neither the docs index nor the posts index - not from the Actions cache, and not from the latest artifact of the embeddings workflows. The answer bot cannot run until this is fixed.
-
-          Check that `docs-embeddings.yml` and `posts-embeddings.yml` are still succeeding and still uploading their `docs-index` / `posts-index` artifacts.
+    # always(), so a restore that hard-fails still gets reported rather than
+    # leaving the scheduled-run email as the only trace
+    - name: Report index status
+      id: status
+      if: always()
+      uses: ./.github/actions/report-index-status
       with:
-        script: |
-          const bot = require(`${process.env.GITHUB_WORKSPACE}/.github/bot-scripts/index.cjs`);
-          await bot.updateEvalTrackingIssue({github, context});
+        docs: ${{ steps.docs-index.outputs.found }}
+        posts: ${{ steps.posts-index.outputs.found }}
+        docs-stale: ${{ steps.docs-index.outputs.stale }}
+        posts-stale: ${{ steps.posts-index.outputs.stale }}
+        # Daily, so one comment per night on a standing outage is a useful
+        # heartbeat rather than noise
+        quiet: 'false'
 
-    # Stricter than the bot, which degrades to one index: a health check should
-    # go red on a partial outage rather than wait for a total one
-    - name: Fail if either index is missing
-      if: steps.docs-index.outputs.found != 'true' || steps.posts-index.outputs.found != 'true'
+    # Stricter than the bot, which degrades to a single index and keeps
+    # answering: a health check exists to go red early, including on a stale
+    # pipeline that the cache is still papering over
+    - name: Fail if either index is missing or stale
+      if: always() && steps.status.outputs.healthy != 'true'
       run: |
-        echo "::error::Index restore failed (docs: ${{ steps.docs-index.outputs.found }}, posts: ${{ steps.posts-index.outputs.found }})"
+        echo "::error::Index restore unhealthy (docs: found=${{ steps.docs-index.outputs.found }} stale=${{ steps.docs-index.outputs.stale }}, posts: found=${{ steps.posts-index.outputs.found }} stale=${{ steps.posts-index.outputs.stale }})"
         exit 1

--- a/.github/workflows/zwave-js-bot_post.yml
+++ b/.github/workflows/zwave-js-bot_post.yml
@@ -122,27 +122,20 @@ jobs:
 
     # This workflow is triggered by whoever opened the issue or discussion, so
     # a failed run notifies them, not the maintainers. Route the outage to the
-    # same tracking issue the nightly evaluations use, and let a later healthy
-    # run close it again.
-    - name: Track index availability
-      # Reporting the outage must never be what breaks the run
-      continue-on-error: true
-      uses: actions/github-script@v9
-      env:
-        TRACKING_ISSUE_TITLE: "🚨 Answer bot cannot restore its search index"
-        EVAL_NAME: answer bot index restore
-        EVAL_OUTCOME: ${{ (steps.docs-index.outputs.found != 'true' && steps.posts-index.outputs.found != 'true') && 'failure' || 'success' }}
-        TRACKING_ISSUE_BODY: |
-          Neither the docs index nor the posts index could be restored - not from the Actions cache, and not from the latest artifact of the embeddings workflows. The answer bot cannot run until this is fixed.
-
-          Check that `docs-embeddings.yml` and `posts-embeddings.yml` are still succeeding and still uploading their `docs-index` / `posts-index` artifacts.
+    # tracking issue instead, and let a later healthy run close it again. The
+    # shared action owns the issue title and the degraded/healthy predicate, so
+    # this reporter and the scheduled self-check cannot disagree and flap it.
+    - name: Report index status
+      if: always()
+      uses: ./.github/actions/report-index-status
+      with:
+        docs: ${{ steps.docs-index.outputs.found }}
+        posts: ${{ steps.posts-index.outputs.found }}
+        docs-stale: ${{ steps.docs-index.outputs.stale }}
+        posts-stale: ${{ steps.posts-index.outputs.stale }}
         # Fires once per new issue or discussion, so an open outage must not
         # collect a comment every time
-        TRACKING_ISSUE_QUIET: 'true'
-      with:
-        script: |
-          const bot = require(`${process.env.GITHUB_WORKSPACE}/.github/bot-scripts/index.cjs`);
-          await bot.updateEvalTrackingIssue({github, context});
+        quiet: 'true'
 
     - name: Fail if neither index is available
       # Both the cache entry and the newest unexpired artifact would have to be


### PR DESCRIPTION
Follow-up to #4753, found while verifying that PR's artifacts after merge.

## The bug

The staleness warning read `createdAt` from inside `index.json`:

```
.docs-index/index.json   built 2026-07-18T05:40:44.763Z (3 day(s) ago)   ← limit is 3
.posts-index/index.json  built 2026-07-21T13:09:16.340Z (0 day(s) ago)
```

But `docs-embeddings.yml` only rebuilds the index when the docs hash changes:

```yaml
- name: Build index
  # An exact cache hit means the index is already up to date
  if: steps.cache.outputs.cache-hit != 'true'
```

On a cache hit the upload step still runs and re-publishes the *same* file. So `createdAt` records **when the docs last changed**, which says nothing about whether the pipeline is alive. Docs last changed on Jul 18, so tomorrow the check would have fired

```
::warning:: docs-index is 4 days old - the nightly rebuild may be failing
```

on every new issue, with nothing wrong and no way for it to ever recover short of someone editing the docs. That is precisely the alarm fatigue the check existed to prevent. `posts-index` was unaffected because `posts-embeddings.yml` rebuilds unconditionally.

## The fix

Measure the artifact's **upload** time instead. The nightly publishes either way, so it only ages when the pipeline genuinely stops.

The lookup step already fetches the artifact; it now runs even on a cache hit to get `created_at` (one API call), which also makes the check work on both restore paths rather than only after an eviction. The download and directory-clear steps keep their cache-miss condition explicitly. Content age is still logged — it is useful — just not alarmed on.

Same real artifacts, before and after:

| | old (content age) | new (upload age) |
|---|---:|---:|
| `docs-index` today | 3 days → warns tomorrow | 0 days |
| `posts-index` today | 0 days | 0 days |

## Also: a scheduled self-check

`zwave-js-bot_post.yml` only runs on `issues` / `discussion`, and this repository can go weeks between those — the last human-filed issue before #4749 was #4682 on Jun 22. That gap is how the original outage stayed invisible for days, and it means the restore path added in #4753 is currently only exercised when a community member happens to post.

`bot-index-selfcheck.yml` runs the same restore path for both indexes on a schedule, after the two nightly rebuilds. A scheduled workflow that fails notifies the account it runs under, so unlike a red run on someone else's issue this one actually reaches a maintainer.

It deliberately shares the bot's tracking issue **and** its outage condition (both indexes missing), so the two reporters cannot disagree and flap the issue open and closed against each other. The job itself is stricter and goes red on a partial outage, since a health check should not wait for a total one.

`workflow_dispatch` makes the whole restore path testable on demand, which is otherwise impossible without opening a real issue and drawing a real bot comment.

## Verification

- Reproduced the false positive against the live artifacts and simulated the check forward 8 days to confirm the new source resets nightly instead of climbing.
- The artifact-selection query, the JSON validation and the age arithmetic were all run against the real `docs-index` / `posts-index` payloads published by the post-merge runs (270 chunks / 591 posts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
