### PR TITLE
fix(bot): run triage on transferred issues

### DIFF
--- a/.github/bot-scripts/answerFromDocs.cjs
+++ b/.github/bot-scripts/answerFromDocs.cjs
@@ -15,6 +15,7 @@ const {
 	rankRelatedPosts,
 } = require("./postsIndex.cjs");
 const { sanitizeModelAnswer } = require("./sanitizeAnswer.cjs");
+const { listCommentsSinceTransfer } = require("./utils.cjs");
 
 const DOCS_BASE_URL = "https://zwave-js.github.io/zwave-js-ui/#";
 const DOCS_ANSWER_COMMENT_TAG = "<!-- DOCS_ANSWER_COMMENT_TAG -->";
@@ -64,6 +65,8 @@ function chunkUrl(chunk) {
  */
 async function alreadyAnswered({ github, context }, post, isDiscussion) {
 	if (isDiscussion) {
+		// Discussions have no timeline API, so an answer inherited from a
+		// transfer cannot be told apart from ours
 		/** @type {string | null} */
 		let cursor = null;
 		for (;;) {
@@ -95,13 +98,11 @@ async function alreadyAnswered({ github, context }, post, isDiscussion) {
 			cursor = comments.pageInfo.endCursor;
 		}
 	} else {
-		const comments = await github.paginate(
-			github.rest.issues.listComments,
-			{
-				...context.repo,
-				issue_number: post.number,
-				per_page: 100,
-			},
+		const comments = await listCommentsSinceTransfer(
+			github,
+			context.repo.owner,
+			context.repo.repo,
+			post.number,
 		);
 		return comments.some((c) => c.body?.includes(DOCS_ANSWER_COMMENT_TAG));
 	}
@@ -647,6 +648,7 @@ ${DOCS_ANSWER_COMMENT_TAG}
 }
 
 module.exports = main;
+module.exports.alreadyAnswered = alreadyAnswered;
 module.exports.judgeAnswer = judgeAnswer;
 module.exports.validateJudgeResponse = validateJudgeResponse;
 module.exports.checkSuppression = checkSuppression;

--- a/.github/bot-scripts/answerFromDocs.test.cjs
+++ b/.github/bot-scripts/answerFromDocs.test.cjs
@@ -4,7 +4,26 @@ import { describe, it, expect } from "vitest";
 import {
 	validateJudgeResponse,
 	checkSuppression,
+	alreadyAnswered,
+	DOCS_ANSWER_COMMENT_TAG,
 } from "./answerFromDocs.cjs";
+
+/**
+ * @param {any[]} comments
+ * @param {any[]} events
+ */
+function mockGithub(comments, events) {
+	return /** @type {any} */ ({
+		paginate: (/** @type {any} */ route, /** @type {any} */ params) =>
+			route(params),
+		rest: {
+			issues: {
+				listComments: () => comments,
+				listEventsForTimeline: () => events,
+			},
+		},
+	});
+}
 
 describe("answerFromDocs", () => {
 	describe("validateJudgeResponse", () => {
@@ -185,6 +204,41 @@ describe("answerFromDocs", () => {
 					embeddingModel,
 				),
 			).toBe("allow");
+		});
+	});
+
+	describe("alreadyAnswered", () => {
+		it("ignores answers inherited from a transferred issue", async () => {
+			const events = [{
+				event: "transferred",
+				created_at: "2026-01-02T00:00:00Z",
+			}];
+			const inherited = {
+				created_at: "2026-01-01T00:00:00Z",
+				body: DOCS_ANSWER_COMMENT_TAG,
+			};
+			const own = {
+				created_at: "2026-01-03T00:00:00Z",
+				body: DOCS_ANSWER_COMMENT_TAG,
+			};
+			/** @param {any[]} comments */
+			const param = (comments) => ({
+				github: mockGithub(comments, events),
+				context: /** @type {any} */ ({
+					repo: { owner: "zwave-js", repo: "zwave-js-ui" },
+				}),
+			});
+
+			expect(
+				await alreadyAnswered(param([inherited]), { number: 1 }, false),
+			).toBe(false);
+			expect(
+				await alreadyAnswered(
+					param([inherited, own]),
+					{ number: 1 },
+					false,
+				),
+			).toBe(true);
 		});
 	});
 });

--- a/.github/bot-scripts/classifyIssueFeedback.cjs
+++ b/.github/bot-scripts/classifyIssueFeedback.cjs
@@ -2,6 +2,8 @@
 
 /// <reference path="types.d.ts" />
 
+const { listCommentsSinceTransfer } = require("./utils.cjs");
+
 const CLASSIFY_ISSUE_COMMENT_TAG = "<!-- CLASSIFY_ISSUE_COMMENT_TAG -->";
 
 /**
@@ -38,12 +40,14 @@ If this is the case, please close this issue and open a one in the [Z-Wave JS re
 		message += CLASSIFY_ISSUE_COMMENT_TAG;
 	}
 
-	// Existing comments are tagged with LOGFILE_COMMENT_TAG
+	// Existing comments are tagged with CLASSIFY_ISSUE_COMMENT_TAG
 	try {
-		const { data: comments } = await github.rest.issues.listComments({
-			...options,
-			issue_number: context.issue.number,
-		});
+		const comments = await listCommentsSinceTransfer(
+			github,
+			options.owner,
+			options.repo,
+			context.issue.number,
+		);
 		const existing = comments.find(
 			(c) =>
 				c.user?.login === "zwave-js-bot"

--- a/.github/bot-scripts/collectDocsFeedback.cjs
+++ b/.github/bot-scripts/collectDocsFeedback.cjs
@@ -20,7 +20,7 @@ const {
 	DOCS_ANSWER_METADATA_VERSION,
 	DOCS_BASE_URL,
 } = require("./answerFromDocs.cjs");
-const { ghGraphql, ghPaginated, ghRequest } = require("./githubApi.cjs");
+const { ghGraphql } = require("./githubApi.cjs");
 const { embedBatched, EMBEDDING_MODEL } = require("./modelsApi.cjs");
 const { cleanQuestion } = require("./postsIndex.cjs");
 const { authorizedUsers } = require("./authorizedUsers.cjs");
@@ -38,15 +38,8 @@ const DEFAULT_WEIGHT = 1;
 // a maintainer downvote or the author plus one other person does
 const SUPPRESS_SCORE = -3;
 
-// Reaction contents in REST ("+1") and GraphQL ("THUMBS_UP") notation
 /** @type {Record<string, number>} */
 const REACTION_SIGNS = {
-	"+1": 1,
-	heart: 1,
-	hooray: 1,
-	rocket: 1,
-	"-1": -1,
-	confused: -1,
 	THUMBS_UP: 1,
 	HEART: 1,
 	HOORAY: 1,
@@ -216,6 +209,81 @@ function scoreReactions(reactions, postAuthor) {
  * @property {number} score
  */
 
+// Comment fields shared by the issue and discussion queries
+const commentFields = `
+	nodes {
+		body
+		url
+		createdAt
+		author { login }
+		reactions(first: 100) {
+			nodes {
+				content
+				user { login }
+			}
+		}
+	}`;
+
+/**
+ * Fetches the remaining comment pages of a busy issue or discussion
+ * @param {"Issue" | "Discussion"} type
+ * @param {string} id
+ * @param {any} connection
+ * @param {string} token
+ * @returns {Promise<any[]>}
+ */
+async function fetchAllComments(type, id, connection, token) {
+	const comments = [...(connection?.nodes ?? [])];
+	let pageInfo = connection?.pageInfo;
+	while (pageInfo?.hasNextPage) {
+		const more = await ghGraphql(
+			`
+			query moreComments($id: ID!, $cursor: String) {
+				node(id: $id) {
+					... on ${type} {
+						comments(first: 100, after: $cursor) {
+							pageInfo { hasNextPage endCursor }
+							${commentFields}
+						}
+					}
+				}
+			}
+			`,
+			{ id, cursor: pageInfo.endCursor },
+			token,
+		);
+		comments.push(...(more.node?.comments?.nodes ?? []));
+		pageInfo = more.node?.comments?.pageInfo;
+	}
+	return comments;
+}
+
+/**
+ * Picks the bot's answers out of a post's comments
+ * @param {any[]} comments
+ * @param {number} [transferredAt] Epoch ms, answers from before are skipped
+ * @returns {any[]}
+ */
+function findAnswers(comments, transferredAt = 0) {
+	return comments.filter(
+		(c) =>
+			c.author?.login === BOT_USER
+			&& c.body?.includes(DOCS_ANSWER_COMMENT_TAG)
+			&& new Date(c.createdAt).getTime() > transferredAt,
+	);
+}
+
+/**
+ * @param {any} comment
+ * @returns {{user: string, content: string}[]}
+ */
+function commentReactions(comment) {
+	return (comment.reactions?.nodes ?? []).map((/** @type {any} */ r) => ({
+		user: r.user?.login ?? "",
+		content: r.content,
+	}));
+}
+
 /**
  * @param {string} owner
  * @param {string} repo
@@ -227,63 +295,77 @@ async function collectFromIssues(owner, repo, since, token) {
 	/** @type {FeedbackRecord[]} */
 	const records = [];
 
-	const query = encodeURIComponent(
-		`repo:${owner}/${repo} is:issue commenter:${BOT_USER} updated:>=${since}`,
-	);
-	/** @type {any[]} */
-	const issues = [];
-	for (let page = 1;; page++) {
-		const result = await ghRequest(
-			"GET",
-			`/search/issues?q=${query}&per_page=100&page=${page}`,
-			undefined,
-			token,
-		);
-		issues.push(...result.items);
-		if (issues.length >= result.total_count || result.items.length === 0) {
-			break;
-		}
-	}
-
-	for (const issue of issues) {
-		const comments = await ghPaginated(
-			`/repos/${owner}/${repo}/issues/${issue.number}/comments?per_page=100`,
-			token,
-		);
-		const answers = comments.filter((c) =>
-			c.user?.login === BOT_USER
-			&& c.body?.includes(DOCS_ANSWER_COMMENT_TAG)
-		);
-		for (const answer of answers) {
-			/** @type {{user: string, content: string}[]} */
-			let reactions = [];
-			if (answer.reactions?.total_count > 0) {
-				/** @type {any[]} */
-				const raw = await ghRequest(
-					"GET",
-					`/repos/${owner}/${repo}/issues/comments/${answer.id}/reactions?per_page=100`,
-					undefined,
-					token,
-				);
-				reactions = raw.map((r) => ({
-					user: r.user?.login ?? "",
-					content: r.content,
-				}));
+	const searchQuery =
+		`repo:${owner}/${repo} is:issue commenter:${BOT_USER} updated:>=${since}`;
+	let cursor = null;
+	for (;;) {
+		const data = await ghGraphql(
+			`
+			query search($searchQuery: String!, $cursor: String) {
+				search(type: ISSUE, query: $searchQuery, first: 25, after: $cursor) {
+					pageInfo { hasNextPage endCursor }
+					nodes {
+						... on Issue {
+							id
+							title
+							body
+							url
+							author { login }
+							timelineItems(first: 100, itemTypes: [TRANSFERRED_EVENT]) {
+								nodes {
+									... on TransferredEvent { createdAt }
+								}
+							}
+							comments(first: 100) {
+								pageInfo { hasNextPage endCursor }
+								${commentFields}
+							}
+						}
+					}
+				}
 			}
-			const author = issue.user?.login ?? "";
-			const { votes, score } = scoreReactions(reactions, author);
-			records.push({
-				type: "issue",
-				postUrl: issue.html_url,
-				commentUrl: answer.html_url,
-				title: issue.title,
-				author,
-				question: cleanQuestion(issue.title, issue.body ?? ""),
-				...parseAnswerMetadata(answer.body),
-				votes,
-				score,
-			});
+			`,
+			{ searchQuery, cursor },
+			token,
+		);
+
+		for (const issue of data.search.nodes) {
+			const comments = await fetchAllComments(
+				"Issue",
+				issue.id,
+				issue.comments,
+				token,
+			);
+			// Answers older than the last transfer were written for the repo
+			// the issue came from
+			const transferredAt = Math.max(
+				0,
+				...issue.timelineItems.nodes.map(
+					(/** @type {any} */ n) => new Date(n.createdAt).getTime(),
+				),
+			);
+			const author = issue.author?.login ?? "";
+			for (const answer of findAnswers(comments, transferredAt)) {
+				const { votes, score } = scoreReactions(
+					commentReactions(answer),
+					author,
+				);
+				records.push({
+					type: "issue",
+					postUrl: issue.url,
+					commentUrl: answer.url,
+					title: issue.title,
+					author,
+					question: cleanQuestion(issue.title, issue.body ?? ""),
+					...parseAnswerMetadata(answer.body),
+					votes,
+					score,
+				});
+			}
 		}
+
+		if (!data.search.pageInfo.hasNextPage) break;
+		cursor = data.search.pageInfo.endCursor;
 	}
 
 	return records;
@@ -299,20 +381,6 @@ async function collectFromIssues(owner, repo, since, token) {
 async function collectFromDiscussions(owner, repo, since, token) {
 	/** @type {FeedbackRecord[]} */
 	const records = [];
-
-	// Shared between the search query and the more-comments query
-	const commentFields = `
-		nodes {
-			body
-			url
-			author { login }
-			reactions(first: 100) {
-				nodes {
-					content
-					user { login }
-				}
-			}
-		}`;
 
 	const searchQuery =
 		`repo:${owner}/${repo} commenter:${BOT_USER} updated:>=${since}`;
@@ -344,44 +412,18 @@ async function collectFromDiscussions(owner, repo, since, token) {
 		);
 
 		for (const discussion of data.search.nodes) {
-			const comments = [...(discussion.comments?.nodes ?? [])];
-			// Fetch remaining comment pages of busy discussions
-			let commentsPage = discussion.comments?.pageInfo;
-			while (commentsPage?.hasNextPage) {
-				const more = await ghGraphql(
-					`
-					query moreComments($id: ID!, $cursor: String) {
-						node(id: $id) {
-							... on Discussion {
-								comments(first: 100, after: $cursor) {
-									pageInfo { hasNextPage endCursor }
-									${commentFields}
-								}
-							}
-						}
-					}
-					`,
-					{ id: discussion.id, cursor: commentsPage.endCursor },
-					token,
-				);
-				comments.push(...(more.node?.comments?.nodes ?? []));
-				commentsPage = more.node?.comments?.pageInfo;
-			}
-
-			const answers = comments.filter(
-				(/** @type {any} */ c) =>
-					c.author?.login === BOT_USER
-					&& c.body?.includes(DOCS_ANSWER_COMMENT_TAG),
+			const comments = await fetchAllComments(
+				"Discussion",
+				discussion.id,
+				discussion.comments,
+				token,
 			);
-			for (const answer of answers) {
-				const reactions = (answer.reactions?.nodes ?? []).map(
-					(/** @type {any} */ r) => ({
-						user: r.user?.login ?? "",
-						content: r.content,
-					}),
+			const author = discussion.author?.login ?? "";
+			for (const answer of findAnswers(comments)) {
+				const { votes, score } = scoreReactions(
+					commentReactions(answer),
+					author,
 				);
-				const author = discussion.author?.login ?? "";
-				const { votes, score } = scoreReactions(reactions, author);
 				records.push({
 					type: "discussion",
 					postUrl: discussion.url,

--- a/.github/bot-scripts/collectDocsFeedback.test.cjs
+++ b/.github/bot-scripts/collectDocsFeedback.test.cjs
@@ -191,8 +191,8 @@ describe("collectDocsFeedback", () => {
 		it("collapses multiple same-sign reactions from one user into a single vote", () => {
 			const { votes, score } = scoreReactions(
 				[
-					{ user: "alice", content: "+1" },
-					{ user: "alice", content: "heart" },
+					{ user: "alice", content: "THUMBS_UP" },
+					{ user: "alice", content: "HEART" },
 				],
 				"postAuthor",
 			);
@@ -204,8 +204,8 @@ describe("collectDocsFeedback", () => {
 		it("cancels out contradicting reactions from the same user into no vote", () => {
 			const { votes, score } = scoreReactions(
 				[
-					{ user: "alice", content: "+1" },
-					{ user: "alice", content: "-1" },
+					{ user: "alice", content: "THUMBS_UP" },
+					{ user: "alice", content: "THUMBS_DOWN" },
 				],
 				"postAuthor",
 			);
@@ -216,9 +216,9 @@ describe("collectDocsFeedback", () => {
 		it("caps three same-sign reactions from one user to a single weighted vote", () => {
 			const { votes, score } = scoreReactions(
 				[
-					{ user: "alice", content: "+1" },
-					{ user: "alice", content: "heart" },
-					{ user: "alice", content: "hooray" },
+					{ user: "alice", content: "THUMBS_UP" },
+					{ user: "alice", content: "HEART" },
+					{ user: "alice", content: "HOORAY" },
 				],
 				"postAuthor",
 			);
@@ -229,9 +229,9 @@ describe("collectDocsFeedback", () => {
 		it("applies maintainer/author weights once per user after collapsing", () => {
 			const { votes, score } = scoreReactions(
 				[
-					{ user: "AlCalzone", content: "+1" },
-					{ user: "AlCalzone", content: "+1" },
-					{ user: "postAuthor", content: "+1" },
+					{ user: "AlCalzone", content: "THUMBS_UP" },
+					{ user: "AlCalzone", content: "THUMBS_UP" },
+					{ user: "postAuthor", content: "THUMBS_UP" },
 				],
 				"postAuthor",
 			);
@@ -242,26 +242,13 @@ describe("collectDocsFeedback", () => {
 		it("ignores reactions with an unrecognized content or bot users", () => {
 			const { votes, score } = scoreReactions(
 				[
-					{ user: "alice", content: "eyes" },
-					{ user: "some-bot[bot]", content: "+1" },
+					{ user: "alice", content: "EYES" },
+					{ user: "some-bot[bot]", content: "THUMBS_UP" },
 				],
 				"postAuthor",
 			);
 			expect(votes).toHaveLength(0);
 			expect(score).toBe(0);
-		});
-
-		it("understands both REST and GraphQL reaction content notations", () => {
-			const { votes: restVotes } = scoreReactions(
-				[{ user: "alice", content: "+1" }],
-				"postAuthor",
-			);
-			const { votes: graphqlVotes } = scoreReactions(
-				[{ user: "alice", content: "THUMBS_UP" }],
-				"postAuthor",
-			);
-			expect(restVotes).toHaveLength(1);
-			expect(graphqlVotes).toHaveLength(1);
 		});
 	});
 });

--- a/.github/bot-scripts/hideTransferredComments.cjs
+++ b/.github/bot-scripts/hideTransferredComments.cjs
@@ -1,0 +1,76 @@
+// @ts-check
+
+/// <reference path="types.d.ts" />
+
+const { lastTransferTime } = require("./utils.cjs");
+
+// Bot comments carry an HTML marker so they can be found again. The pattern
+// also matches the tags used in zwave-js-ui, which are not known here.
+const COMMENT_TAG_REGEX = /<!--\s*[A-Z0-9_]+_TAG\s*-->/;
+
+/**
+ * Collapses the bot comments an issue inherited from another repository.
+ * They were written for the repo the issue came from, so their advice is
+ * wrong here.
+ *
+ * @param {{github: Github, context: Context}} param
+ */
+async function main(param) {
+	const { github, context } = param;
+
+	if (!context.payload.issue) return;
+
+	const options = {
+		owner: context.repo.owner,
+		repo: context.repo.repo,
+	};
+	const issue_number = context.payload.issue.number;
+
+	const events = await github.paginate(
+		github.rest.issues.listEventsForTimeline,
+		{ ...options, issue_number, per_page: 100 },
+	);
+	const transferredAt = lastTransferTime(events);
+	if (!transferredAt) {
+		console.log("Issue was not transferred, nothing to hide");
+		return;
+	}
+
+	const comments = await github.paginate(github.rest.issues.listComments, {
+		...options,
+		issue_number,
+		per_page: 100,
+	});
+	// Transferred comments keep their original creation date
+	const inherited = comments.filter(
+		(c) =>
+			new Date(c.created_at).getTime() < transferredAt
+			&& c.user?.login === "zwave-js-bot"
+			&& COMMENT_TAG_REGEX.test(c.body ?? ""),
+	);
+	console.log(`Hiding ${inherited.length} inherited bot comment(s)`);
+
+	for (const comment of inherited) {
+		try {
+			await github.graphql(
+				`
+				mutation minimize($commentId: ID!) {
+					minimizeComment(input: {
+						subjectId: $commentId,
+						classifier: OUTDATED
+					}) {
+						minimizedComment { isMinimized }
+					}
+				}
+				`,
+				{ commentId: comment.node_id },
+			);
+			console.log(`Hid comment ${comment.html_url}`);
+		} catch (e) {
+			console.log(`Failed to hide comment ${comment.html_url}: ${e}`);
+		}
+	}
+}
+
+module.exports = main;
+module.exports.COMMENT_TAG_REGEX = COMMENT_TAG_REGEX;

--- a/.github/bot-scripts/index.cjs
+++ b/.github/bot-scripts/index.cjs
@@ -2,6 +2,8 @@ module.exports = {
 	checkAuthorized: (...args) => require("./checkAuthorized.cjs")(...args),
 	classifyIssueFeedback: (...args) =>
 		require("./classifyIssueFeedback.cjs")(...args),
+	hideTransferredComments: (...args) =>
+		require("./hideTransferredComments.cjs")(...args),
 	fixLintFeedback: (...args) => require("./fixLintFeedback.cjs")(...args),
 	getFixLintInfo: (...args) => require("./getFixLintInfo.cjs")(...args),
 	rebaseFeedback: (...args) => require("./rebaseFeedback.cjs")(...args),

--- a/.github/bot-scripts/utils.cjs
+++ b/.github/bot-scripts/utils.cjs
@@ -1,0 +1,65 @@
+// @ts-check
+
+/// <reference path="types.d.ts" />
+
+/**
+ * Returns when an issue was last transferred into this repository,
+ * or 0 if it was created here.
+ * @param {{event?: string, created_at?: string}[]} events - Timeline events
+ * @returns {number} Epoch milliseconds
+ */
+function lastTransferTime(events) {
+	let transferredAt = 0;
+	for (const event of events) {
+		if (event.event !== "transferred" || !event.created_at) continue;
+		// Issues may be transferred repeatedly, only the last hop matters
+		transferredAt = Math.max(
+			transferredAt,
+			new Date(event.created_at).getTime(),
+		);
+	}
+	return transferredAt;
+}
+
+/**
+ * Lists an issue's comments, ignoring those inherited from another repository.
+ * Transferring an issue recreates the source repo's comments here with their
+ * original creation date, so everything older than the last transfer was
+ * written elsewhere.
+ *
+ * @param {Github} github
+ * @param {string} owner
+ * @param {string} repo
+ * @param {number} issueNumber
+ */
+async function listCommentsSinceTransfer(github, owner, repo, issueNumber) {
+	const comments = await github.paginate(github.rest.issues.listComments, {
+		owner,
+		repo,
+		issue_number: issueNumber,
+		per_page: 100,
+	});
+	// Without comments there is nothing to filter, save the timeline request
+	if (comments.length === 0) return comments;
+
+	const events = await github.paginate(
+		github.rest.issues.listEventsForTimeline,
+		{
+			owner,
+			repo,
+			issue_number: issueNumber,
+			per_page: 100,
+		},
+	);
+	const transferredAt = lastTransferTime(events);
+	if (!transferredAt) return comments;
+
+	return comments.filter(
+		(c) => new Date(c.created_at).getTime() > transferredAt,
+	);
+}
+
+module.exports = {
+	lastTransferTime,
+	listCommentsSinceTransfer,
+};

--- a/.github/bot-scripts/utils.test.cjs
+++ b/.github/bot-scripts/utils.test.cjs
@@ -1,0 +1,27 @@
+// @ts-check
+
+import { describe, expect, it } from "vitest";
+import { lastTransferTime } from "./utils.cjs";
+
+describe("lastTransferTime", () => {
+	it("returns 0 when the issue was never transferred", () => {
+		expect(lastTransferTime([
+			{ event: "labeled", created_at: "2026-01-01T00:00:00Z" },
+			{ event: "committed" },
+		])).toBe(0);
+	});
+
+	it("returns the transfer timestamp", () => {
+		expect(lastTransferTime([
+			{ event: "labeled", created_at: "2026-01-01T00:00:00Z" },
+			{ event: "transferred", created_at: "2026-01-02T00:00:00Z" },
+		])).toBe(new Date("2026-01-02T00:00:00Z").getTime());
+	});
+
+	it("returns the newest of multiple transfers, regardless of order", () => {
+		expect(lastTransferTime([
+			{ event: "transferred", created_at: "2026-01-03T00:00:00Z" },
+			{ event: "transferred", created_at: "2026-01-02T00:00:00Z" },
+		])).toBe(new Date("2026-01-03T00:00:00Z").getTime());
+	});
+});

--- a/.github/workflows/zwave-js-bot_post.yml
+++ b/.github/workflows/zwave-js-bot_post.yml
@@ -67,6 +67,24 @@ jobs:
           const bot = require(`${process.env.GITHUB_WORKSPACE}/.github/bot-scripts/index.cjs`);
           return bot.classifyIssueFeedback({github, context}, aiResponse);
 
+  # Collapse the bot comments a transferred issue inherited from the repo
+  # it came from, they are about the wrong repository now
+  hide-transferred-comments:
+    runs-on: [ubuntu-latest]
+    if: github.event_name == 'issues' && github.event.action == 'opened'
+
+    steps:
+    - name: Checkout master branch
+      uses: actions/checkout@v7
+
+    - name: Hide inherited bot comments
+      uses: actions/github-script@v9
+      with:
+        github-token: ${{secrets.BOT_TOKEN}}
+        script: |
+          const bot = require(`${process.env.GITHUB_WORKSPACE}/.github/bot-scripts/index.cjs`);
+          await bot.hideTransferredComments({github, context});
+
   # Answer questions that are covered by the documentation and/or
   # suggest similar existing posts. Discussions are restricted to the
   # Q&A category by answerFromDocs.cjs itself. Excluding maintainers


### PR DESCRIPTION
Port of zwave-js/zwave-js#8982, for issues transferred the other way.

Transferring an issue recreates the source repo's comments in the destination with their original timestamps, and `zwave-js` runs a mirrored copy of these scripts that stamps the same marker tags. So the docs answer and the wrong-repo notice both considered themselves done and stayed silent, and nothing on a transferred comment identifies where it came from. The `transferred` timeline event is the one usable signal.

- New `utils.cjs` with `listCommentsSinceTransfer()`, which lists an issue's comments and drops everything older than the last transfer. `answerFromDocs` and `classifyIssueFeedback` use it instead of their own lookups.
- Bot comments inherited from the other repo are collapsed as outdated — they are about the wrong repository now.
- The nightly feedback digest no longer scores a foreign answer as one of ours, where reactions to it could suppress unrelated future answers.

Discussions keep the old behavior; they have no timeline API, so an inherited answer there still counts as answered.

Verified with unit tests plus a full 180-day digest run against the live repo, which produces identical records to the current code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)