### PR TITLE
feat(bot): compute embeddings locally instead of using GitHub Models

### DIFF
--- a/.github/actions/restore-bot-index/action.yml
+++ b/.github/actions/restore-bot-index/action.yml
@@ -65,8 +65,8 @@ runs:
       uses: actions/cache/restore@v6
       with:
         path: .docs-index
-        key: docs-embeddings-v2-${{ hashFiles('docs/**/*.md', '.github/bot-scripts/buildDocsIndex.cjs', '.github/bot-scripts/docsIndex.cjs', '.github/bot-scripts/modelsApi.cjs') }}
-        restore-keys: docs-embeddings-v2-
+        key: docs-embeddings-v3-${{ hashFiles('docs/**/*.md', '.github/bot-scripts/buildDocsIndex.cjs', '.github/bot-scripts/docsIndex.cjs', '.github/bot-scripts/localEmbeddings.cjs') }}
+        restore-keys: docs-embeddings-v3-
 
     - name: Restore the posts index from cache
       if: inputs.index == 'posts'
@@ -75,8 +75,8 @@ runs:
         path: .posts-index
         # There is no exact key to match, the newest index is picked
         # via the prefix
-        key: posts-embeddings-v1-
-        restore-keys: posts-embeddings-v1-
+        key: posts-embeddings-v2-
+        restore-keys: posts-embeddings-v2-
 
     # Decide on the file, not on the cache key: a prefix match can restore an
     # entry that was saved while its build was still writing it

--- a/.github/actions/restore-bot-index/action.yml
+++ b/.github/actions/restore-bot-index/action.yml
@@ -65,7 +65,7 @@ runs:
       uses: actions/cache/restore@v6
       with:
         path: .docs-index
-        key: docs-embeddings-v3-${{ hashFiles('docs/**/*.md', '.github/bot-scripts/buildDocsIndex.cjs', '.github/bot-scripts/docsIndex.cjs', '.github/bot-scripts/localEmbeddings.cjs') }}
+        key: docs-embeddings-v3-${{ hashFiles('docs/**/*.md', '.github/bot-scripts/buildDocsIndex.cjs', '.github/bot-scripts/docsIndex.cjs', '.github/bot-scripts/localEmbeddings.cjs', '.github/bot-scripts/package-lock.json') }}
         restore-keys: docs-embeddings-v3-
 
     - name: Restore the posts index from cache

--- a/.github/actions/setup-bot-embeddings/action.yml
+++ b/.github/actions/setup-bot-embeddings/action.yml
@@ -1,0 +1,75 @@
+name: Setup bot embeddings
+description: >-
+  Installs the bot-script dependencies and restores the local embedding
+  model, for jobs that embed text with localEmbeddings.cjs.
+
+# This action is the single owner of the model cache location and key -
+# the JS side reads the location from BOT_MODEL_CACHE_DIR set below, and
+# the key is derived from the model pin in localEmbeddings.cjs, so an
+# unrelated edit to that file does not evict the weights.
+
+inputs:
+  save-model-cache:
+    description: >-
+      Save the model cache after a miss. Only the nightly index builders
+      should do this - user-triggered jobs restore only, so a job that is
+      cut short cannot persist a partial download under an immutable key.
+    required: false
+    default: 'false'
+
+runs:
+  using: composite
+
+  steps:
+    - name: Setup Node.js
+      uses: actions/setup-node@v5
+      with:
+        node-version-file: .nvmrc
+        cache: 'npm'
+        cache-dependency-path: .github/bot-scripts/package-lock.json
+
+    # Cache node_modules itself: the ~350 MB onnxruntime extraction
+    # dominates npm ci, and setup-node's npm cache only covers the
+    # download side
+    - name: Restore dependencies
+      id: node-modules
+      uses: actions/cache@v6
+      with:
+        path: .github/bot-scripts/node_modules
+        key: bot-scripts-modules-${{ runner.os }}-${{ hashFiles('.github/bot-scripts/package-lock.json') }}
+
+    - name: Install dependencies
+      if: steps.node-modules.outputs.cache-hit != 'true'
+      shell: bash
+      working-directory: .github/bot-scripts
+      # --ignore-scripts skips onnxruntime-node's postinstall, which would
+      # download additional (GPU) execution providers - the CPU runtime
+      # ships inside the package itself
+      run: npm ci --ignore-scripts
+
+    - name: Resolve the model cache key
+      id: model
+      shell: bash
+      run: |
+        set -euo pipefail
+        key=$(node --print "require('./.github/bot-scripts/localEmbeddings.cjs').MODEL_CACHE_KEY")
+        echo "key=embedding-model-$key" >> "$GITHUB_OUTPUT"
+        echo "BOT_MODEL_CACHE_DIR=$HOME/.cache/zwave-js-ui-bot/models" >> "$GITHUB_ENV"
+
+    # The restore-keys prefix seeds the cache dir from an older entry on
+    # a near-miss; transformers.js re-downloads only what is missing
+    - name: Restore embedding model
+      if: inputs.save-model-cache != 'true'
+      uses: actions/cache/restore@v6
+      with:
+        path: ~/.cache/zwave-js-ui-bot/models
+        key: ${{ steps.model.outputs.key }}
+        restore-keys: embedding-model-
+
+    - name: Restore and save embedding model
+      if: inputs.save-model-cache == 'true'
+      uses: actions/cache@v6
+      with:
+        path: ~/.cache/zwave-js-ui-bot/models
+        key: ${{ steps.model.outputs.key }}
+        restore-keys: embedding-model-

--- a/.github/bot-scripts/answerFromDocs.cjs
+++ b/.github/bot-scripts/answerFromDocs.cjs
@@ -7,7 +7,8 @@ const { authorizedUsers } = require("./authorizedUsers.cjs");
 const { cosineSimilarity, loadDocsIndex, retrieve } = require(
 	"./docsIndex.cjs",
 );
-const { CHAT_MODEL, embed, modelsRequest } = require("./modelsApi.cjs");
+const { EMBEDDING_MODEL, embed } = require("./localEmbeddings.cjs");
+const { CHAT_MODEL, modelsRequest } = require("./modelsApi.cjs");
 const {
 	QUESTION_CATEGORY_SLUGS,
 	cleanQuestion,
@@ -32,14 +33,18 @@ const MAX_RETRIEVED_CHUNKS = 5;
 // If not even the best dense match reaches this cosine similarity,
 // the post is considered off-topic and no chat request is made.
 // The real relevance judgment is left to the chat model.
-const MIN_SIMILARITY = 0.2;
+// Calibrated for all-MiniLM-L6-v2: on-topic questions score >= 0.36
+// against the docs index, clearly off-topic ones <= 0.17
+const MIN_SIMILARITY = 0.35;
 // Confidence thresholds for the different response styles
 const ANSWER_CONFIDENCE = 75;
 const LINKS_CONFIDENCE = 40;
 
 // A related post is only suggested above this cosine similarity.
 // A wrong suggestion is worse than a missed one, so keep this high.
-const POSTS_MIN_SIMILARITY = 0.55;
+// Calibrated for all-MiniLM-L6-v2: confirmed-related posts score
+// 0.55-0.78 on the eval set, while unrelated ones reach up to 0.58
+const POSTS_MIN_SIMILARITY = 0.6;
 const MAX_RELATED_POSTS = 3;
 
 // Questions at least this similar to a previously downvoted answer
@@ -297,10 +302,15 @@ async function buildDocsAnswerSection(
 
 	// Ask the model whether the docs answer the question. judgeAnswer()
 	// already degrades malformed/invalid model content to a safe "no
-	// answer" result internally - a genuine Models API/network error
-	// (thrown by modelsRequest) is intentionally NOT caught here, so it
-	// fails the job instead of silently posting nothing.
-	const result = await judgeAnswer(question, ranked, token);
+	// answer" result internally. Skip the docs section on a genuine API
+	// error, the related-posts section is still useful.
+	let result;
+	try {
+		result = await judgeAnswer(question, ranked, token);
+	} catch (e) {
+		console.log(`Chat request failed: ${e.message}`);
+		return;
+	}
 	console.log("Model response:", JSON.stringify(result));
 
 	const related = (result.relatedExcerpts ?? [])
@@ -445,7 +455,8 @@ ${links}`;
  * documentation, and/or suggests similar existing posts, in a single comment.
  *
  * Expects the following environment variables:
- * - MODELS_TOKEN: token with models:read permission
+ * - MODELS_TOKEN: token with models:read permission, enables the docs
+ *   answer section. Without it, only related posts are suggested.
  * - DOCS_INDEX_PATH: path to the embeddings index created by buildDocsIndex.cjs
  * - POSTS_INDEX_PATH: path to the embeddings index created by buildPostsIndex.cjs
  *
@@ -455,10 +466,6 @@ async function main(param) {
 	const { github, context } = param;
 
 	const modelsToken = process.env.MODELS_TOKEN;
-	if (!modelsToken) {
-		console.log("No MODELS_TOKEN provided, skipping");
-		return;
-	}
 	// Figure out where the question comes from
 	const isDiscussion = !!context.payload.discussion;
 	const post = context.payload.discussion ?? context.payload.issue;
@@ -497,7 +504,7 @@ async function main(param) {
 	// Load the pre-built embeddings indices. Either may be missing,
 	// each one enables its part of the comment.
 	const docsIndexPath = process.env.DOCS_INDEX_PATH;
-	const docsIndex = await loadDocsIndex(docsIndexPath);
+	let docsIndex = await loadDocsIndex(docsIndexPath);
 	if (docsIndex) {
 		console.log(
 			`Loaded docs index with ${docsIndex.chunks.length} chunks (created ${docsIndex.createdAt})`,
@@ -517,26 +524,26 @@ async function main(param) {
 		);
 	}
 
-	if (!docsIndex && !postsIndex) return;
-
 	const question = cleanQuestion(post.title, post.body ?? "");
 
-	// A single embedding request serves both docs retrieval and
-	// related-post ranking. Similarities are only comparable within
-	// one model, so an index embedded with a different model is skipped.
-	const embeddingModel = docsIndex?.model ?? postsIndex?.model;
-	if (postsIndex && postsIndex.model !== embeddingModel) {
+	// The question is embedded locally. Similarities are only comparable
+	// within one model, so indexes built with a different model are skipped
+	// until the nightly rebuild replaces them.
+	if (docsIndex && docsIndex.model !== EMBEDDING_MODEL) {
 		console.log(
-			`Posts index model ${postsIndex.model} does not match ${embeddingModel}, ignoring it`,
+			`Docs index model ${docsIndex.model} does not match ${EMBEDDING_MODEL}, ignoring it`,
+		);
+		docsIndex = undefined;
+	}
+	if (postsIndex && postsIndex.model !== EMBEDDING_MODEL) {
+		console.log(
+			`Posts index model ${postsIndex.model} does not match ${EMBEDDING_MODEL}, ignoring it`,
 		);
 		postsIndex = undefined;
-		if (!docsIndex) return;
 	}
-	const [questionEmbedding] = await embed(
-		[question],
-		modelsToken,
-		embeddingModel,
-	);
+	if (!docsIndex && !postsIndex) return;
+
+	const [questionEmbedding] = await embed([question]);
 
 	// Feedback guardrail: check the question against previously
 	// downvoted answers collected by collectDocsFeedback.cjs
@@ -553,11 +560,12 @@ async function main(param) {
 		suppression = checkSuppression(
 			questionEmbedding,
 			feedback,
-			embeddingModel,
+			EMBEDDING_MODEL,
 		);
 	}
 
-	const docsSection = docsIndex && suppression !== "silent"
+	// The docs section needs the chat model as relevance judge
+	const docsSection = docsIndex && modelsToken && suppression !== "silent"
 		? await buildDocsAnswerSection(
 			question,
 			questionEmbedding,

--- a/.github/bot-scripts/answerFromDocs.cjs
+++ b/.github/bot-scripts/answerFromDocs.cjs
@@ -7,7 +7,9 @@ const { authorizedUsers } = require("./authorizedUsers.cjs");
 const { cosineSimilarity, loadDocsIndex, retrieve } = require(
 	"./docsIndex.cjs",
 );
-const { EMBEDDING_MODEL, embed } = require("./localEmbeddings.cjs");
+const { EMBEDDING_MODEL, embed, indexMatchesModel } = require(
+	"./localEmbeddings.cjs",
+);
 const { CHAT_MODEL, modelsRequest } = require("./modelsApi.cjs");
 const {
 	QUESTION_CATEGORY_SLUGS,
@@ -303,12 +305,15 @@ async function buildDocsAnswerSection(
 	// Ask the model whether the docs answer the question. judgeAnswer()
 	// already degrades malformed/invalid model content to a safe "no
 	// answer" result internally. Skip the docs section on a genuine API
-	// error, the related-posts section is still useful.
+	// error, the related-posts section is still useful - but annotate
+	// the run so the degradation is visible without reading the log.
 	let result;
 	try {
 		result = await judgeAnswer(question, ranked, token);
 	} catch (e) {
-		console.log(`Chat request failed: ${e.message}`);
+		console.log(
+			`::warning::Chat request failed, answering without a docs section: ${e.message}`,
+		);
 		return;
 	}
 	console.log("Model response:", JSON.stringify(result));
@@ -529,16 +534,10 @@ async function main(param) {
 	// The question is embedded locally. Similarities are only comparable
 	// within one model, so indexes built with a different model are skipped
 	// until the nightly rebuild replaces them.
-	if (docsIndex && docsIndex.model !== EMBEDDING_MODEL) {
-		console.log(
-			`Docs index model ${docsIndex.model} does not match ${EMBEDDING_MODEL}, ignoring it`,
-		);
+	if (docsIndex && !indexMatchesModel(docsIndex, "docs index")) {
 		docsIndex = undefined;
 	}
-	if (postsIndex && postsIndex.model !== EMBEDDING_MODEL) {
-		console.log(
-			`Posts index model ${postsIndex.model} does not match ${EMBEDDING_MODEL}, ignoring it`,
-		);
+	if (postsIndex && !indexMatchesModel(postsIndex, "posts index")) {
 		postsIndex = undefined;
 	}
 	if (!docsIndex && !postsIndex) return;
@@ -660,7 +659,10 @@ module.exports.alreadyAnswered = alreadyAnswered;
 module.exports.judgeAnswer = judgeAnswer;
 module.exports.validateJudgeResponse = validateJudgeResponse;
 module.exports.checkSuppression = checkSuppression;
+module.exports.buildRelatedPostsSection = buildRelatedPostsSection;
 module.exports.chunkUrl = chunkUrl;
+module.exports.MIN_SIMILARITY = MIN_SIMILARITY;
+module.exports.POSTS_MIN_SIMILARITY = POSTS_MIN_SIMILARITY;
 module.exports.DOCS_ANSWER_COMMENT_TAG = DOCS_ANSWER_COMMENT_TAG;
 module.exports.DOCS_ANSWER_METADATA_TAG = DOCS_ANSWER_METADATA_TAG;
 module.exports.DOCS_ANSWER_METADATA_VERSION = DOCS_ANSWER_METADATA_VERSION;

--- a/.github/bot-scripts/answerFromDocs.test.cjs
+++ b/.github/bot-scripts/answerFromDocs.test.cjs
@@ -5,6 +5,8 @@ import {
 	validateJudgeResponse,
 	checkSuppression,
 	alreadyAnswered,
+	buildRelatedPostsSection,
+	POSTS_MIN_SIMILARITY,
 	DOCS_ANSWER_COMMENT_TAG,
 } from "./answerFromDocs.cjs";
 
@@ -239,6 +241,36 @@ describe("answerFromDocs", () => {
 					false,
 				),
 			).toBe(true);
+		});
+	});
+
+	describe("buildRelatedPostsSection", () => {
+		/** @param {number} similarity Desired cosine against [1, 0] */
+		const post = (similarity, number) => ({
+			type: "issue",
+			number,
+			title: `Post ${number}`,
+			url: `https://example.com/${number}`,
+			state: "open",
+			// Unit vector at the desired cosine to the unit question vector
+			embedding: [
+				similarity,
+				Math.sqrt(1 - similarity ** 2),
+			],
+		});
+		const self = { type: "discussion", number: 999 };
+
+		it("suggests posts at the similarity floor", () => {
+			const index = { posts: [post(POSTS_MIN_SIMILARITY, 1)] };
+			const section = buildRelatedPostsSection(index, [1, 0], self);
+			expect(section).toContain("Post 1");
+		});
+
+		it("stays silent below the similarity floor", () => {
+			const index = { posts: [post(POSTS_MIN_SIMILARITY - 0.01, 1)] };
+			expect(
+				buildRelatedPostsSection(index, [1, 0], self),
+			).toBeUndefined();
 		});
 	});
 });

--- a/.github/bot-scripts/buildDocsIndex.cjs
+++ b/.github/bot-scripts/buildDocsIndex.cjs
@@ -13,12 +13,13 @@ const { EMBEDDING_MODEL, embedBatched } = require("./localEmbeddings.cjs");
 // Chunks shorter than this are unlikely to contain useful information
 const MIN_CHUNK_LENGTH = 50;
 // Sections longer than this are sub-split so nothing gets truncated away.
-// The model is trained on short passages and its reference implementation
-// caps input at 256 word pieces (the tokenizer itself accepts 512), so
-// chunks are sized for that budget - code tokenizes at ~2-3 chars/token
-const MAX_CHUNK_LENGTH = 700;
+// Sized empirically against the pipeline's real 512-token window: at
+// 1200 chars, p99 of the chunks measures ~440 tokens and only 0.6%
+// exceed the window slightly. That is past the model's 256-word-piece
+// training length, but retrieval quality holds (eval hit@5 18/18).
+const MAX_CHUNK_LENGTH = 1200;
 // Overlap between sub-splits so answers spanning a split boundary aren't lost
-const CHUNK_OVERLAP = 150;
+const CHUNK_OVERLAP = 200;
 
 /**
  * Removes HTML tags, repeating to avoid leaving partial tags behind

--- a/.github/bot-scripts/buildDocsIndex.cjs
+++ b/.github/bot-scripts/buildDocsIndex.cjs
@@ -1,22 +1,24 @@
 // @ts-check
 
 // Builds a semantic search index over the documentation by chunking all
-// markdown files and embedding the chunks using GitHub Models.
+// markdown files and embedding the chunks with a local model.
 // Usage: node buildDocsIndex.cjs <docs-dir> <output-file>
-// Requires GITHUB_TOKEN with models:read permission.
 
 const crypto = require("node:crypto");
 const fs = require("node:fs/promises");
 const path = require("node:path");
 const { DOCS_INDEX_VERSION } = require("./docsIndex.cjs");
-const { embedBatched, EMBEDDING_MODEL } = require("./modelsApi.cjs");
+const { EMBEDDING_MODEL, embedBatched } = require("./localEmbeddings.cjs");
 
 // Chunks shorter than this are unlikely to contain useful information
 const MIN_CHUNK_LENGTH = 50;
-// Sections longer than this are sub-split so nothing gets truncated away
-const MAX_CHUNK_LENGTH = 4000;
+// Sections longer than this are sub-split so nothing gets truncated away.
+// The embedding model truncates input at 256 tokens, and code blocks
+// tokenize at ~2-3 characters/token, so oversized chunks would lose
+// their tails to truncation
+const MAX_CHUNK_LENGTH = 700;
 // Overlap between sub-splits so answers spanning a split boundary aren't lost
-const CHUNK_OVERLAP = 400;
+const CHUNK_OVERLAP = 150;
 
 /**
  * Removes HTML tags, repeating to avoid leaving partial tags behind
@@ -184,12 +186,6 @@ async function main() {
 		);
 		process.exit(1);
 	}
-	const token = process.env.GITHUB_TOKEN;
-	if (!token) {
-		console.error("GITHUB_TOKEN environment variable is required");
-		process.exit(1);
-	}
-
 	// Reuse embeddings from a previous index for unchanged chunks
 	/** @type {Map<string, number[]>} */
 	const previousEmbeddings = new Map();
@@ -241,7 +237,6 @@ async function main() {
 
 	const embeddings = await embedBatched(
 		pending.map((c) => c.embeddedText),
-		token,
 	);
 	pending.forEach((chunk, i) => chunk.embedding = embeddings[i]);
 

--- a/.github/bot-scripts/buildDocsIndex.cjs
+++ b/.github/bot-scripts/buildDocsIndex.cjs
@@ -13,9 +13,9 @@ const { EMBEDDING_MODEL, embedBatched } = require("./localEmbeddings.cjs");
 // Chunks shorter than this are unlikely to contain useful information
 const MIN_CHUNK_LENGTH = 50;
 // Sections longer than this are sub-split so nothing gets truncated away.
-// The embedding model truncates input at 256 tokens, and code blocks
-// tokenize at ~2-3 characters/token, so oversized chunks would lose
-// their tails to truncation
+// The model is trained on short passages and its reference implementation
+// caps input at 256 word pieces (the tokenizer itself accepts 512), so
+// chunks are sized for that budget - code tokenizes at ~2-3 chars/token
 const MAX_CHUNK_LENGTH = 700;
 // Overlap between sub-splits so answers spanning a split boundary aren't lost
 const CHUNK_OVERLAP = 150;

--- a/.github/bot-scripts/buildDocsIndex.cjs
+++ b/.github/bot-scripts/buildDocsIndex.cjs
@@ -13,10 +13,10 @@ const { EMBEDDING_MODEL, embedBatched } = require("./localEmbeddings.cjs");
 // Chunks shorter than this are unlikely to contain useful information
 const MIN_CHUNK_LENGTH = 50;
 // Sections longer than this are sub-split so nothing gets truncated away.
-// Sized empirically against the pipeline's real 512-token window: at
-// 1200 chars, p99 of the chunks measures ~440 tokens and only 0.6%
-// exceed the window slightly. That is past the model's 256-word-piece
-// training length, but retrieval quality holds (eval hit@5 18/18).
+// Sized for the 512-token window the tokenizer enforces: at 1200 chars the
+// median chunk measures 132 tokens and 0.6% exceed the window. The 256 word
+// pieces on the model card are sentence-transformers' inference default,
+// which this ONNX port does not ship.
 const MAX_CHUNK_LENGTH = 1200;
 // Overlap between sub-splits so answers spanning a split boundary aren't lost
 const CHUNK_OVERLAP = 200;

--- a/.github/bot-scripts/buildPostsIndex.cjs
+++ b/.github/bot-scripts/buildPostsIndex.cjs
@@ -1,17 +1,17 @@
 // @ts-check
 
 // Builds a semantic search index over GitHub issues and discussions
-// by embedding their title + cleaned body using GitHub Models.
+// by embedding their title + cleaned body with a local model.
 // Indexed are open issues, issues closed within the last year, and all
 // discussions in the question categories.
 // Usage: node buildPostsIndex.cjs <owner/repo> <output-file>
-// Requires GITHUB_TOKEN with models:read permission and read access
-// to the repository's issues and discussions.
+// Requires GITHUB_TOKEN with read access to the repository's issues
+// and discussions.
 
 const fs = require("node:fs/promises");
 const path = require("node:path");
 const { ghGraphql, ghPaginated } = require("./githubApi.cjs");
-const { embedBatched, EMBEDDING_MODEL } = require("./modelsApi.cjs");
+const { EMBEDDING_MODEL, embedBatched } = require("./localEmbeddings.cjs");
 const {
 	POSTS_INDEX_VERSION,
 	QUESTION_CATEGORY_SLUGS,
@@ -204,7 +204,6 @@ async function main() {
 
 	const embeddings = await embedBatched(
 		pending.map((p) => p.embeddedText),
-		token,
 	);
 	pending.forEach((post, i) => post.embedding = embeddings[i]);
 

--- a/.github/bot-scripts/collectDocsFeedback.cjs
+++ b/.github/bot-scripts/collectDocsFeedback.cjs
@@ -21,7 +21,7 @@ const {
 	DOCS_BASE_URL,
 } = require("./answerFromDocs.cjs");
 const { ghGraphql } = require("./githubApi.cjs");
-const { embedBatched, EMBEDDING_MODEL } = require("./modelsApi.cjs");
+const { EMBEDDING_MODEL, embedBatched } = require("./localEmbeddings.cjs");
 const { cleanQuestion } = require("./postsIndex.cjs");
 const { authorizedUsers } = require("./authorizedUsers.cjs");
 
@@ -505,7 +505,7 @@ async function main() {
 		(r) => r.score <= SUPPRESS_SCORE && r.style !== "posts",
 	);
 	const embeddings = downvoted.length > 0
-		? await embedBatched(downvoted.map((r) => r.question), token)
+		? await embedBatched(downvoted.map((r) => r.question))
 		: [];
 	const suppressed = downvoted
 		.map((r, i) => ({

--- a/.github/bot-scripts/evalDocsAnswers.cjs
+++ b/.github/bot-scripts/evalDocsAnswers.cjs
@@ -6,18 +6,17 @@
 // changes to the chunking/retrieval logic.
 //
 // Usage: node evalDocsAnswers.cjs <index-file> [--answers]
-// Requires GITHUB_TOKEN in the environment.
 //
 // With --answers, each question is also run through the chat model and
 // the generated answer is printed for manual inspection. This costs one
-// chat request per question, so use sparingly.
+// chat request per question and requires GITHUB_TOKEN, so use sparingly.
 
 const fs = require("node:fs/promises");
 const path = require("node:path");
 const { judgeAnswer } = require("./answerFromDocs.cjs");
 const { loadDocsIndex, retrieve } = require("./docsIndex.cjs");
 const { logCase, reportResults } = require("./evalUtils.cjs");
-const { embed } = require("./modelsApi.cjs");
+const { EMBEDDING_MODEL, embed } = require("./localEmbeddings.cjs");
 
 const NUM_RESULTS = 5;
 // Allow a small number of misses before failing, retrieval is not exact
@@ -34,8 +33,8 @@ async function main() {
 		process.exit(1);
 	}
 	const token = process.env.GITHUB_TOKEN;
-	if (!token) {
-		console.error("GITHUB_TOKEN environment variable is required");
+	if (showAnswers && !token) {
+		console.error("GITHUB_TOKEN is required for --answers");
 		process.exit(1);
 	}
 
@@ -43,6 +42,12 @@ async function main() {
 	if (!index) {
 		console.error(
 			`No valid docs index found at ${indexFile} (missing, wrong version, or malformed)`,
+		);
+		process.exit(1);
+	}
+	if (index.model !== EMBEDDING_MODEL) {
+		console.error(
+			`Index was created with ${index.model}, but questions would be embedded with ${EMBEDDING_MODEL}`,
 		);
 		process.exit(1);
 	}
@@ -63,12 +68,7 @@ async function main() {
 		);
 	}
 
-	// A single batched request embeds all eval questions at once
-	const embeddings = await embed(
-		cases.map((c) => c.question),
-		token,
-		index.model,
-	);
+	const embeddings = await embed(cases.map((c) => c.question));
 
 	/** @type {import("./evalUtils.cjs").EvalResult[]} */
 	const failures = [];

--- a/.github/bot-scripts/evalDocsAnswers.cjs
+++ b/.github/bot-scripts/evalDocsAnswers.cjs
@@ -16,7 +16,7 @@ const path = require("node:path");
 const { judgeAnswer } = require("./answerFromDocs.cjs");
 const { loadDocsIndex, retrieve } = require("./docsIndex.cjs");
 const { logCase, reportResults } = require("./evalUtils.cjs");
-const { EMBEDDING_MODEL, embed } = require("./localEmbeddings.cjs");
+const { embed, indexMatchesModel } = require("./localEmbeddings.cjs");
 
 const NUM_RESULTS = 5;
 // Allow a small number of misses before failing, retrieval is not exact
@@ -45,12 +45,7 @@ async function main() {
 		);
 		process.exit(1);
 	}
-	if (index.model !== EMBEDDING_MODEL) {
-		console.error(
-			`Index was created with ${index.model}, but questions would be embedded with ${EMBEDDING_MODEL}`,
-		);
-		process.exit(1);
-	}
+	if (!indexMatchesModel(index, "docs index")) process.exit(1);
 	/** @type {{question: string, expectedFiles: string[]}[]} */
 	const cases = JSON.parse(
 		await fs.readFile(

--- a/.github/bot-scripts/evalRelatedPosts.cjs
+++ b/.github/bot-scripts/evalRelatedPosts.cjs
@@ -6,12 +6,11 @@
 // ranking logic or embedding model.
 //
 // Usage: node evalRelatedPosts.cjs <index-file>
-// Requires GITHUB_TOKEN in the environment.
 
 const fs = require("node:fs/promises");
 const path = require("node:path");
 const { logCase, reportResults } = require("./evalUtils.cjs");
-const { embed } = require("./modelsApi.cjs");
+const { EMBEDDING_MODEL, embed } = require("./localEmbeddings.cjs");
 const { rankRelatedPosts } = require("./postsIndex.cjs");
 
 const NUM_RESULTS = 5;
@@ -24,13 +23,13 @@ async function main() {
 		console.error("Usage: node evalRelatedPosts.cjs <index-file>");
 		process.exit(1);
 	}
-	const token = process.env.GITHUB_TOKEN;
-	if (!token) {
-		console.error("GITHUB_TOKEN environment variable is required");
+	const index = JSON.parse(await fs.readFile(indexFile, "utf8"));
+	if (index.model !== EMBEDDING_MODEL) {
+		console.error(
+			`Index was created with ${index.model}, but questions would be embedded with ${EMBEDDING_MODEL}`,
+		);
 		process.exit(1);
 	}
-
-	const index = JSON.parse(await fs.readFile(indexFile, "utf8"));
 	/** @type {{question: string, expectedPosts: {type: string, number: number}[]}[]} */
 	const allCases = JSON.parse(
 		await fs.readFile(
@@ -65,12 +64,7 @@ async function main() {
 		);
 	}
 
-	// A single batched request embeds all eval questions at once
-	const embeddings = await embed(
-		cases.map((c) => c.question),
-		token,
-		index.model,
-	);
+	const embeddings = await embed(cases.map((c) => c.question));
 
 	/** @type {import("./evalUtils.cjs").EvalResult[]} */
 	const failures = [];

--- a/.github/bot-scripts/evalRelatedPosts.cjs
+++ b/.github/bot-scripts/evalRelatedPosts.cjs
@@ -10,7 +10,7 @@
 const fs = require("node:fs/promises");
 const path = require("node:path");
 const { logCase, reportResults } = require("./evalUtils.cjs");
-const { EMBEDDING_MODEL, embed } = require("./localEmbeddings.cjs");
+const { embed, indexMatchesModel } = require("./localEmbeddings.cjs");
 const { rankRelatedPosts } = require("./postsIndex.cjs");
 
 const NUM_RESULTS = 5;
@@ -24,12 +24,7 @@ async function main() {
 		process.exit(1);
 	}
 	const index = JSON.parse(await fs.readFile(indexFile, "utf8"));
-	if (index.model !== EMBEDDING_MODEL) {
-		console.error(
-			`Index was created with ${index.model}, but questions would be embedded with ${EMBEDDING_MODEL}`,
-		);
-		process.exit(1);
-	}
+	if (!indexMatchesModel(index, "posts index")) process.exit(1);
 	/** @type {{question: string, expectedPosts: {type: string, number: number}[]}[]} */
 	const allCases = JSON.parse(
 		await fs.readFile(

--- a/.github/bot-scripts/localEmbeddings.cjs
+++ b/.github/bot-scripts/localEmbeddings.cjs
@@ -79,14 +79,24 @@ async function embed(inputs) {
 	if (inputs.length === 0) return [];
 	const extractor = await getExtractor();
 
+	// Each batch is padded to its longest member, so batch texts of
+	// similar length together and restore the input order afterwards
+	const order = inputs
+		.map((_, i) => i)
+		.sort((a, b) => inputs[a].length - inputs[b].length);
+
 	/** @type {number[][]} */
-	const results = [];
-	for (let i = 0; i < inputs.length; i += BATCH_SIZE) {
-		const batch = inputs.slice(i, i + BATCH_SIZE);
-		const output = await extractor(batch, {
-			pooling: "mean",
-			normalize: true,
-		});
+	const results = new Array(inputs.length);
+	let done = 0;
+	for (let i = 0; i < order.length; i += BATCH_SIZE) {
+		const batchOrder = order.slice(i, i + BATCH_SIZE);
+		const output = await extractor(
+			batchOrder.map((j) => inputs[j]),
+			{
+				pooling: "mean",
+				normalize: true,
+			},
+		);
 		// dims is [batch, hidden]; anything else means the pipeline
 		// changed shape, and flattening it blindly would push corrupted
 		// vectors into the index
@@ -95,11 +105,13 @@ async function embed(inputs) {
 				`Unexpected embedding tensor shape [${output.dims}]`,
 			);
 		}
-		results.push(...output.tolist());
+		const vectors = output.tolist();
+		batchOrder.forEach((j, k) => results[j] = vectors[k]);
+		done += batchOrder.length;
 		// Index builds run for minutes; leave evidence of progress in
 		// case the job hits its timeout
 		if (inputs.length > BATCH_SIZE) {
-			console.log(`Embedded ${results.length}/${inputs.length} texts`);
+			console.log(`Embedded ${done}/${inputs.length} texts`);
 		}
 	}
 	return results;

--- a/.github/bot-scripts/localEmbeddings.cjs
+++ b/.github/bot-scripts/localEmbeddings.cjs
@@ -11,6 +11,15 @@ const { join } = require("node:path");
 // quality stay comparable between the two bots
 const EMBEDDING_MODEL = "Xenova/all-MiniLM-L6-v2";
 const MODEL_REVISION = "751bff37182d3f1213fa05d7196b954e230abad9";
+// q8 quantization quarters the download and memory footprint; the
+// retrieval evals showed no quality loss against the full weights
+const MODEL_DTYPE = "q8";
+
+// CI cache key for the model weights: changes exactly when different
+// weights would be downloaded, so unrelated edits to this file don't
+// evict the cache. Consumed by .github/actions/setup-bot-embeddings.
+const MODEL_CACHE_KEY = `${EMBEDDING_MODEL}@${MODEL_REVISION}@${MODEL_DTYPE}`
+	.replaceAll("/", "_");
 
 // Process a bounded number of texts per pipeline call to limit peak memory
 const BATCH_SIZE = 32;
@@ -26,17 +35,38 @@ function defaultModelCacheDir() {
 /** @type {Promise<any> | undefined} */
 let extractorPromise;
 
+async function createExtractor() {
+	// The package is ESM-only, hence the dynamic import
+	const { pipeline } = await import("@huggingface/transformers");
+	// A cache miss downloads the weights from huggingface.co. Retry with
+	// backoff so a hiccup there does not fail a user-triggered run.
+	let lastError;
+	for (let attempt = 1; attempt <= 3; attempt++) {
+		try {
+			return await pipeline("feature-extraction", EMBEDDING_MODEL, {
+				cache_dir: process.env.BOT_MODEL_CACHE_DIR?.trim()
+					|| defaultModelCacheDir(),
+				revision: MODEL_REVISION,
+				dtype: MODEL_DTYPE,
+			});
+		} catch (e) {
+			lastError = e;
+			console.log(
+				`::warning::Loading the embedding model failed (attempt ${attempt}/3): ${e.message}`,
+			);
+			await new Promise((resolve) =>
+				setTimeout(resolve, attempt * 5000)
+			);
+		}
+	}
+	throw new Error(
+		`Could not load the embedding model ${EMBEDDING_MODEL}: ${lastError.message}`,
+		{ cause: lastError },
+	);
+}
+
 function getExtractor() {
-	extractorPromise ??= (async () => {
-		// The package is ESM-only, hence the dynamic import
-		const { pipeline } = await import("@huggingface/transformers");
-		return pipeline("feature-extraction", EMBEDDING_MODEL, {
-			cache_dir: process.env.BOT_MODEL_CACHE_DIR?.trim()
-				|| defaultModelCacheDir(),
-			revision: MODEL_REVISION,
-			dtype: "q8",
-		});
-	})();
+	extractorPromise ??= createExtractor();
 	return extractorPromise;
 }
 
@@ -57,8 +87,20 @@ async function embed(inputs) {
 			pooling: "mean",
 			normalize: true,
 		});
-		const data = output.tolist();
-		results.push(...(Array.isArray(data[0]) ? data : [data]));
+		// dims is [batch, hidden]; anything else means the pipeline
+		// changed shape, and flattening it blindly would push corrupted
+		// vectors into the index
+		if (output.dims?.length !== 2) {
+			throw new Error(
+				`Unexpected embedding tensor shape [${output.dims}]`,
+			);
+		}
+		results.push(...output.tolist());
+		// Index builds run for minutes; leave evidence of progress in
+		// case the job hits its timeout
+		if (inputs.length > BATCH_SIZE) {
+			console.log(`Embedded ${results.length}/${inputs.length} texts`);
+		}
 	}
 	return results;
 }
@@ -77,8 +119,27 @@ async function embedBatched(texts) {
 	);
 }
 
+/**
+ * Checks that an index was embedded with the pinned model, so its
+ * similarities are comparable to freshly embedded questions. Emits a
+ * workflow warning on mismatch, so a skipped index shows up in the run
+ * annotations instead of only in the log.
+ * @param {{model?: string} | undefined} index
+ * @param {string} description
+ */
+function indexMatchesModel(index, description) {
+	if (!index) return false;
+	if (index.model === EMBEDDING_MODEL) return true;
+	console.log(
+		`::warning::The ${description} was created with ${index.model}, not ${EMBEDDING_MODEL} - ignoring it until it is rebuilt`,
+	);
+	return false;
+}
+
 module.exports = {
 	embed,
 	embedBatched,
+	indexMatchesModel,
 	EMBEDDING_MODEL,
+	MODEL_CACHE_KEY,
 };

--- a/.github/bot-scripts/localEmbeddings.cjs
+++ b/.github/bot-scripts/localEmbeddings.cjs
@@ -1,0 +1,84 @@
+// @ts-check
+
+// Local embedding pipeline running on the CI runner, replacing the
+// retired GitHub Models embeddings API
+
+const { homedir } = require("node:os");
+const { join } = require("node:path");
+
+// Keep model, revision and dtype in sync with the zwave-js repository
+// (.github/bot-scripts/localEmbeddings.cjs there), so evals and answer
+// quality stay comparable between the two bots
+const EMBEDDING_MODEL = "Xenova/all-MiniLM-L6-v2";
+const MODEL_REVISION = "751bff37182d3f1213fa05d7196b954e230abad9";
+
+// Process a bounded number of texts per pipeline call to limit peak memory
+const BATCH_SIZE = 32;
+
+function defaultModelCacheDir() {
+	const xdg = process.env.XDG_CACHE_HOME;
+	const base = xdg && xdg.trim().length > 0
+		? xdg
+		: join(homedir(), ".cache");
+	return join(base, "zwave-js-ui-bot", "models");
+}
+
+/** @type {Promise<any> | undefined} */
+let extractorPromise;
+
+function getExtractor() {
+	extractorPromise ??= (async () => {
+		// The package is ESM-only, hence the dynamic import
+		const { pipeline } = await import("@huggingface/transformers");
+		return pipeline("feature-extraction", EMBEDDING_MODEL, {
+			cache_dir: process.env.BOT_MODEL_CACHE_DIR?.trim()
+				|| defaultModelCacheDir(),
+			revision: MODEL_REVISION,
+			dtype: "q8",
+		});
+	})();
+	return extractorPromise;
+}
+
+/**
+ * Embeds one or more texts, returning the embeddings in input order
+ * @param {string[]} inputs
+ * @returns {Promise<number[][]>}
+ */
+async function embed(inputs) {
+	if (inputs.length === 0) return [];
+	const extractor = await getExtractor();
+
+	/** @type {number[][]} */
+	const results = [];
+	for (let i = 0; i < inputs.length; i += BATCH_SIZE) {
+		const batch = inputs.slice(i, i + BATCH_SIZE);
+		const output = await extractor(batch, {
+			pooling: "mean",
+			normalize: true,
+		});
+		const data = output.tolist();
+		results.push(...(Array.isArray(data[0]) ? data : [data]));
+	}
+	return results;
+}
+
+/**
+ * Embeds texts destined for an index
+ * @param {string[]} texts
+ * @returns {Promise<number[][]>} Embeddings in input order
+ */
+async function embedBatched(texts) {
+	console.log(`Embedding ${texts.length} texts locally...`);
+	const embeddings = await embed(texts);
+	// Round to reduce index size, this has no measurable impact on similarity
+	return embeddings.map((embedding) =>
+		embedding.map((x) => Math.round(x * 1e5) / 1e5)
+	);
+}
+
+module.exports = {
+	embed,
+	embedBatched,
+	EMBEDDING_MODEL,
+};

--- a/.github/bot-scripts/localEmbeddings.test.cjs
+++ b/.github/bot-scripts/localEmbeddings.test.cjs
@@ -52,6 +52,12 @@ describe("localEmbeddings", () => {
 		]);
 	});
 
+	it("restores input order after length-sorted batching", async () => {
+		const result = await embed(["xxx", "x", "xx"]);
+		expect(result.map((v) => v[0])).toEqual([3, 1, 2]);
+		expect(extractorCalls.pop()).toEqual(["x", "xx", "xxx"]);
+	});
+
 	it("rejects unexpected tensor shapes instead of guessing", async () => {
 		await expect(embed(["bad-shape"])).rejects.toThrow(
 			/Unexpected embedding tensor shape/,

--- a/.github/bot-scripts/localEmbeddings.test.cjs
+++ b/.github/bot-scripts/localEmbeddings.test.cjs
@@ -1,0 +1,65 @@
+// @ts-check
+
+import { describe, expect, it, vi } from "vitest";
+
+/** @type {string[][]} */
+const extractorCalls = [];
+
+vi.mock("@huggingface/transformers", () => ({
+	pipeline: vi.fn(async () => async (/** @type {string[]} */ batch) => {
+		extractorCalls.push([...batch]);
+		if (batch.includes("bad-shape")) {
+			return { dims: [1, batch.length, 3], tolist: () => [] };
+		}
+		return {
+			dims: [batch.length, 3],
+			// Encode the input length so tests can verify ordering across
+			// batches, plus an unrounded component for the rounding test
+			tolist: () =>
+				batch.map((text, i) => [text.length, i + 0.123456789, 0]),
+		};
+	}),
+}));
+
+import { embed, embedBatched } from "./localEmbeddings.cjs";
+
+describe("localEmbeddings", () => {
+	it("returns an empty result for empty input without touching the pipeline", async () => {
+		expect(await embed([])).toEqual([]);
+		expect(extractorCalls.length).toBe(0);
+	});
+
+	it("embeds a single input as one 2D batch", async () => {
+		const result = await embed(["ab"]);
+		expect(result).toEqual([[2, 0.123456789, 0]]);
+		expect(extractorCalls.pop()).toEqual(["ab"]);
+	});
+
+	it("splits input at the batch size and preserves input order", async () => {
+		const inputs = Array.from(
+			{ length: 33 },
+			(_, i) => "x".repeat(i + 1),
+		);
+		const result = await embed(inputs);
+		expect(result.length).toBe(33);
+		// The first vector component is the input length
+		expect(result.map((v) => v[0])).toEqual(
+			inputs.map((text) => text.length),
+		);
+		expect(extractorCalls.splice(0).map((b) => b.length)).toEqual([
+			32,
+			1,
+		]);
+	});
+
+	it("rejects unexpected tensor shapes instead of guessing", async () => {
+		await expect(embed(["bad-shape"])).rejects.toThrow(
+			/Unexpected embedding tensor shape/,
+		);
+	});
+
+	it("rounds index embeddings to 5 decimals", async () => {
+		const [vector] = await embedBatched(["ab"]);
+		expect(vector).toEqual([2, 0.12346, 0]);
+	});
+});

--- a/.github/bot-scripts/modelsApi.cjs
+++ b/.github/bot-scripts/modelsApi.cjs
@@ -3,22 +3,9 @@
 // Shared helpers for calling the GitHub Models API
 
 const API_BASE = "https://models.github.ai/inference";
-const EMBEDDING_MODEL = process.env.EMBEDDING_MODEL
-	|| "openai/text-embedding-3-small";
 const CHAT_MODEL = process.env.CHAT_MODEL || "openai/gpt-4o";
 
 const MAX_RETRIES = 5;
-
-// Stay well below the 64K tokens/request limit for embedding requests
-const MAX_BATCH_TOKENS = 40_000;
-const MAX_BATCH_INPUTS = 128;
-// The free tier allows 15 requests/minute
-const THROTTLE_MS = 4500;
-
-/** @param {string} str */
-function estimateTokens(str) {
-	return Math.ceil(str.length / 4);
-}
 
 /**
  * Performs a request against the Models API, retrying with backoff
@@ -62,72 +49,7 @@ async function modelsRequest(path, body, token) {
 	}
 }
 
-/**
- * Embeds one or more texts, returning the embeddings in input order
- * @param {string[]} inputs
- * @param {string} token
- * @param {string} [model]
- * @returns {Promise<number[][]>}
- */
-async function embed(inputs, token, model = EMBEDDING_MODEL) {
-	const result = await modelsRequest("/embeddings", {
-		model,
-		input: inputs,
-	}, token);
-	return result.data
-		.sort((/** @type {any} */ a, /** @type {any} */ b) => a.index - b.index)
-		.map((/** @type {any} */ d) => d.embedding);
-}
-
-/**
- * Embeds texts destined for an index, batching them within the
- * per-request limits and throttling between requests.
- * @param {string[]} texts
- * @param {string} token
- * @param {string} [model]
- * @returns {Promise<number[][]>} Embeddings in input order
- */
-async function embedBatched(texts, token, model = EMBEDDING_MODEL) {
-	/** @type {number[][]} */
-	const results = [];
-	let cursor = 0;
-	let requestCount = 0;
-	while (cursor < texts.length) {
-		const batch = [];
-		let batchTokens = 0;
-		while (cursor < texts.length && batch.length < MAX_BATCH_INPUTS) {
-			const tokens = estimateTokens(texts[cursor]);
-			if (batch.length > 0 && batchTokens + tokens > MAX_BATCH_TOKENS) {
-				break;
-			}
-			batch.push(texts[cursor]);
-			batchTokens += tokens;
-			cursor++;
-		}
-
-		if (requestCount > 0) {
-			await new Promise((resolve) => setTimeout(resolve, THROTTLE_MS));
-		}
-		console.log(
-			`Embedding batch of ${batch.length} texts (~${batchTokens} tokens)...`,
-		);
-		const embeddings = await embed(batch, token, model);
-		requestCount++;
-		results.push(
-			// Round to reduce index size, this has no measurable impact on similarity
-			...embeddings.map((embedding) =>
-				embedding.map((x) => Math.round(x * 1e5) / 1e5)
-			),
-		);
-	}
-	console.log(`Done, used ${requestCount} embedding requests`);
-	return results;
-}
-
 module.exports = {
 	modelsRequest,
-	embed,
-	embedBatched,
-	EMBEDDING_MODEL,
 	CHAT_MODEL,
 };

--- a/.github/bot-scripts/package-lock.json
+++ b/.github/bot-scripts/package-lock.json
@@ -1,0 +1,1030 @@
+{
+  "name": "zwave-js-ui-bot-scripts",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "zwave-js-ui-bot-scripts",
+      "dependencies": {
+        "@huggingface/transformers": "^4.2.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.3.tgz",
+      "integrity": "sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@huggingface/jinja": {
+      "version": "0.5.9",
+      "resolved": "https://registry.npmjs.org/@huggingface/jinja/-/jinja-0.5.9.tgz",
+      "integrity": "sha512-uWTG+l3VJRsl7EXxYizuL3P+cCPoc3cRqbWWRcQN0FhejRfbdq0RNhCmbY/YDtnTcz9icdLYuLDjsnz4d8JMuw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@huggingface/tokenizers": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@huggingface/tokenizers/-/tokenizers-0.1.3.tgz",
+      "integrity": "sha512-8rF/RRT10u+kn7YuUbUg0OF30K8rjTc78aHpxT+qJ1uWSqxT1MHi8+9ltwYfkFYJzT/oS+qw3JVfHtNMGAdqyA==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@huggingface/transformers": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@huggingface/transformers/-/transformers-4.2.0.tgz",
+      "integrity": "sha512-8BRCoBMH0XsWaEIamuR0LrJGAfftgHAfb2Vrffy0VKlSAE/MnUJ5/h/zTfEP3fDIft+nk7TqB8xXEyABGitBjQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@huggingface/jinja": "^0.5.6",
+        "@huggingface/tokenizers": "^0.1.3",
+        "onnxruntime-node": "1.24.3",
+        "onnxruntime-web": "1.26.0-dev.20260416-b7804b056c",
+        "sharp": "^0.34.5"
+      }
+    },
+    "node_modules/@img/colour": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
+      "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@img/sharp-darwin-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.5.tgz",
+      "integrity": "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-darwin-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.5.tgz",
+      "integrity": "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.4.tgz",
+      "integrity": "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz",
+      "integrity": "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.4.tgz",
+      "integrity": "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==",
+      "cpu": [
+        "arm"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.4.tgz",
+      "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-ppc64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.2.4.tgz",
+      "integrity": "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-riscv64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.2.4.tgz",
+      "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-s390x": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.2.4.tgz",
+      "integrity": "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz",
+      "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.4.tgz",
+      "integrity": "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz",
+      "integrity": "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.5.tgz",
+      "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
+      "cpu": [
+        "arm"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.5.tgz",
+      "integrity": "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-ppc64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.34.5.tgz",
+      "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-ppc64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-riscv64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.34.5.tgz",
+      "integrity": "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-riscv64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-s390x": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.5.tgz",
+      "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
+      "cpu": [
+        "s390x"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-s390x": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz",
+      "integrity": "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.5.tgz",
+      "integrity": "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.5.tgz",
+      "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-wasm32": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.34.5.tgz",
+      "integrity": "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==",
+      "cpu": [
+        "wasm32"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/runtime": "^1.7.0"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.5.tgz",
+      "integrity": "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-ia32": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.5.tgz",
+      "integrity": "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz",
+      "integrity": "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/codegen": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
+      "integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/eventemitter": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz",
+      "integrity": "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/fetch": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.1.tgz",
+      "integrity": "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.1"
+      }
+    },
+    "node_modules/@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/utf8": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.2.tgz",
+      "integrity": "sha512-b1UQwcEZ4yCnMCD8DAL1VlbvBJE9/IX4FTIp7BG1xYpf29SLazLSrqUkj4w7Y5y7cCVP6E5tcqqcI0xemPkHug==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@types/node": {
+      "version": "26.1.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.2.tgz",
+      "integrity": "sha512-Vu4a5UFA9rIIFJ7rB/Vaafh9lrCQszopTCx6KjFboXTGQbPNasehVR5TEiithSDGyd1DEiUByggTZsg8jukeIg==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~8.3.0"
+      }
+    },
+    "node_modules/adm-zip": {
+      "version": "0.5.18",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.18.tgz",
+      "integrity": "sha512-ufJnssQGbxzLNS1Ho9bCtX4rQKCCvoVuDLHoJyc3F9dOGDB4BkWs2Ci0kv53lqocAEQ/Cbi+I2XCsNYGqVYqng==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0"
+      }
+    },
+    "node_modules/boolean": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/boolean/-/boolean-3.2.0.tgz",
+      "integrity": "sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw==",
+      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
+      "license": "MIT"
+    },
+    "node_modules/define-data-property": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+      "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/define-properties": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
+      "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.0.1",
+        "has-property-descriptors": "^1.0.0",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/detect-node": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.1.0.tgz",
+      "integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==",
+      "license": "MIT"
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es6-error": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz",
+      "integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==",
+      "license": "MIT"
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/flatbuffers": {
+      "version": "25.9.23",
+      "resolved": "https://registry.npmjs.org/flatbuffers/-/flatbuffers-25.9.23.tgz",
+      "integrity": "sha512-MI1qs7Lo4Syw0EOzUl0xjs2lsoeqFku44KpngfIduHBYvzm8h2+7K8YMQh1JtVVVrUvhLpNwqVi4DERegUJhPQ==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/global-agent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/global-agent/-/global-agent-3.0.0.tgz",
+      "integrity": "sha512-PT6XReJ+D07JvGoxQMkT6qji/jVNfX/h364XHZOWeRzy64sSFr+xJ5OX7LI3b4MPQzdL4H8Y8M0xzPpsVMwA8Q==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "boolean": "^3.0.1",
+        "es6-error": "^4.1.1",
+        "matcher": "^3.0.0",
+        "roarr": "^2.15.3",
+        "semver": "^7.3.2",
+        "serialize-error": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=10.0"
+      }
+    },
+    "node_modules/globalthis": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.4.tgz",
+      "integrity": "sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==",
+      "license": "MIT",
+      "dependencies": {
+        "define-properties": "^1.2.1",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/guid-typescript": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/guid-typescript/-/guid-typescript-1.0.9.tgz",
+      "integrity": "sha512-Y8T4vYhEfwJOTbouREvG+3XDsjr8E3kIr7uf+JZ0BYloFsttiHU0WfvANVsR7TxNUJa/WpCnw/Ino/p+DeBhBQ==",
+      "license": "ISC"
+    },
+    "node_modules/has-property-descriptors": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+      "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
+      "license": "ISC"
+    },
+    "node_modules/long": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/matcher": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/matcher/-/matcher-3.0.0.tgz",
+      "integrity": "sha512-OkeDaAZ/bQCxeFAozM55PKcKU0yJMPGifLwV4Qgjitu+5MoAfSQN4lsLJeXZ1b8w0x+/Emda6MZgXS1jvsapng==",
+      "license": "MIT",
+      "dependencies": {
+        "escape-string-regexp": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/object-keys": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/onnxruntime-common": {
+      "version": "1.24.3",
+      "resolved": "https://registry.npmjs.org/onnxruntime-common/-/onnxruntime-common-1.24.3.tgz",
+      "integrity": "sha512-GeuPZO6U/LBJXvwdaqHbuUmoXiEdeCjWi/EG7Y1HNnDwJYuk6WUbNXpF6luSUY8yASul3cmUlLGrCCL1ZgVXqA==",
+      "license": "MIT"
+    },
+    "node_modules/onnxruntime-node": {
+      "version": "1.24.3",
+      "resolved": "https://registry.npmjs.org/onnxruntime-node/-/onnxruntime-node-1.24.3.tgz",
+      "integrity": "sha512-JH7+czbc8ALA819vlTgcV+Q214/+VjGeBHDjX81+ZCD0PCVCIFGFNtT0V4sXG/1JXypKPgScQcB3ij/hk3YnTg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "os": [
+        "win32",
+        "darwin",
+        "linux"
+      ],
+      "dependencies": {
+        "adm-zip": "^0.5.16",
+        "global-agent": "^3.0.0",
+        "onnxruntime-common": "1.24.3"
+      }
+    },
+    "node_modules/onnxruntime-web": {
+      "version": "1.26.0-dev.20260416-b7804b056c",
+      "resolved": "https://registry.npmjs.org/onnxruntime-web/-/onnxruntime-web-1.26.0-dev.20260416-b7804b056c.tgz",
+      "integrity": "sha512-MD6Ss4GSpQBo6zqoJzyT9LRbKYs7x/JVN23FT24EcEvlqF4VuzPOeH6X38orZPKHQDbprn7K+SBpu0/mj2CQiw==",
+      "license": "MIT",
+      "dependencies": {
+        "flatbuffers": "^25.1.24",
+        "guid-typescript": "^1.0.9",
+        "long": "^5.2.3",
+        "onnxruntime-common": "1.24.0-dev.20251116-b39e144322",
+        "platform": "^1.3.6",
+        "protobufjs": "^7.2.4"
+      }
+    },
+    "node_modules/onnxruntime-web/node_modules/onnxruntime-common": {
+      "version": "1.24.0-dev.20251116-b39e144322",
+      "resolved": "https://registry.npmjs.org/onnxruntime-common/-/onnxruntime-common-1.24.0-dev.20251116-b39e144322.tgz",
+      "integrity": "sha512-BOoomdHYmNRL5r4iQ4bMvsl2t0/hzVQ3OM3PHD0gxeXu1PmggqBv3puZicEUVOA3AtHHYmqZtjMj9FOfGrATTw==",
+      "license": "MIT"
+    },
+    "node_modules/platform": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/platform/-/platform-1.3.6.tgz",
+      "integrity": "sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg==",
+      "license": "MIT"
+    },
+    "node_modules/protobufjs": {
+      "version": "7.6.5",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.5.tgz",
+      "integrity": "sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw==",
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.5",
+        "@protobufjs/eventemitter": "^1.1.1",
+        "@protobufjs/fetch": "^1.1.1",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.1",
+        "@types/node": ">=13.7.0",
+        "long": "^5.3.2"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/roarr": {
+      "version": "2.15.4",
+      "resolved": "https://registry.npmjs.org/roarr/-/roarr-2.15.4.tgz",
+      "integrity": "sha512-CHhPh+UNHD2GTXNYhPWLnU8ONHdI+5DI+4EYIAOaiD63rHeYlZvyh8P+in5999TTSFgUYuKUAjzRI4mdh/p+2A==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "boolean": "^3.0.1",
+        "detect-node": "^2.0.4",
+        "globalthis": "^1.0.1",
+        "json-stringify-safe": "^5.0.1",
+        "semver-compare": "^1.0.0",
+        "sprintf-js": "^1.1.2"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/semver-compare": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
+      "integrity": "sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow==",
+      "license": "MIT"
+    },
+    "node_modules/serialize-error": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-7.0.1.tgz",
+      "integrity": "sha512-8I8TjW5KMOKsZQTvoxjuSIa7foAwPWGOts+6o7sgjz41/qMD9VQHEDxi6PBvK2l0MXUmqZyNpUK+T2tQaaElvw==",
+      "license": "MIT",
+      "dependencies": {
+        "type-fest": "^0.13.1"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/sharp": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
+      "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@img/colour": "^1.0.0",
+        "detect-libc": "^2.1.2",
+        "semver": "^7.7.3"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-darwin-arm64": "0.34.5",
+        "@img/sharp-darwin-x64": "0.34.5",
+        "@img/sharp-libvips-darwin-arm64": "1.2.4",
+        "@img/sharp-libvips-darwin-x64": "1.2.4",
+        "@img/sharp-libvips-linux-arm": "1.2.4",
+        "@img/sharp-libvips-linux-arm64": "1.2.4",
+        "@img/sharp-libvips-linux-ppc64": "1.2.4",
+        "@img/sharp-libvips-linux-riscv64": "1.2.4",
+        "@img/sharp-libvips-linux-s390x": "1.2.4",
+        "@img/sharp-libvips-linux-x64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4",
+        "@img/sharp-linux-arm": "0.34.5",
+        "@img/sharp-linux-arm64": "0.34.5",
+        "@img/sharp-linux-ppc64": "0.34.5",
+        "@img/sharp-linux-riscv64": "0.34.5",
+        "@img/sharp-linux-s390x": "0.34.5",
+        "@img/sharp-linux-x64": "0.34.5",
+        "@img/sharp-linuxmusl-arm64": "0.34.5",
+        "@img/sharp-linuxmusl-x64": "0.34.5",
+        "@img/sharp-wasm32": "0.34.5",
+        "@img/sharp-win32-arm64": "0.34.5",
+        "@img/sharp-win32-ia32": "0.34.5",
+        "@img/sharp-win32-x64": "0.34.5"
+      }
+    },
+    "node_modules/sprintf-js": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
+      "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD",
+      "optional": true
+    },
+    "node_modules/type-fest": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.13.1.tgz",
+      "integrity": "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==",
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
+      "license": "MIT"
+    }
+  }
+}

--- a/.github/bot-scripts/package.json
+++ b/.github/bot-scripts/package.json
@@ -1,6 +1,9 @@
 {
   "name": "zwave-js-ui-bot-scripts",
   "private": true,
+  "engines": {
+    "node": ">=22"
+  },
   "description": "Runtime dependencies for the bot scripts, installed separately (npm ci --ignore-scripts in this directory) so the bot jobs don't pay for a full application install",
   "dependencies": {
     "@huggingface/transformers": "^4.2.0"

--- a/.github/bot-scripts/package.json
+++ b/.github/bot-scripts/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "zwave-js-ui-bot-scripts",
+  "private": true,
+  "description": "Runtime dependencies for the bot scripts, installed separately (npm ci --ignore-scripts in this directory) so the bot jobs don't pay for a full application install",
+  "dependencies": {
+    "@huggingface/transformers": "^4.2.0"
+  }
+}

--- a/.github/bot-scripts/postsIndex.cjs
+++ b/.github/bot-scripts/postsIndex.cjs
@@ -27,14 +27,20 @@ const MAX_QUESTION_LENGTH = 6000;
  * @param {string} body
  */
 function cleanQuestion(title, body) {
-	// Template instructions are hidden in HTML comments.
-	// Replacements can create new comment sequences, repeat until stable.
+	// Template instructions are hidden in HTML comments. Strip them with
+	// an index scan, a regex would backtrack polynomially on crafted input
 	let text = body;
-	let previous;
-	do {
-		previous = text;
-		text = text.replace(/<!--[\s\S]*?-->/g, "");
-	} while (text !== previous);
+	let searchFrom = 0;
+	for (;;) {
+		const start = text.indexOf("<!--", searchFrom);
+		if (start === -1) break;
+		const end = text.indexOf("-->", start + 4);
+		if (end === -1) break;
+		text = text.slice(0, start) + text.slice(end + 3);
+		// Removing a comment can splice the surrounding text into a new
+		// comment opener, re-check just before the removal point
+		searchFrom = Math.max(0, start - 3);
+	}
 
 	text = text
 		// Checked/unchecked checklist items carry no information

--- a/.github/bot-scripts/postsIndex.cjs
+++ b/.github/bot-scripts/postsIndex.cjs
@@ -27,20 +27,21 @@ const MAX_QUESTION_LENGTH = 6000;
  * @param {string} body
  */
 function cleanQuestion(title, body) {
-	// Template instructions are hidden in HTML comments. Strip them with
-	// an index scan, a regex would backtrack polynomially on crafted input
-	let text = body;
-	let searchFrom = 0;
+	// Template instructions are hidden in HTML comments. Strip them in a
+	// single left-to-right pass - this matches the semantics of a lazy
+	// /<!--[\s\S]*?-->/g regex (spliced-together text is not re-scanned)
+	// without its polynomial backtracking on crafted input
+	let text = "";
+	let cursor = 0;
 	for (;;) {
-		const start = text.indexOf("<!--", searchFrom);
+		const start = body.indexOf("<!--", cursor);
 		if (start === -1) break;
-		const end = text.indexOf("-->", start + 4);
+		const end = body.indexOf("-->", start + 4);
 		if (end === -1) break;
-		text = text.slice(0, start) + text.slice(end + 3);
-		// Removing a comment can splice the surrounding text into a new
-		// comment opener, re-check just before the removal point
-		searchFrom = Math.max(0, start - 3);
+		text += body.slice(cursor, start);
+		cursor = end + 3;
 	}
+	text += body.slice(cursor);
 
 	text = text
 		// Checked/unchecked checklist items carry no information

--- a/.github/bot-scripts/updatePostsIndex.cjs
+++ b/.github/bot-scripts/updatePostsIndex.cjs
@@ -7,7 +7,7 @@
 // for questions arriving before the next nightly rebuild.
 
 const fs = require("node:fs/promises");
-const { embedBatched } = require("./modelsApi.cjs");
+const { EMBEDDING_MODEL, embedBatched } = require("./localEmbeddings.cjs");
 const {
 	QUESTION_CATEGORY_SLUGS,
 	cleanQuestion,
@@ -17,7 +17,6 @@ const {
 
 /**
  * Expects the following environment variables:
- * - MODELS_TOKEN: token with models:read permission
  * - POSTS_INDEX_PATH: path to the index created by buildPostsIndex.cjs
  *
  * @param {{github: Github, context: Context}} param
@@ -25,12 +24,6 @@ const {
  */
 async function main(param) {
 	const { context } = param;
-
-	const modelsToken = process.env.MODELS_TOKEN;
-	if (!modelsToken) {
-		console.log("No MODELS_TOKEN provided, skipping");
-		return false;
-	}
 
 	const isDiscussion = !!context.payload.discussion;
 	const post = context.payload.discussion ?? context.payload.issue;
@@ -59,6 +52,14 @@ async function main(param) {
 		console.log(`No posts index found at ${indexPath}, skipping`);
 		return false;
 	}
+	// Embeddings from different models are not comparable. The nightly
+	// rebuild reconciles indexes created with an older model.
+	if (index.model !== EMBEDDING_MODEL) {
+		console.log(
+			`Posts index was created with ${index.model}, skipping`,
+		);
+		return false;
+	}
 
 	const embeddedText = cleanQuestion(post.title, post.body ?? "");
 	const hash = hashPost(embeddedText);
@@ -72,11 +73,7 @@ async function main(param) {
 		return false;
 	}
 
-	const [embedding] = await embedBatched(
-		[embeddedText],
-		modelsToken,
-		index.model,
-	);
+	const [embedding] = await embedBatched([embeddedText]);
 	/** @type {import("./postsIndex.cjs").IndexedPost} */
 	const entry = {
 		type,

--- a/.github/bot-scripts/updatePostsIndex.cjs
+++ b/.github/bot-scripts/updatePostsIndex.cjs
@@ -7,7 +7,7 @@
 // for questions arriving before the next nightly rebuild.
 
 const fs = require("node:fs/promises");
-const { EMBEDDING_MODEL, embedBatched } = require("./localEmbeddings.cjs");
+const { embedBatched, indexMatchesModel } = require("./localEmbeddings.cjs");
 const {
 	QUESTION_CATEGORY_SLUGS,
 	cleanQuestion,
@@ -54,12 +54,7 @@ async function main(param) {
 	}
 	// Embeddings from different models are not comparable. The nightly
 	// rebuild reconciles indexes created with an older model.
-	if (index.model !== EMBEDDING_MODEL) {
-		console.log(
-			`Posts index was created with ${index.model}, skipping`,
-		);
-		return false;
-	}
+	if (!indexMatchesModel(index, "posts index")) return false;
 
 	const embeddedText = cleanQuestion(post.title, post.body ?? "");
 	const hash = hashPost(embeddedText);

--- a/.github/workflows/docs-embeddings.yml
+++ b/.github/workflows/docs-embeddings.yml
@@ -43,30 +43,16 @@ jobs:
       uses: actions/cache@v6
       with:
         path: .docs-index
-        key: docs-embeddings-v3-${{ hashFiles('docs/**/*.md', '.github/bot-scripts/buildDocsIndex.cjs', '.github/bot-scripts/docsIndex.cjs', '.github/bot-scripts/localEmbeddings.cjs') }}
+        key: docs-embeddings-v3-${{ hashFiles('docs/**/*.md', '.github/bot-scripts/buildDocsIndex.cjs', '.github/bot-scripts/docsIndex.cjs', '.github/bot-scripts/localEmbeddings.cjs', '.github/bot-scripts/package-lock.json') }}
         # Restore an older index so only changed chunks need to be re-embedded
         restore-keys: |
           docs-embeddings-v3-
 
-    - name: Setup Node.js
+    - name: Setup embeddings
       if: steps.cache.outputs.cache-hit != 'true'
-      uses: actions/setup-node@v5
+      uses: ./.github/actions/setup-bot-embeddings
       with:
-        node-version: 22
-        cache: 'npm'
-        cache-dependency-path: .github/bot-scripts/package-lock.json
-
-    - name: Install embedding dependencies
-      if: steps.cache.outputs.cache-hit != 'true'
-      working-directory: .github/bot-scripts
-      run: npm ci --ignore-scripts
-
-    - name: Restore embedding model
-      if: steps.cache.outputs.cache-hit != 'true'
-      uses: actions/cache@v6
-      with:
-        path: ~/.cache/zwave-js-ui-bot/models
-        key: embedding-model-${{ hashFiles('.github/bot-scripts/localEmbeddings.cjs') }}
+        save-model-cache: 'true'
 
     - name: Build index
       # An exact cache hit means the index is already up to date
@@ -108,7 +94,7 @@ jobs:
       uses: actions/cache/restore@v6
       with:
         path: .docs-index
-        key: docs-embeddings-v3-${{ hashFiles('docs/**/*.md', '.github/bot-scripts/buildDocsIndex.cjs', '.github/bot-scripts/docsIndex.cjs', '.github/bot-scripts/localEmbeddings.cjs') }}
+        key: docs-embeddings-v3-${{ hashFiles('docs/**/*.md', '.github/bot-scripts/buildDocsIndex.cjs', '.github/bot-scripts/docsIndex.cjs', '.github/bot-scripts/localEmbeddings.cjs', '.github/bot-scripts/package-lock.json') }}
 
     - name: Fail if docs index is missing
       # build-index should always have produced this exact cache entry;
@@ -119,22 +105,8 @@ jobs:
         echo "::error::Docs index cache miss after build-index - cannot evaluate retrieval quality"
         exit 1
 
-    - name: Setup Node.js
-      uses: actions/setup-node@v5
-      with:
-        node-version: 22
-        cache: 'npm'
-        cache-dependency-path: .github/bot-scripts/package-lock.json
-
-    - name: Install embedding dependencies
-      working-directory: .github/bot-scripts
-      run: npm ci --ignore-scripts
-
-    - name: Restore embedding model
-      uses: actions/cache@v6
-      with:
-        path: ~/.cache/zwave-js-ui-bot/models
-        key: embedding-model-${{ hashFiles('.github/bot-scripts/localEmbeddings.cjs') }}
+    - name: Setup embeddings
+      uses: ./.github/actions/setup-bot-embeddings
 
     - name: Evaluate retrieval quality
       id: eval
@@ -168,22 +140,8 @@ jobs:
     - name: Checkout master branch
       uses: actions/checkout@v7
 
-    - name: Setup Node.js
-      uses: actions/setup-node@v5
-      with:
-        node-version: 22
-        cache: 'npm'
-        cache-dependency-path: .github/bot-scripts/package-lock.json
-
-    - name: Install embedding dependencies
-      working-directory: .github/bot-scripts
-      run: npm ci --ignore-scripts
-
-    - name: Restore embedding model
-      uses: actions/cache@v6
-      with:
-        path: ~/.cache/zwave-js-ui-bot/models
-        key: embedding-model-${{ hashFiles('.github/bot-scripts/localEmbeddings.cjs') }}
+    - name: Setup embeddings
+      uses: ./.github/actions/setup-bot-embeddings
 
     - name: Collect feedback on bot answers
       env:

--- a/.github/workflows/docs-embeddings.yml
+++ b/.github/workflows/docs-embeddings.yml
@@ -13,7 +13,7 @@ on:
       - 'docs/**/*.md'
       - '.github/bot-scripts/buildDocsIndex.cjs'
       - '.github/bot-scripts/docsIndex.cjs'
-      - '.github/bot-scripts/modelsApi.cjs'
+      - '.github/bot-scripts/localEmbeddings.cjs'
       - '.github/bot-scripts/githubApi.cjs'
       - '.github/bot-scripts/evalDocsAnswers.cjs'
       - '.github/bot-scripts/evalUtils.cjs'
@@ -26,7 +26,6 @@ on:
 
 permissions:
   contents: read
-  models: read
 
 jobs:
   build-index:
@@ -42,16 +41,34 @@ jobs:
       uses: actions/cache@v6
       with:
         path: .docs-index
-        key: docs-embeddings-v2-${{ hashFiles('docs/**/*.md', '.github/bot-scripts/buildDocsIndex.cjs', '.github/bot-scripts/docsIndex.cjs', '.github/bot-scripts/modelsApi.cjs') }}
+        key: docs-embeddings-v3-${{ hashFiles('docs/**/*.md', '.github/bot-scripts/buildDocsIndex.cjs', '.github/bot-scripts/docsIndex.cjs', '.github/bot-scripts/localEmbeddings.cjs') }}
         # Restore an older index so only changed chunks need to be re-embedded
         restore-keys: |
-          docs-embeddings-v2-
+          docs-embeddings-v3-
+
+    - name: Setup Node.js
+      if: steps.cache.outputs.cache-hit != 'true'
+      uses: actions/setup-node@v5
+      with:
+        node-version: 22
+        cache: 'npm'
+        cache-dependency-path: .github/bot-scripts/package-lock.json
+
+    - name: Install embedding dependencies
+      if: steps.cache.outputs.cache-hit != 'true'
+      working-directory: .github/bot-scripts
+      run: npm ci --ignore-scripts
+
+    - name: Restore embedding model
+      if: steps.cache.outputs.cache-hit != 'true'
+      uses: actions/cache@v6
+      with:
+        path: ~/.cache/zwave-js-ui-bot/models
+        key: embedding-model-${{ hashFiles('.github/bot-scripts/localEmbeddings.cjs') }}
 
     - name: Build index
       # An exact cache hit means the index is already up to date
       if: steps.cache.outputs.cache-hit != 'true'
-      env:
-        GITHUB_TOKEN: ${{ github.token }}
       run: node .github/bot-scripts/buildDocsIndex.cjs docs .docs-index/index.json
 
     # The cache entry is regularly evicted before the answer bot gets to use it
@@ -78,7 +95,6 @@ jobs:
     timeout-minutes: 15
     permissions:
       contents: read
-      models: read
       issues: write
 
     steps:
@@ -90,7 +106,7 @@ jobs:
       uses: actions/cache/restore@v6
       with:
         path: .docs-index
-        key: docs-embeddings-v2-${{ hashFiles('docs/**/*.md', '.github/bot-scripts/buildDocsIndex.cjs', '.github/bot-scripts/docsIndex.cjs', '.github/bot-scripts/modelsApi.cjs') }}
+        key: docs-embeddings-v3-${{ hashFiles('docs/**/*.md', '.github/bot-scripts/buildDocsIndex.cjs', '.github/bot-scripts/docsIndex.cjs', '.github/bot-scripts/localEmbeddings.cjs') }}
 
     - name: Fail if docs index is missing
       # build-index should always have produced this exact cache entry;
@@ -101,11 +117,26 @@ jobs:
         echo "::error::Docs index cache miss after build-index - cannot evaluate retrieval quality"
         exit 1
 
+    - name: Setup Node.js
+      uses: actions/setup-node@v5
+      with:
+        node-version: 22
+        cache: 'npm'
+        cache-dependency-path: .github/bot-scripts/package-lock.json
+
+    - name: Install embedding dependencies
+      working-directory: .github/bot-scripts
+      run: npm ci --ignore-scripts
+
+    - name: Restore embedding model
+      uses: actions/cache@v6
+      with:
+        path: ~/.cache/zwave-js-ui-bot/models
+        key: embedding-model-${{ hashFiles('.github/bot-scripts/localEmbeddings.cjs') }}
+
     - name: Evaluate retrieval quality
       id: eval
       continue-on-error: true
-      env:
-        GITHUB_TOKEN: ${{ github.token }}
       run: node .github/bot-scripts/evalDocsAnswers.cjs .docs-index/index.json
 
     - name: Update tracking issue
@@ -128,13 +159,29 @@ jobs:
     timeout-minutes: 15
     permissions:
       contents: read
-      models: read
       issues: write
       discussions: read
 
     steps:
     - name: Checkout master branch
       uses: actions/checkout@v7
+
+    - name: Setup Node.js
+      uses: actions/setup-node@v5
+      with:
+        node-version: 22
+        cache: 'npm'
+        cache-dependency-path: .github/bot-scripts/package-lock.json
+
+    - name: Install embedding dependencies
+      working-directory: .github/bot-scripts
+      run: npm ci --ignore-scripts
+
+    - name: Restore embedding model
+      uses: actions/cache@v6
+      with:
+        path: ~/.cache/zwave-js-ui-bot/models
+        key: embedding-model-${{ hashFiles('.github/bot-scripts/localEmbeddings.cjs') }}
 
     - name: Collect feedback on bot answers
       env:
@@ -152,4 +199,4 @@ jobs:
       uses: actions/cache/save@v6
       with:
         path: .docs-feedback/feedback.json
-        key: docs-feedback-v1-${{ github.run_id }}
+        key: docs-feedback-v2-${{ github.run_id }}

--- a/.github/workflows/docs-embeddings.yml
+++ b/.github/workflows/docs-embeddings.yml
@@ -14,6 +14,8 @@ on:
       - '.github/bot-scripts/buildDocsIndex.cjs'
       - '.github/bot-scripts/docsIndex.cjs'
       - '.github/bot-scripts/localEmbeddings.cjs'
+      - '.github/bot-scripts/package.json'
+      - '.github/bot-scripts/package-lock.json'
       - '.github/bot-scripts/githubApi.cjs'
       - '.github/bot-scripts/evalDocsAnswers.cjs'
       - '.github/bot-scripts/evalUtils.cjs'

--- a/.github/workflows/posts-embeddings.yml
+++ b/.github/workflows/posts-embeddings.yml
@@ -15,7 +15,7 @@ on:
     paths:
       - '.github/bot-scripts/buildPostsIndex.cjs'
       - '.github/bot-scripts/postsIndex.cjs'
-      - '.github/bot-scripts/modelsApi.cjs'
+      - '.github/bot-scripts/localEmbeddings.cjs'
       - '.github/bot-scripts/githubApi.cjs'
       - '.github/bot-scripts/evalRelatedPosts.cjs'
       - '.github/bot-scripts/evalUtils.cjs'
@@ -26,7 +26,6 @@ on:
 
 permissions:
   contents: read
-  models: read
   issues: read
   discussions: read
 
@@ -49,9 +48,26 @@ jobs:
         path: .posts-index
         # There is no exact key to match, the newest index is picked
         # via the prefix
-        key: posts-embeddings-v1-
+        key: posts-embeddings-v2-
         restore-keys: |
-          posts-embeddings-v1-
+          posts-embeddings-v2-
+
+    - name: Setup Node.js
+      uses: actions/setup-node@v5
+      with:
+        node-version: 22
+        cache: 'npm'
+        cache-dependency-path: .github/bot-scripts/package-lock.json
+
+    - name: Install embedding dependencies
+      working-directory: .github/bot-scripts
+      run: npm ci --ignore-scripts
+
+    - name: Restore embedding model
+      uses: actions/cache@v6
+      with:
+        path: ~/.cache/zwave-js-ui-bot/models
+        key: embedding-model-${{ hashFiles('.github/bot-scripts/localEmbeddings.cjs') }}
 
     - name: Build index
       env:
@@ -62,7 +78,7 @@ jobs:
       uses: actions/cache/save@v6
       with:
         path: .posts-index
-        key: posts-embeddings-v1-${{ github.run_id }}
+        key: posts-embeddings-v2-${{ github.run_id }}
 
     # The cache entry is regularly evicted before the answer bot gets to use it
     # (the repository cache is capped and evicted least-recently-used), so keep
@@ -87,7 +103,6 @@ jobs:
     timeout-minutes: 15
     permissions:
       contents: read
-      models: read
       issues: write
 
     steps:
@@ -99,7 +114,7 @@ jobs:
       uses: actions/cache/restore@v6
       with:
         path: .posts-index
-        key: posts-embeddings-v1-${{ github.run_id }}
+        key: posts-embeddings-v2-${{ github.run_id }}
 
     - name: Fail if posts index is missing
       # build-index should always have just saved this exact run-scoped
@@ -110,11 +125,26 @@ jobs:
         echo "::error::Posts index cache miss after build-index - cannot evaluate retrieval quality"
         exit 1
 
+    - name: Setup Node.js
+      uses: actions/setup-node@v5
+      with:
+        node-version: 22
+        cache: 'npm'
+        cache-dependency-path: .github/bot-scripts/package-lock.json
+
+    - name: Install embedding dependencies
+      working-directory: .github/bot-scripts
+      run: npm ci --ignore-scripts
+
+    - name: Restore embedding model
+      uses: actions/cache@v6
+      with:
+        path: ~/.cache/zwave-js-ui-bot/models
+        key: embedding-model-${{ hashFiles('.github/bot-scripts/localEmbeddings.cjs') }}
+
     - name: Evaluate retrieval quality
       id: eval
       continue-on-error: true
-      env:
-        GITHUB_TOKEN: ${{ github.token }}
       run: node .github/bot-scripts/evalRelatedPosts.cjs .posts-index/index.json
 
     - name: Update tracking issue

--- a/.github/workflows/posts-embeddings.yml
+++ b/.github/workflows/posts-embeddings.yml
@@ -16,6 +16,8 @@ on:
       - '.github/bot-scripts/buildPostsIndex.cjs'
       - '.github/bot-scripts/postsIndex.cjs'
       - '.github/bot-scripts/localEmbeddings.cjs'
+      - '.github/bot-scripts/package.json'
+      - '.github/bot-scripts/package-lock.json'
       - '.github/bot-scripts/githubApi.cjs'
       - '.github/bot-scripts/evalRelatedPosts.cjs'
       - '.github/bot-scripts/evalUtils.cjs'

--- a/.github/workflows/posts-embeddings.yml
+++ b/.github/workflows/posts-embeddings.yml
@@ -54,22 +54,10 @@ jobs:
         restore-keys: |
           posts-embeddings-v2-
 
-    - name: Setup Node.js
-      uses: actions/setup-node@v5
+    - name: Setup embeddings
+      uses: ./.github/actions/setup-bot-embeddings
       with:
-        node-version: 22
-        cache: 'npm'
-        cache-dependency-path: .github/bot-scripts/package-lock.json
-
-    - name: Install embedding dependencies
-      working-directory: .github/bot-scripts
-      run: npm ci --ignore-scripts
-
-    - name: Restore embedding model
-      uses: actions/cache@v6
-      with:
-        path: ~/.cache/zwave-js-ui-bot/models
-        key: embedding-model-${{ hashFiles('.github/bot-scripts/localEmbeddings.cjs') }}
+        save-model-cache: 'true'
 
     - name: Build index
       env:
@@ -127,22 +115,8 @@ jobs:
         echo "::error::Posts index cache miss after build-index - cannot evaluate retrieval quality"
         exit 1
 
-    - name: Setup Node.js
-      uses: actions/setup-node@v5
-      with:
-        node-version: 22
-        cache: 'npm'
-        cache-dependency-path: .github/bot-scripts/package-lock.json
-
-    - name: Install embedding dependencies
-      working-directory: .github/bot-scripts
-      run: npm ci --ignore-scripts
-
-    - name: Restore embedding model
-      uses: actions/cache@v6
-      with:
-        path: ~/.cache/zwave-js-ui-bot/models
-        key: embedding-model-${{ hashFiles('.github/bot-scripts/localEmbeddings.cjs') }}
+    - name: Setup embeddings
+      uses: ./.github/actions/setup-bot-embeddings
 
     - name: Evaluate retrieval quality
       id: eval

--- a/.github/workflows/zwave-js-bot_post.yml
+++ b/.github/workflows/zwave-js-bot_post.yml
@@ -164,22 +164,8 @@ jobs:
         echo "::error::Neither the docs index nor the posts index could be restored, from cache or from artifacts - the answer bot cannot run"
         exit 1
 
-    - name: Setup Node.js
-      uses: actions/setup-node@v5
-      with:
-        node-version: 22
-        cache: 'npm'
-        cache-dependency-path: .github/bot-scripts/package-lock.json
-
-    - name: Install embedding dependencies
-      working-directory: .github/bot-scripts
-      run: npm ci --ignore-scripts
-
-    - name: Restore embedding model
-      uses: actions/cache@v6
-      with:
-        path: ~/.cache/zwave-js-ui-bot/models
-        key: embedding-model-${{ hashFiles('.github/bot-scripts/localEmbeddings.cjs') }}
+    - name: Setup embeddings
+      uses: ./.github/actions/setup-bot-embeddings
 
     - name: Answer from documentation
       uses: actions/github-script@v9
@@ -229,25 +215,9 @@ jobs:
       run: |
         echo "::warning::The posts index could not be restored, from cache or from artifacts - this post will only be indexed by the next nightly rebuild"
 
-    - name: Setup Node.js
+    - name: Setup embeddings
       if: steps.posts-index.outputs.found == 'true'
-      uses: actions/setup-node@v5
-      with:
-        node-version: 22
-        cache: 'npm'
-        cache-dependency-path: .github/bot-scripts/package-lock.json
-
-    - name: Install embedding dependencies
-      if: steps.posts-index.outputs.found == 'true'
-      working-directory: .github/bot-scripts
-      run: npm ci --ignore-scripts
-
-    - name: Restore embedding model
-      if: steps.posts-index.outputs.found == 'true'
-      uses: actions/cache@v6
-      with:
-        path: ~/.cache/zwave-js-ui-bot/models
-        key: embedding-model-${{ hashFiles('.github/bot-scripts/localEmbeddings.cjs') }}
+      uses: ./.github/actions/setup-bot-embeddings
 
     - name: Add post to index
       id: update

--- a/.github/workflows/zwave-js-bot_post.yml
+++ b/.github/workflows/zwave-js-bot_post.yml
@@ -125,9 +125,9 @@ jobs:
       uses: actions/cache/restore@v6
       with:
         path: .docs-feedback/feedback.json
-        key: docs-feedback-v1-
+        key: docs-feedback-v2-
         restore-keys: |
-          docs-feedback-v1-
+          docs-feedback-v2-
 
     # One missing index still answers, just worse - say so instead of
     # letting a half-working bot look healthy
@@ -164,6 +164,23 @@ jobs:
         echo "::error::Neither the docs index nor the posts index could be restored, from cache or from artifacts - the answer bot cannot run"
         exit 1
 
+    - name: Setup Node.js
+      uses: actions/setup-node@v5
+      with:
+        node-version: 22
+        cache: 'npm'
+        cache-dependency-path: .github/bot-scripts/package-lock.json
+
+    - name: Install embedding dependencies
+      working-directory: .github/bot-scripts
+      run: npm ci --ignore-scripts
+
+    - name: Restore embedding model
+      uses: actions/cache@v6
+      with:
+        path: ~/.cache/zwave-js-ui-bot/models
+        key: embedding-model-${{ hashFiles('.github/bot-scripts/localEmbeddings.cjs') }}
+
     - name: Answer from documentation
       uses: actions/github-script@v9
       env:
@@ -181,14 +198,13 @@ jobs:
   # related post before the next nightly rebuild. Discussions outside
   # the Q&A category are ignored by updatePostsIndex.cjs itself.
   # Edits are reconciled by the nightly rebuild instead, so repeated
-  # edits cannot burn Models API requests and cache storage.
+  # edits cannot burn compute and cache storage.
   update-posts-index:
     runs-on: [ubuntu-latest]
     timeout-minutes: 10
     permissions:
       actions: read
       contents: read
-      models: read
     if: github.event.action == 'opened' || github.event.action == 'created'
 
     steps:
@@ -213,12 +229,31 @@ jobs:
       run: |
         echo "::warning::The posts index could not be restored, from cache or from artifacts - this post will only be indexed by the next nightly rebuild"
 
+    - name: Setup Node.js
+      if: steps.posts-index.outputs.found == 'true'
+      uses: actions/setup-node@v5
+      with:
+        node-version: 22
+        cache: 'npm'
+        cache-dependency-path: .github/bot-scripts/package-lock.json
+
+    - name: Install embedding dependencies
+      if: steps.posts-index.outputs.found == 'true'
+      working-directory: .github/bot-scripts
+      run: npm ci --ignore-scripts
+
+    - name: Restore embedding model
+      if: steps.posts-index.outputs.found == 'true'
+      uses: actions/cache@v6
+      with:
+        path: ~/.cache/zwave-js-ui-bot/models
+        key: embedding-model-${{ hashFiles('.github/bot-scripts/localEmbeddings.cjs') }}
+
     - name: Add post to index
       id: update
       if: steps.posts-index.outputs.found == 'true'
       uses: actions/github-script@v9
       env:
-        MODELS_TOKEN: ${{ github.token }}
         POSTS_INDEX_PATH: .posts-index/index.json
       with:
         script: |
@@ -230,4 +265,4 @@ jobs:
       uses: actions/cache/save@v6
       with:
         path: .posts-index
-        key: posts-embeddings-v1-${{ github.run_id }}
+        key: posts-embeddings-v2-${{ github.run_id }}


### PR DESCRIPTION
## Description

GitHub Models retires on July 30. This is the first of three PRs migrating off it (porting zwave-js/zwave-js#8985 to this repo), and covers all embeddings usage (docs answer bot, related-posts suggestions).

- Embeddings are computed on the runner with `@huggingface/transformers` and the `Xenova/all-MiniLM-L6-v2` model — the same model the zwave-js bots use, pinned to the same revision. Since this repo is not a monorepo, the dependency lives in a dedicated `.github/bot-scripts/package.json`, installed with `npm ci --ignore-scripts` (which also skips the `onnxruntime-node` CUDA download, see zwave-js/zwave-js#8974) by a shared `setup-bot-embeddings` composite action that owns the node_modules and model-weight caches.
- Doc chunks are re-chunked (`MAX_CHUNK_LENGTH` 4000 → 1200), sized empirically against the pipeline's 512-token window (p99 ≈ 440 tokens, 0.6% slight overflow). Texts are batched by length to cut padding waste.
- Similarity floors recalibrated for MiniLM's cosine distribution (`MIN_SIMILARITY` 0.2 → 0.35, `POSTS_MIN_SIMILARITY` 0.55 → 0.6), based on measured on-topic/off-topic separation against the rebuilt indexes.
- Index cache keys bumped (`docs-embeddings-v3`, `posts-embeddings-v2`, `docs-feedback-v2`) in the workflows and the `restore-bot-index` action; indexes built with the old model are ignored (with a workflow warning) until the nightly rebuilds replace them.
- `models: read` and `MODELS_TOKEN` removed from all embedding paths. The chat-based answer judge still uses the Models API and is migrated in the follow-up PRs.

## Validation

- Retrieval evals with the new model and chunking: docs hit@5 18/18 (100%, required 90%) at every chunk cap tried (700/1000/1200/1400), posts hit@5 7/8 (87.5%, required 80%)
- Docs index: 310 chunks; build takes a few minutes of runner CPU
- All 136 bot-script tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)