### PR TITLE
feat: add speed column for control panel

### DIFF
--- a/src/components/nodes-table/index.vue
+++ b/src/components/nodes-table/index.vue
@@ -310,6 +310,13 @@
 			</div>
 			<div v-else></div>
 		</template>
+		<template #[`item.lwrSpeed`]="{ item }">
+			<rich-value
+				v-if="!item.isControllerNode && !item.virtual"
+				:value="richValue(item, 'lwrSpeed')"
+			/>
+			<div v-else></div>
+		</template>
 		<template #[`item.failed`]="{ item }">
 			<rich-value
 				v-if="!item.isControllerNode && !item.virtual"

--- a/src/components/nodes-table/nodes-table.js
+++ b/src/components/nodes-table/nodes-table.js
@@ -32,6 +32,9 @@ import {
 import { instances, manager } from '../../lib/instanceManager.js'
 import { defineAsyncComponent } from 'vue'
 
+const RATE_LABELS = { 1: '9.6k', 2: '40k', 3: '100k', 4: '100k LR' }
+const RATE_TO_BPS = { 1: 9600, 2: 40000, 3: 100000, 4: 100000 }
+
 export default {
 	props: {
 		socket: Object,
@@ -237,6 +240,28 @@ export default {
 						v.description = getProtocol(node)
 						v.iconStyle = `color: ${getProtocolColor(node, this.currentTheme)}`
 						return v
+					},
+				},
+				lwrSpeed: {
+					type: 'string',
+					label: 'Speed',
+					richValue: (node) => {
+						const rate = node.statistics?.lwr?.protocolDataRate
+						if (!rate) {
+							return { align: 'center', icon: '', displayValue: '-' }
+						}
+
+						const lwrBps = RATE_TO_BPS[rate]
+						const maxBps = node.maxDataRate
+
+						return {
+							align: 'center',
+							icon: '',
+							displayValue: RATE_LABELS[rate],
+							description: maxBps
+								? `${lwrBps / 1000} kbps (capable of ${maxBps / 1000} kbps)`
+								: `${lwrBps / 1000} kbps`,
+						}
 					},
 				},
 				firmwareVersion: {

--- a/src/components/nodes-table/nodes-table.js
+++ b/src/components/nodes-table/nodes-table.js
@@ -31,9 +31,17 @@ import {
 } from '../../lib/utils.js'
 import { instances, manager } from '../../lib/instanceManager.js'
 import { defineAsyncComponent } from 'vue'
+import { ProtocolDataRate, protocolDataRateToString } from '@zwave-js/core'
 
-const RATE_LABELS = { 1: '9.6k', 2: '40k', 3: '100k', 4: '100k LR' }
-const RATE_TO_BPS = { 1: 9600, 2: 40000, 3: 100000, 4: 100000 }
+// Short labels for the table cell, `protocolDataRateToString` is too verbose here
+const RATE_LABELS = {
+	[ProtocolDataRate.ZWave_9k6]: '9.6k',
+	[ProtocolDataRate.ZWave_40k]: '40k',
+	[ProtocolDataRate.ZWave_100k]: '100k',
+	[ProtocolDataRate.LongRange_100k]: '100k LR',
+}
+
+const NO_RATE = '-'
 
 export default {
 	props: {
@@ -245,24 +253,11 @@ export default {
 				lwrSpeed: {
 					type: 'string',
 					label: 'Speed',
-					richValue: (node) => {
-						const rate = node.statistics?.lwr?.protocolDataRate
-						if (!rate) {
-							return { align: 'center', icon: '', displayValue: '-' }
-						}
-
-						const lwrBps = RATE_TO_BPS[rate]
-						const maxBps = node.maxDataRate
-
-						return {
-							align: 'center',
-							icon: '',
-							displayValue: RATE_LABELS[rate],
-							description: maxBps
-								? `${lwrBps / 1000} kbps (capable of ${maxBps / 1000} kbps)`
-								: `${lwrBps / 1000} kbps`,
-						}
-					},
+					customValue: (node) => this.lwrSpeedLabel(node),
+					customSort: (sortDesc, nodeA, nodeB) =>
+						this.lwrSpeedSort(sortDesc, nodeA, nodeB),
+					richValue: (node) => this.lwrSpeedRichValue(node),
+					undefinedPlaceholder: NO_RATE, // must match the text of undefined value
 				},
 				firmwareVersion: {
 					type: 'string',
@@ -427,6 +422,42 @@ export default {
 				description: description,
 				rawValue: level,
 			}
+		},
+		lwrSpeedLabel(node) {
+			return RATE_LABELS[node.statistics?.lwr?.protocolDataRate]
+		},
+		lwrSpeedRichValue(node) {
+			const rate = node.statistics?.lwr?.protocolDataRate
+			const label = RATE_LABELS[rate]
+
+			if (!label) {
+				return {
+					align: 'center',
+					icon: '',
+					displayValue: NO_RATE,
+					displayStyle: '',
+				}
+			}
+
+			const maxBps = node.maxDataRate
+
+			return {
+				align: 'center',
+				icon: '',
+				displayValue: label,
+				displayStyle: '',
+				description: maxBps
+					? `${protocolDataRateToString(rate)} (capable of ${maxBps / 1000} kbit/s)`
+					: protocolDataRateToString(rate),
+			}
+		},
+		lwrSpeedSort(sortDesc, nodeA, nodeB) {
+			// Sort on the rate enum, the labels would order 100k before 40k
+			const rateA = nodeA.statistics?.lwr?.protocolDataRate || 0
+			const rateB = nodeB.statistics?.lwr?.protocolDataRate || 0
+
+			const res = rateA < rateB ? -1 : rateA > rateB ? 1 : 0
+			return sortDesc ? -res : res
 		},
 		powerSort(sortDesc, nodeA, nodeB) {
 			// Special sort for power column

--- a/src/modules/ManagedItems.js
+++ b/src/modules/ManagedItems.js
@@ -39,10 +39,10 @@ export class ManagedItems {
 				: this.filters
 
 		// sometimes columns are updated in new releases, this allows us to show them
-		if (!this.loadSetting('cleared3', false)) {
+		if (!this.loadSetting('cleared4', false)) {
 			this._filters = this.initialFilters
 			this._columns = this.initialTableColumns
-			this.storeSetting('cleared3', true)
+			this.storeSetting('cleared4', true)
 		}
 
 		this._selected = this.initialSelected


### PR DESCRIPTION
Added a speed column to the control panel for each device, capturing the LWR speed in kbps (9.6, 40, 100, 100 LR)

This often helps debugging or figuring out mesh issues.

The value is available in the Network Graph but its much nicer to have it on each device in a summary form.
