### PR TITLE
feat(mqtt): discover Window Covering CC as HA cover entities

### DIFF
--- a/api/lib/Gateway.ts
+++ b/api/lib/Gateway.ts
@@ -442,11 +442,19 @@ export default class Gateway {
 						payload ===
 						(hassDevice.discovery_payload.payload_stop ?? 'STOP')
 					) {
+						// the value used to stop an ongoing level change
+						// depends on the command class
+						const stopProperty =
+							valueId.commandClass ===
+							CommandClasses['Window Covering']
+								? 'levelChangeUp'
+								: 'Up'
+
 						this._zwave
 							.writeValue(
 								{
 									...valueId,
-									property: 'Up',
+									property: stopProperty,
 								},
 								false,
 							)
@@ -1279,6 +1287,26 @@ export default class Gateway {
 					if (valueId.isCurrentValue) {
 						cfg = utils.copy(hassCfg.barrier_state)
 						cfg.discovery_payload.position_topic = getTopic
+					} else return
+					break
+				case CommandClasses['Window Covering']:
+					// Values are duplicated for each supported parameter
+					// (propertyKey). Only odd parameters support positioning,
+					// even ones can just be moved with levelChangeUp/Down
+					if (
+						valueId.isCurrentValue &&
+						typeof valueId.propertyKey === 'number' &&
+						valueId.propertyKey % 2 !== 0
+					) {
+						cfg = utils.copy(hassCfg.cover_position)
+						cfg.discovery_payload.command_topic = setTopic
+						cfg.discovery_payload.position_topic = getTopic
+						cfg.discovery_payload.set_position_topic = setTopic
+						// a node can expose more than one cover, one per parameter
+						cfg.object_id = utils.joinProps(
+							cfg.object_id,
+							valueId.propertyKeyName || valueId.propertyKey,
+						)
 					} else return
 					break
 				case CommandClasses['Multilevel Switch']:

--- a/test/lib/Gateway.test.ts
+++ b/test/lib/Gateway.test.ts
@@ -1,6 +1,7 @@
-import { describe, it, expect, beforeEach } from 'vitest'
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { CommandClasses } from '@zwave-js/core'
 import Gateway, { closeWatchers } from '../../api/lib/Gateway.ts'
-import type { ZUINode } from '../../api/lib/ZwaveClient.ts'
+import type { ZUINode, ZUIValueId } from '../../api/lib/ZwaveClient.ts'
 
 describe('#Gateway', () => {
 	const gw = new Gateway({ type: 0 }, null as any, null as any)
@@ -131,6 +132,69 @@ describe('#Gateway', () => {
 			expect(trimmed.suggested_area).to.equal('Kitchen')
 			expect(blank).to.not.have.property('suggested_area')
 			closeWatchers()
+		})
+	})
+
+	describe('#parsePayload()', () => {
+		const targetValue = (commandClass: CommandClasses) =>
+			({
+				id: `1-${commandClass}-0-targetValue-13`,
+				nodeId: 1,
+				commandClass,
+				endpoint: 0,
+				property: 'targetValue',
+				propertyKey: 13,
+				type: 'number',
+			}) as unknown as ZUIValueId
+
+		let writeValue: ReturnType<typeof vi.fn>
+
+		beforeEach(() => {
+			writeValue = vi.fn(() => Promise.resolve())
+			gw['_zwave'] = { writeValue } as any
+			gw['discovered'] = {}
+		})
+
+		it('stops an ongoing Window Covering level change', () => {
+			const valueId = targetValue(CommandClasses['Window Covering'])
+			gw['discovered'][valueId.id] = {
+				type: 'cover',
+				discovery_payload: { payload_stop: 'stop' },
+			} as any
+
+			expect(gw.parsePayload('stop', valueId, null)).to.equal(null)
+			expect(writeValue).toHaveBeenCalledWith(
+				expect.objectContaining({
+					property: 'levelChangeUp',
+					propertyKey: 13,
+				}),
+				false,
+			)
+		})
+
+		it('stops an ongoing Multilevel Switch level change', () => {
+			const valueId = targetValue(CommandClasses['Multilevel Switch'])
+			gw['discovered'][valueId.id] = {
+				type: 'cover',
+				discovery_payload: { payload_stop: 'stop' },
+			} as any
+
+			expect(gw.parsePayload('stop', valueId, null)).to.equal(null)
+			expect(writeValue).toHaveBeenCalledWith(
+				expect.objectContaining({ property: 'Up' }),
+				false,
+			)
+		})
+
+		it('leaves position payloads untouched', () => {
+			const valueId = targetValue(CommandClasses['Window Covering'])
+			gw['discovered'][valueId.id] = {
+				type: 'cover',
+				discovery_payload: { payload_stop: 'stop' },
+			} as any
+
+			expect(gw.parsePayload('42', valueId, null)).to.equal('42')
+			expect(writeValue).not.toHaveBeenCalled()
 		})
 	})
 })


### PR DESCRIPTION
Closes #4782

## Problem

`Window Covering` (CC 0x6A) had no case in the discovery `switch (cmdClass)` in `api/lib/Gateway.ts`, so it fell through to `default: return` and no entity was ever published. Devices that implement it instead of `Multilevel Switch` — e.g. the Fibaro FGR-224 from the issue — showed up in Home Assistant without any cover.

The values themselves were already published on their normal MQTT topics; only the discovery config was missing.

## Change

A `case CommandClasses['Window Covering']` next to the Multilevel Switch branch. For each **positioned** parameter it publishes a `cover_position` entity:

- `position_topic` → `currentValue` (0-99)
- `command_topic` / `set_position_topic` → `targetValue`
- `object_id` gets the parameter name appended, so a node exposing more than one parameter (shutter + slats) gets one cover each: `cover.<node>_position_outbound_bottom`

Even-numbered parameters are skipped. zwave-js creates metadata for them but never queries a position (`refreshValues` filters to `param % 2 != 0`) and `setValue` on their `targetValue` throws, so there is nothing to map onto an HA cover.

### Stop payload

`parsePayload` already intercepted the HA stop payload for covers and wrote `property: 'Up'`. That property only exists on `Multilevel Switch`; on Window Covering it would throw `throwUnsupportedProperty`. It now picks `levelChangeUp` for this CC, which zwave-js turns into `stopLevelChange(parameter)` when written with `false`.

## Not included

`levelChangeUp` / `levelChangeDown` are not exposed as separate HA entities — open/close go through `targetValue` (99/0), same as the FGR-223 behaviour the reporter compared against. Happy to add button entities for them in a follow-up if wanted.

## Tests

Three cases added to `test/lib/Gateway.test.ts` covering the stop routing per CC and that position payloads pass through untouched. Full suite: 208 passed.

Not verified on real hardware — I don't have an FGR-224.

https://claude.ai/code/session_01E2qjTLomNxBUNpt89VjvFm
