### PR TITLE
docs: clarify that soft reset cannot be disabled on 700/800 series

### DIFF
--- a/docs/troubleshooting/app_crash.md
+++ b/docs/troubleshooting/app_crash.md
@@ -33,7 +33,7 @@ In this case
 
 should be entered in the Z-Wave settings instead of `/dev/ttyUSB0`.
 
-If this does not help, the stick restart can be disabled by disabling __Soft Reset__ option under Z-Wave settings, but this may limit functionality.
+If this does not help, the stick restart can be disabled by disabling __Soft Reset__ option under Z-Wave settings, but this may limit functionality. Note that this only works for 500 series and older controllers: 700/800 series controllers are always soft reset, regardless of this setting.
 
 > This is definitely necessary with the zwave.me UZB1. However, the adapter tries to detect this stick by itself.
 

--- a/docs/usage/setup.md
+++ b/docs/usage/setup.md
@@ -108,7 +108,7 @@ NVM:
 - **Response timeout**: How long to wait for a controller response in milliseconds. Leave blank to use the default (10000ms)
 - **Send to sleep timeout**: How long to wait without pending commands before sending a node back to sleep in milliseconds. Leave blank to use the default (250ms)
 - **Increase node report timeout**: This can help with the inclusion or interview of some devices, but can also slow down communication
-- **Soft reset**: Soft Reset is required after some commands like changing the RF region or restoring an NVM backup. Because it may cause problems in Docker containers with certain Z-Wave sticks, this functionality may be disabled
+- **Soft reset**: Soft Reset is required after some commands like changing the RF region or restoring an NVM backup. Because it may cause problems in Docker containers with certain Z-Wave sticks, this functionality may be disabled. **This setting only affects 500 series and older controllers**: on 700/800 series controllers Z-Wave JS always performs a soft reset, because those controllers require it in too many situations, so disabling it there has no effect
 - **Controller recovery**: When disabled, commands will simply fail when the controller is unresponsive and nodes may get randomly marked as dead until the controller recovers on its own
 - **Watchdog**: Controllers of the 700 series and newer have a hardware watchdog that can be enabled to automatically reset the chip in case it becomes unresponsive
 - **Bootloader only**: Enable this to start the driver in bootloader-only mode, useful to recover sticks when a firmware upgrade fails. When enabled, the stick will NOT be able to communicate with the network
@@ -415,7 +415,7 @@ The external settings file should be a JSON file with the following structure:
 
 **Features**:
 
-- `enableSoftReset` (boolean): Enable soft reset functionality
+- `enableSoftReset` (boolean): Enable soft reset functionality. Ignored on 700/800 series controllers, which are always soft reset
 - `enableStatistics` (boolean): Enable Z-Wave JS usage statistics. When set, the statistics opt-in dialog is not shown and the managing application is expected to control the statistics opt-in (e.g. via the Z-Wave JS Server API)
 
 **Z-Wave JS Server Settings**:


### PR DESCRIPTION
## Why

Z-Wave JS ignores the `enableSoftReset` option on 700+ series controllers and always soft resets them — intentional since zwave-js#6154 ("always enable soft-reset on 700+ series controllers"), because those controllers need it in too many situations.

Our docs never said so. Both `docs/usage/setup.md` and `docs/troubleshooting/app_crash.md` still presented **Soft Reset** as a general remedy, so users of 800 series sticks disable it, see soft reset happen anyway, and conclude Z-Wave JS UI has a bug that ignores their settings — see discussion 4789 and issue 4790, where a user ended up patching `Driver.js` locally.

The UI hint in `src/views/Settings.vue` already carries the caveat; only the docs were missing it.

## What

- `docs/usage/setup.md` — Soft reset bullet now states the setting only affects 500 series and older, and why.
- `docs/usage/setup.md` — external-settings `enableSoftReset` entry notes it is ignored on 700/800 series.
- `docs/troubleshooting/app_crash.md` — the "disable Soft Reset" workaround notes it does not apply to 700/800 series.

Docs only, no behavior change. `markdownlint` passes on both files.
