### PR TITLE
fix(api): refresh access control state on User Code CC value changes

### DIFF
--- a/api/lib/ZwaveClient.ts
+++ b/api/lib/ZwaveClient.ts
@@ -350,9 +350,14 @@ const observedCCProps: {
 		},
 	},
 	[CommandClasses['User Code']]: {
+		userCode(node) {
+			this.scheduleAccessControlRefresh(node.id)
+		},
 		userIdStatus(node, value) {
 			const userId = value.propertyKey as number
 			const status = value.value as UserIDStatus
+
+			this.scheduleAccessControlRefresh(node.id)
 
 			if (!node.userCodes) {
 				return
@@ -1676,6 +1681,31 @@ class ZwaveClient extends TypedEventEmitter<ZwaveClientEventCallbacks> {
 		}
 		node.accessControl = ac
 		this.emitNodeUpdate(node, { accessControl: ac })
+	}
+
+	/**
+	 * Re-read access control state, at most once every second.
+	 *
+	 * zwave-js only emits `user added/modified/deleted` from its high level
+	 * access control API and, for User Credential CC, from unsolicited reports.
+	 * User Code CC changes made through the raw CC API (Home Assistant's
+	 * `set_lock_usercode`, another controller, the keypad) surface as plain
+	 * value updates, so without this the Access Control tab keeps showing the
+	 * state read at interview time. Public because value observers are defined
+	 * outside the class.
+	 */
+	scheduleAccessControlRefresh(nodeId: number) {
+		// Values are also added during the interview, before the first read
+		if (!this._nodes.get(nodeId)?.accessControl?.supported) return
+
+		this.throttle(
+			'_refreshAccessControlState_' + nodeId,
+			() => {
+				const zwaveNode = this.getNode(nodeId)
+				if (zwaveNode) this._refreshAccessControlState(zwaveNode)
+			},
+			1000,
+		)
 	}
 
 	/** Returns the cached access-control state — call this from the UI as a primer. */


### PR DESCRIPTION
Fixes #4786

## The bug

`node.accessControl` is built once at node-ready and afterwards refreshed only on six zwave-js events — `user added`/`modified`/`deleted` and `credential added`/`modified`/`deleted`.

Those events are emitted from exactly two places in zwave-js:

- `lib/node/feature-apis/AccessControl.js` — the high-level `setUser` / `addUser` / `deleteUser` API, and only when its own verification reports success.
- `lib/node/CCHandlers/UserCredentialCC.js` — unsolicited reports, **User Credential CC only**. There is no `CCHandlers/UserCodeCC.js`.

So on a User Code CC lock, every status change that does not go through the high-level API updates zwave-js's value DB but emits only `value updated`:

- Home Assistant's `set_lock_usercode` / `clear_lock_usercode` (raw CC API)
- another controller, or the lock keypad
- a high-level `setUser` on a node without Supervision, where the unsupervised verify path requires `verifiedStatus !== existingStatus` to consider the write successful — the verification GET persists the new status, but no event is emitted

We ignored all of those, so the Access Control tab kept rendering the snapshot taken at interview time. The status dot lags one change behind, which reads as inverted when a code is toggled back and forth, and a slot that was `Enabled` at interview stays green forever.

The reporter's Kwikset HC620 hits the last case on every write: its device config removes Supervision (`zwave-js/packages/config/config/devices/0x0090/hc620.json`), so `setUser` always takes the unsupervised verify path.

## The fix

Refresh from the existing `observedCCProps` value observers for User Code CC (`userIdStatus` and `userCode`), throttled to once per second through the existing `throttle` helper so an interview burst doesn't rebuild the whole state once per slot. The refresh no-ops until the node's first read has happened.

User Credential CC needs nothing — its CC handler already emits the user events on unsolicited reports.

## Not changed

"A code that has never been explicitly enabled or disabled always appears enabled" is inherent to User Code CC: a slot in use is `UserIDStatus.Enabled`, there is no distinct "never configured" state. Only User Credential CC has a real active flag.

## Verification

`tsc --noEmit`, eslint and prettier clean; full test suite passes. Not reproduced against physical hardware — the mechanism was traced from the zwave-js sources listed above.

https://claude.ai/code/session_01HQ7eZNp2LFHJFSCUbh36w7
