### PR TITLE
fix(ui): always show both ping directions in health check results

### DIFF
--- a/src/components/dialogs/DialogHealthCheck.vue
+++ b/src/components/dialogs/DialogHealthCheck.vue
@@ -150,107 +150,195 @@
 
 						<template #[`item.minPowerlevel`]="{ item }">
 							<strong
+								v-if="item.failedPingsController > 0"
+								class="text-error"
+								v-tooltip:bottom="noErrorFreePowerlevelHint"
+								>none</strong
+							>
+							<strong
+								v-else-if="item.minPowerlevel !== undefined"
 								:class="getPowerLevelColor(item.minPowerlevel)"
-								v-if="item.minPowerlevel !== undefined"
 								>{{ getPowerLevel(item.minPowerlevel) }}</strong
+							>
+							<em
+								v-else-if="item.rating !== undefined"
+								class="text-medium-emphasis"
+								v-tooltip:bottom="
+									noPowerlevelHint(activeNode.id)
+								"
+								>not measured</em
 							>
 						</template>
 
 						<template #[`item.failedPingsNode`]="{ item }">
-							<p
-								class="mb-0"
-								v-if="item.failedPingsNode !== undefined"
-							>
-								{{ resultsTargetNode }} → {{ activeNode.id }}:
-								<strong
-									:class="
-										getFailedPingsColor(
-											item.failedPingsNode,
-										)
-									"
-									>{{ item.failedPingsNode }}/10</strong
-								>
-							</p>
-							<p
-								class="mb-0"
-								v-if="item.failedPingsController !== undefined"
-							>
-								{{ resultsTargetNode }} ← {{ activeNode.id }}:
-								<strong
-									:class="
-										getFailedPingsColor(
-											item.failedPingsController,
-										)
-									"
-									>{{ item.failedPingsController }}/10</strong
-								>
-							</p>
+							<template v-if="item.rating !== undefined">
+								<p class="mb-0">
+									{{ resultsTargetNode }} →
+									{{ activeNode.id }}:
+									<strong
+										:class="
+											getFailedPingsColor(
+												item.failedPingsNode,
+											)
+										"
+										>{{ item.failedPingsNode }}/10</strong
+									>
+								</p>
+								<p class="mb-0">
+									{{ resultsTargetNode }} ←
+									{{ activeNode.id }}:
+									<strong
+										v-if="
+											failedPingsToController(item) !==
+											undefined
+										"
+										:class="
+											getFailedPingsColor(
+												failedPingsToController(item),
+											)
+										"
+										>{{
+											failedPingsToController(item)
+										}}/10</strong
+									>
+									<em
+										v-else
+										class="text-medium-emphasis"
+										v-tooltip:bottom="
+											noPowerlevelHint(activeNode.id)
+										"
+										>not measured</em
+									>
+								</p>
+							</template>
 						</template>
 
 						<template #[`item.failedPingsToSource`]="{ item }">
-							<p
-								class="mb-0"
-								v-if="item.failedPingsToSource !== undefined"
-							>
-								{{ resultsTargetNode }} → {{ activeNode.id }}:
-								<strong
-									:class="
-										getFailedPingsColor(
-											item.failedPingsToSource,
-										)
-									"
-									>{{ item.failedPingsToSource }}/10</strong
-								>
-							</p>
-							<p
-								class="mb-0"
-								v-if="item.failedPingsToTarget !== undefined"
-							>
-								{{ resultsTargetNode }} ← {{ activeNode.id }}:
-								<strong
-									:class="
-										getFailedPingsColor(
-											item.failedPingsToTarget,
-										)
-									"
-									>{{ item.failedPingsToTarget }}/10</strong
-								>
-							</p>
+							<template v-if="item.rating !== undefined">
+								<p class="mb-0">
+									{{ resultsTargetNode }} →
+									{{ activeNode.id }}:
+									<strong
+										v-if="
+											item.failedPingsToSource !==
+											undefined
+										"
+										:class="
+											getFailedPingsColor(
+												item.failedPingsToSource,
+											)
+										"
+										>{{
+											item.failedPingsToSource
+										}}/10</strong
+									>
+									<em
+										v-else
+										class="text-medium-emphasis"
+										v-tooltip:bottom="targetPowerlevelHint"
+										>not measured</em
+									>
+								</p>
+								<p class="mb-0">
+									{{ resultsTargetNode }} ←
+									{{ activeNode.id }}:
+									<strong
+										v-if="
+											item.failedPingsToTarget !==
+											undefined
+										"
+										:class="
+											getFailedPingsColor(
+												item.failedPingsToTarget,
+											)
+										"
+										>{{
+											item.failedPingsToTarget
+										}}/10</strong
+									>
+									<em
+										v-else
+										class="text-medium-emphasis"
+										v-tooltip:bottom="
+											noPowerlevelHint(activeNode.id)
+										"
+										>not measured</em
+									>
+								</p>
+							</template>
 						</template>
 
 						<template #[`item.minPowerlevelSource`]="{ item }">
-							<p
-								class="mb-0"
-								v-if="item.minPowerlevelSource !== undefined"
-							>
-								Node {{ activeNode.id }}:
-								<strong
-									:class="
-										getPowerLevelColor(
-											item.minPowerlevelSource,
-										)
-									"
-									>{{
-										getPowerLevel(item.minPowerlevelSource)
-									}}</strong
-								>
-							</p>
-							<p
-								class="mb-0"
-								v-if="item.minPowerlevelTarget !== undefined"
-							>
-								Node {{ resultsTargetNode }}:
-								<strong
-									:class="
-										getPowerLevelColor(
-											item.minPowerlevelTarget,
-										)
-									"
-									>{{
-										getPowerLevel(item.minPowerlevelTarget)
-									}}</strong
-								>
-							</p>
+							<template v-if="item.rating !== undefined">
+								<p class="mb-0">
+									Node {{ activeNode.id }}:
+									<strong
+										v-if="item.failedPingsToTarget > 0"
+										class="text-error"
+										v-tooltip:bottom="
+											noErrorFreePowerlevelHint
+										"
+										>none</strong
+									>
+									<strong
+										v-else-if="
+											item.minPowerlevelSource !==
+											undefined
+										"
+										:class="
+											getPowerLevelColor(
+												item.minPowerlevelSource,
+											)
+										"
+										>{{
+											getPowerLevel(
+												item.minPowerlevelSource,
+											)
+										}}</strong
+									>
+									<em
+										v-else
+										class="text-medium-emphasis"
+										v-tooltip:bottom="
+											noPowerlevelHint(activeNode.id)
+										"
+										>not measured</em
+									>
+								</p>
+								<p class="mb-0">
+									Node {{ resultsTargetNode }}:
+									<strong
+										v-if="item.failedPingsToSource > 0"
+										class="text-error"
+										v-tooltip:bottom="
+											noErrorFreePowerlevelHint
+										"
+										>none</strong
+									>
+									<strong
+										v-else-if="
+											item.minPowerlevelTarget !==
+											undefined
+										"
+										:class="
+											getPowerLevelColor(
+												item.minPowerlevelTarget,
+											)
+										"
+										>{{
+											getPowerLevel(
+												item.minPowerlevelTarget,
+											)
+										}}</strong
+									>
+									<em
+										v-else
+										class="text-medium-emphasis"
+										v-tooltip:bottom="targetPowerlevelHint"
+										>not measured</em
+									>
+								</p>
+							</template>
 						</template>
 					</v-data-table>
 				</v-container>
@@ -313,6 +401,15 @@ export default {
 		},
 		isLR() {
 			return this.activeNode?.protocol === Protocols.ZWaveLongRange
+		},
+		noErrorFreePowerlevelHint() {
+			return 'Pings kept failing even at normal power, so there is no power level without errors'
+		},
+		targetPowerlevelHint() {
+			// the target side is skipped when the source node sleeps, see zwave-js checkRouteHealth
+			return this.activeNode?.canSleep
+				? `Node ${this.activeNode.id} is a sleeping node, so this can't be measured`
+				: this.noPowerlevelHint(this.resultsTargetNode)
 		},
 		filteredNodes() {
 			if (this.isLR) {
@@ -401,6 +498,15 @@ export default {
 			} else {
 				return 'text-error'
 			}
+		},
+		noPowerlevelHint(nodeId) {
+			return `Node ${nodeId} doesn't support Powerlevel CC, so this can't be measured`
+		},
+		// only reported when the node supports Powerlevel CC; a min. power level
+		// was found means every ping at that level was ACKed, i.e. none failed
+		failedPingsToController(item) {
+			if (item.minPowerlevel === undefined) return undefined
+			return item.failedPingsController ?? 0
 		},
 		getRatingColor(rating) {
 			if (rating === undefined) {

--- a/src/components/dialogs/DialogHealthCheckInfo.vue
+++ b/src/components/dialogs/DialogHealthCheckInfo.vue
@@ -17,7 +17,7 @@
 				A lifeline check measures the two directions with different
 				mechanisms: controller → node is measured by pinging the node,
 				node → controller by asking the node to run a Powerlevel CC
-				test. Most columns below therefore describe only one of the two
+				test. Some columns below therefore describe only one of the two
 				directions.
 			</v-card-text>
 			<v-list density="compact">
@@ -36,9 +36,10 @@
 						>The maximum time it took to send a ping to the node.
 						Lower = better, ideally 10 ms. Will use the time in TX
 						reports if available, otherwise fall back to measuring
-						the round trip time. Only covers the controller → node
-						direction, the opposite one is not
-						timed.</v-list-item-subtitle
+						the round trip time. Measured by pinging the node from
+						the controller, but since it is a round trip
+						(NoOperation sent, ACK received) it applies to both
+						directions.</v-list-item-subtitle
 					>
 				</v-list-item>
 				<v-list-item>

--- a/src/components/dialogs/DialogHealthCheckInfo.vue
+++ b/src/components/dialogs/DialogHealthCheckInfo.vue
@@ -39,10 +39,13 @@
 					>
 				</v-list-item>
 				<v-list-item>
-					<v-list-item-title>Failed Pings node</v-list-item-title>
+					<v-list-item-title>Failed pings</v-list-item-title>
 					<v-list-item-subtitle
-						>How many pings were not ACKed by the node. Lower =
-						better, ideally 0.</v-list-item-subtitle
+						>How many of the 10 pings sent in each direction were
+						not ACKed. Lower = better, ideally 0. Pings sent
+						<em>by</em> a node can only be counted when that node
+						supports Powerlevel CC, otherwise the direction is shown
+						as <em>not measured</em>.</v-list-item-subtitle
 					>
 				</v-list-item>
 				<v-list-item>
@@ -50,20 +53,11 @@
 					<v-list-item-subtitle
 						>The minimum powerlevel where all pings from the
 						(source) node were ACKed by the target node /
-						controller. Lower = better, ideally -6dBm or less. Only
-						available if the (source) node supports Powerlevel
-						CC</v-list-item-subtitle
-					>
-				</v-list-item>
-				<v-list-item>
-					<v-list-item-title
-						>Failed pings Controller</v-list-item-title
-					>
-					<v-list-item-subtitle
-						>If no powerlevel was found where the controller ACKed
-						all pings from the node, this contains the number of
-						pings that weren't ACKed. Lower = better, ideally
-						0.</v-list-item-subtitle
+						controller. Lower = better, ideally -6dBm or less. Shown
+						as <em>none</em> when pings kept failing even at normal
+						power, and as <em>not measured</em> when the (source)
+						node doesn't support Powerlevel
+						CC.</v-list-item-subtitle
 					>
 				</v-list-item>
 				<v-list-item>

--- a/src/components/dialogs/DialogHealthCheckInfo.vue
+++ b/src/components/dialogs/DialogHealthCheckInfo.vue
@@ -13,13 +13,21 @@
 					<v-icon>close</v-icon>
 				</v-btn>
 			</v-row>
+			<v-card-text class="pt-0 pb-0 text-body-2">
+				A lifeline check measures the two directions with different
+				mechanisms: controller → node is measured by pinging the node,
+				node → controller by asking the node to run a Powerlevel CC
+				test. Most columns below therefore describe only one of the two
+				directions.
+			</v-card-text>
 			<v-list density="compact">
 				<v-list-item>
 					<v-list-item-title>Route changes</v-list-item-title>
 					<v-list-item-subtitle
 						>How many times at least one new route was needed. Lower
 						= better, ideally 0. Only available if the controller
-						supports TX reports</v-list-item-subtitle
+						supports TX reports. Counted on the pings sent from the
+						controller to the node.</v-list-item-subtitle
 					>
 				</v-list-item>
 				<v-list-item>
@@ -28,7 +36,9 @@
 						>The maximum time it took to send a ping to the node.
 						Lower = better, ideally 10 ms. Will use the time in TX
 						reports if available, otherwise fall back to measuring
-						the round trip time.</v-list-item-subtitle
+						the round trip time. Only covers the controller → node
+						direction, the opposite one is not
+						timed.</v-list-item-subtitle
 					>
 				</v-list-item>
 				<v-list-item>
@@ -65,7 +75,9 @@
 					<v-list-item-subtitle
 						>An estimation of the Signal-to-Noise Ratio Margin in
 						dBm. Only available if the controller supports TX
-						reports.</v-list-item-subtitle
+						reports. Measured by the controller on the ACKs it
+						receives, so it describes the node → controller
+						direction.</v-list-item-subtitle
 					>
 				</v-list-item>
 				<v-list-item>


### PR DESCRIPTION
Closes #3557

## Problem

The `node → controller` row in the health check table only rendered when the driver reported `failedPingsController`. The driver only sets that field when **no** power level was found where all pings were ACKed — i.e. only when things went badly:

```js
// zwave-js Node.ts, checkLifelineHealthInternal
if (powerlevel == undefined) {
    ret.minPowerlevel = Powerlevel["Normal Power"]
    ret.failedPingsController = failedPingsController  // only here
} else {
    ret.minPowerlevel = powerlevel                     // no failed pings field
}
```

So a healthy check (0 failed pings) and a check on a node without Powerlevel CC (nothing measurable) both rendered as *nothing at all*. That's what the reporter saw: the same node showing the row on one run and not the next.

## Fix

Both directions are always rendered now, and each "missing" case says why:

| driver result | before | after |
| --- | --- | --- |
| `minPowerlevel: 2` | *(row hidden)* | `1 ← 102: 0/10` |
| `minPowerlevel: 0, failedPingsController: 2` | `1 ← 102: 2/10` | unchanged |
| `minPowerlevel: undefined` (no Powerlevel CC) | *(row hidden)* | `1 ← 102: not measured` + tooltip |

`minPowerlevel === undefined` is the only case that means "not measurable"; when a level *was* found, every ping at that level was ACKed, so the count is 0.

The min. power level cell also no longer claims `Normal Power` was error-free when `failedPingsController > 0` — it shows `none` (there is no error-free level) with a tooltip.

Route checks get the same treatment per side. There, `failedPingsToSource`/`minPowerlevelTarget` and `failedPingsToTarget`/`minPowerlevelSource` are set together, and a side is skipped when that node lacks Powerlevel CC — or, for the target side, when the source node sleeps. The tooltip names the actual reason.

Rows still render nothing while a round is in progress (guarded on `rating !== undefined`).

The info dialog was updated to match: the stale "Failed pings Controller" entry is folded into the "Failed pings" and "Min Power Level" entries, which now explain `not measured` and `none`.

## Notes

Follows @AlCalzone's read of the semantics in the issue thread, and @gdt's more recent ask — don't hide zeros, say clearly when something couldn't be measured. I kept the two-column layout rather than merging failed pings into the power level column, since the direction labels already disambiguate.

Verified with `tsc` + `vite build` and eslint/prettier. No screenshots: reproducing the `not measured` path needs a real node without Powerlevel CC.

## Second commit: direction notes in the info dialog

From https://github.com/zwave-js/zwave-js-ui/discussions/4798 — the table gives no hint that most columns describe a single direction, so a `1 → 12: 0/10` next to `Max latency: 20 ms` reads as if the latency covered both.

Verified against the driver:

- **Route changes** are counted on the controller → node `NoOperation` ping loop only.
- **SNR margin** is `txReport.ackRSSI - measuredNoiseFloor`, measured by the controller on the ACKs it receives, so it actually describes node → controller.
- **Max latency** is a round trip (`NoOperation` sent → ACK received). Only the controller can start it, but the value itself is independent of the direction — thanks @AlCalzone for the correction, the third commit fixes the wording.

The info dialog now states this, with a short intro explaining that the two directions are measured by different mechanisms (pings vs. a Powerlevel CC node test).

The remaining half of that discussion — `failedPingsController: 10` when the node's Powerlevel CC test never runs, which forces the rating to 0 — is not fixable here and is filed as https://github.com/zwave-js/zwave-js/issues/9127.

