### PR TITLE
feat(build): package x64/arm64 binaries as SEA on stock Node.js

### DIFF
--- a/.github/actions/e2e/action.yml
+++ b/.github/actions/e2e/action.yml
@@ -34,10 +34,12 @@ runs:
         if grep -qE "Cannot find module|MODULE_NOT_FOUND" native.log; then
           echo "The serialport addon was not loadable from the packaged binary" && exit 1
         fi
-        # match the device path only, so a reworded serialport error does not read
-        # as the addon having failed to load
-        if ! grep -q "/dev/ttyUSB-does-not-exist" native.log; then
-          echo "The serialport addon never reported on the port it was given" && exit 1
+        # "cannot open" is the addon's own errno message. The app logs
+        # "Connecting to <port>" before serialport is reached, so matching the
+        # device path alone would pass with a completely broken addon.
+        if ! grep -q "cannot open /dev/ttyUSB-does-not-exist" native.log; then
+          echo "The serialport addon did not report the expected open failure;" \
+               "either it was not usable from the binary, or its error wording changed" && exit 1
         fi
 
     - name: Spawn fake stick
@@ -47,8 +49,6 @@ runs:
         setsid nohup npm run fake-stick > fake-stick.log 2>&1 &
         echo $! > fake-stick.pid
 
-    # pinned by digest: this runs in the same job that holds the release token.
-    # Bump with: docker manifest inspect eclipse-mosquitto:<version>
     # The mock controller crashes on the first bytes if the app connects while it
     # is still coming up, and then the driver never gets a controller to talk to.
     - name: Wait for the mock stick
@@ -66,6 +66,8 @@ runs:
         done
         echo "Mock stick did not start within 60s" && cat fake-stick.log && exit 1
 
+    # pinned by digest: this runs in the same job that holds the release token.
+    # Bump with: docker manifest inspect eclipse-mosquitto:<version>
     - name: Start broker container
       shell: bash
       run: |
@@ -118,38 +120,42 @@ runs:
         done
         echo "Application did not answer within 60s" && cat server.log && exit 1
 
-    # The HTTP server is up long before the driver has interviewed the mock nodes,
-    # and only then does the gateway act on `.../set` topics.
-    - name: Wait for the Z-Wave driver
+    # The HTTP server is up long before the driver has the mock nodes, and the
+    # gateway only acts on `.../set` for a node that is ready. "Ready" rather than
+    # "Interview COMPLETED": the interview is skipped when the store is warm.
+    - name: Wait for the mock nodes
       shell: bash
       run: |
-        for _ in $(seq 1 90); do
-          if grep -q "Driver ready" server.log; then
-            echo "Driver is ready" && exit 0
+        for _ in $(seq 1 120); do
+          if grep -q "\[Node 002\] Ready" server.log; then
+            echo "Node 2 is ready" && exit 0
           fi
           if ! kill -0 "$(cat app.pid)" 2>/dev/null; then
-            echo "Application exited before the driver was ready" && cat server.log && exit 1
+            echo "Application exited before the nodes were ready" && cat server.log && exit 1
           fi
           sleep 1
         done
-        echo "Driver was not ready within 90s" && cat server.log && exit 1
+        echo "Node 2 was not ready within 120s" && cat server.log && exit 1
 
     - name: Test MQTT write and read
       shell: bash
       run: |
-        timeout 30 docker exec broker \
-          mosquitto_pub -h localhost -p 1883 -t "zwave/nodeID_2/106/0/targetValue/3/set" -m "1"
-        # Poll the retained value rather than reading the next message on the
-        # topic: the gateway publishes there while it is still interviewing, so
-        # the reply to this write is not necessarily the message that arrives
-        # next. The mock reports 0 until the write lands, so requiring 1 cannot
-        # pass on the pre-set value.
+        # Read the retained value rather than the next message on the topic: the
+        # gateway also publishes there on its own, so the reply to this write is
+        # not necessarily what arrives next. The mock reports 0 until the write
+        # lands, so requiring 1 cannot pass on the pre-set value.
+        #
+        # The write is repeated because it is idempotent, and is dropped outright
+        # if the gateway is not subscribed yet.
         for _ in $(seq 1 30); do
+          timeout 10 docker exec broker \
+            mosquitto_pub -h localhost -p 1883 -t "zwave/nodeID_2/106/0/targetValue/3/set" -m "1" \
+            || true
           value=$(timeout 10 docker exec broker \
             mosquitto_sub -h localhost -p 1883 -t "zwave/nodeID_2/106/0/currentValue/3" -C 1 -W 5 \
             2>/dev/null || true)
           case "$value" in
-            *'"value":1'*|1)
+            *'"value":1}'*|1)
               echo "currentValue reported over MQTT: $value" && exit 0 ;;
           esac
           sleep 1

--- a/.github/actions/e2e/action.yml
+++ b/.github/actions/e2e/action.yml
@@ -5,9 +5,6 @@ inputs:
   start-command:
     description: "Command that starts the app under test"
     required: true
-  process-pattern:
-    description: "pgrep -f pattern matching the started process"
-    required: true
   binary:
     description: "Path to the packaged binary. When set, the assets embedded in it are checked too."
     required: false
@@ -37,7 +34,9 @@ runs:
 
     - name: Spawn fake stick
       shell: bash
-      run: nohup npm run fake-stick > fake-stick.log 2>&1 &
+      run: |
+        nohup npm run fake-stick > fake-stick.log 2>&1 &
+        echo $! > fake-stick.pid
 
     - name: Start broker container
       shell: bash
@@ -51,18 +50,18 @@ runs:
       shell: bash
       env:
         START_COMMAND: ${{ inputs.start-command }}
-      run: nohup bash -c "exec $START_COMMAND" > server.log 2>&1 &
+      run: |
+        nohup bash -c "$START_COMMAND" > server.log 2>&1 &
+        echo $! > app.pid
 
     - name: Wait for the application to answer
       shell: bash
-      env:
-        PROCESS_PATTERN: ${{ inputs.process-pattern }}
       run: |
         for _ in $(seq 1 60); do
-          if curl -fsS -o /dev/null http://127.0.0.1:8091/; then
+          if curl -fs -o /dev/null http://127.0.0.1:8091/; then
             echo "Application is up" && exit 0
           fi
-          if ! pgrep -f "$PROCESS_PATTERN" > /dev/null; then
+          if ! kill -0 "$(cat app.pid)" 2>/dev/null; then
             echo "Application exited during startup" && cat server.log && exit 1
           fi
           sleep 1
@@ -86,10 +85,13 @@ runs:
         if [ "$index_size" -lt 500 ]; then
           echo "The UI was not served from the packaged binary" && exit 1
         fi
+        if [ ! -d store/.config-db ]; then
+          echo "The config DB was not extracted from the packaged binary" && exit 1
+        fi
         config_files=$(find store/.config-db -name '*.json' | wc -l)
         echo "Config DB files extracted: $config_files"
         if [ "$config_files" -lt 100 ]; then
-          echo "The config DB was not extracted from the packaged binary" && exit 1
+          echo "The config DB was only partially extracted from the packaged binary" && exit 1
         fi
 
     - name: Output application logs
@@ -105,10 +107,8 @@ runs:
     - name: Ensure application is still running
       if: always()
       shell: bash
-      env:
-        PROCESS_PATTERN: ${{ inputs.process-pattern }}
       run: |
-        if ! pgrep -f "$PROCESS_PATTERN" > /dev/null; then
+        if ! kill -0 "$(cat app.pid)" 2>/dev/null; then
           echo "Application crashed!" && exit 1
         fi
         echo "Application is running successfully."
@@ -116,9 +116,16 @@ runs:
     - name: Tear down
       if: always()
       shell: bash
-      env:
-        PROCESS_PATTERN: ${{ inputs.process-pattern }}
       run: |
-        pkill -f "$PROCESS_PATTERN" || true
-        pkill -f mock-server || true
+        for pidfile in app.pid fake-stick.pid; do
+          [ -f "$pidfile" ] || continue
+          pid=$(cat "$pidfile")
+          pkill -P "$pid" 2>/dev/null || true
+          kill "$pid" 2>/dev/null || true
+          for _ in $(seq 1 10); do
+            kill -0 "$pid" 2>/dev/null || break
+            sleep 1
+          done
+          kill -9 "$pid" 2>/dev/null || true
+        done
         docker rm -f broker || true

--- a/.github/actions/e2e/action.yml
+++ b/.github/actions/e2e/action.yml
@@ -34,8 +34,10 @@ runs:
         if grep -qE "Cannot find module|MODULE_NOT_FOUND" native.log; then
           echo "The serialport addon was not loadable from the packaged binary" && exit 1
         fi
-        if ! grep -q "cannot open /dev/ttyUSB-does-not-exist" native.log; then
-          echo "The serialport addon did not report the expected open failure" && exit 1
+        # match the device path only, so a reworded serialport error does not read
+        # as the addon having failed to load
+        if ! grep -q "/dev/ttyUSB-does-not-exist" native.log; then
+          echo "The serialport addon never reported on the port it was given" && exit 1
         fi
 
     - name: Spawn fake stick
@@ -47,12 +49,41 @@ runs:
 
     # pinned by digest: this runs in the same job that holds the release token.
     # Bump with: docker manifest inspect eclipse-mosquitto:<version>
+    # The mock controller crashes on the first bytes if the app connects while it
+    # is still coming up, and then the driver never gets a controller to talk to.
+    - name: Wait for the mock stick
+      shell: bash
+      run: |
+        for _ in $(seq 1 60); do
+          if grep -q "Server listening" fake-stick.log; then
+            sleep 5
+            echo "Mock stick is listening" && exit 0
+          fi
+          if ! kill -0 "$(cat fake-stick.pid)" 2>/dev/null; then
+            echo "Mock stick exited during startup" && cat fake-stick.log && exit 1
+          fi
+          sleep 1
+        done
+        echo "Mock stick did not start within 60s" && cat fake-stick.log && exit 1
+
     - name: Start broker container
       shell: bash
       run: |
-        docker run -d --name broker -p 1883:1883 \
+        # loopback only: the app connects on 127.0.0.1 and the mosquitto clients
+        # run inside the container, so nothing needs an externally bound port
+        docker run -d --name broker -p 127.0.0.1:1883:1883 \
           -v "$PWD/test/e2e/mosquitto.conf:/mosquitto/config/mosquitto.conf" \
           eclipse-mosquitto@sha256:212f89e1eaeb2c322d6441b64396e3346026674db8fa9c27beac293405c32b3c
+        # `docker run -d` succeeds even when mosquitto dies on its config, and the
+        # app tolerates a missing broker, so the real cause would only surface
+        # minutes later as a confusing failure in the MQTT step
+        for _ in $(seq 1 30); do
+          if docker exec broker mosquitto_pub -h localhost -p 1883 -t ping -m up 2>/dev/null; then
+            echo "Broker is accepting connections" && exit 0
+          fi
+          sleep 1
+        done
+        echo "Broker did not accept connections within 30s" && docker logs broker && exit 1
 
     - name: Create settings.json
       shell: bash
@@ -106,24 +137,24 @@ runs:
     - name: Test MQTT write and read
       shell: bash
       run: |
-        # subscribe first, and with -R so the copy retained from startup is
-        # skipped: otherwise this reads back the pre-set value and passes
-        # whether or not the gateway ever handled the write
-        received=$(mktemp)
-        timeout 60 docker exec broker \
-          mosquitto_sub -h localhost -p 1883 -t "zwave/nodeID_2/106/0/currentValue/3" -C 1 -R \
-          > "$received" &
-        subscriber=$!
-        sleep 2
         timeout 30 docker exec broker \
           mosquitto_pub -h localhost -p 1883 -t "zwave/nodeID_2/106/0/targetValue/3/set" -m "1"
-        wait "$subscriber"
-        value=$(cat "$received")
-        echo "currentValue reported over MQTT: $value"
-        case "$value" in
-          *'"value":1'*|1) ;;
-          *) echo "The gateway did not apply the write" && exit 1 ;;
-        esac
+        # Poll the retained value rather than reading the next message on the
+        # topic: the gateway publishes there while it is still interviewing, so
+        # the reply to this write is not necessarily the message that arrives
+        # next. The mock reports 0 until the write lands, so requiring 1 cannot
+        # pass on the pre-set value.
+        for _ in $(seq 1 30); do
+          value=$(timeout 10 docker exec broker \
+            mosquitto_sub -h localhost -p 1883 -t "zwave/nodeID_2/106/0/currentValue/3" -C 1 -W 5 \
+            2>/dev/null || true)
+          case "$value" in
+            *'"value":1'*|1)
+              echo "currentValue reported over MQTT: $value" && exit 0 ;;
+          esac
+          sleep 1
+        done
+        echo "The gateway did not apply the write; last value seen: $value" && exit 1
 
     # The UI and the Z-Wave config DB are read out of the binary at runtime, so a
     # broken virtual filesystem only shows up when they are actually read.
@@ -154,9 +185,9 @@ runs:
       if: always()
       shell: bash
       run: |
-        for log in server.log fake-stick.log; do
+        for log in server.log fake-stick.log native.log; do
           echo "===== $log ====="
-          [ -f "$log" ] && cat "$log"
+          if [ -f "$log" ]; then cat "$log"; else echo "(not created)"; fi
         done
         echo "===== broker ====="
         docker logs broker || true

--- a/.github/actions/e2e/action.yml
+++ b/.github/actions/e2e/action.yml
@@ -1,0 +1,124 @@
+name: "End-to-end test"
+description: "Boots the app against the mock Z-Wave stick and an MQTT broker, then checks it works end to end"
+
+inputs:
+  start-command:
+    description: "Command that starts the app under test"
+    required: true
+  process-pattern:
+    description: "pgrep -f pattern matching the started process"
+    required: true
+  binary:
+    description: "Path to the packaged binary. When set, the assets embedded in it are checked too."
+    required: false
+    default: ""
+
+runs:
+  using: composite
+  steps:
+    # The serialport addon is unpacked from the binary the first time it is used,
+    # and that unpacking works differently under SEA than it did under legacy pkg.
+    # Pointing at a device that does not exist proves the addon loaded: the failure
+    # then comes from the addon itself rather than from module resolution.
+    - name: Check the native addon can be loaded
+      if: inputs.binary != ''
+      shell: bash
+      env:
+        BINARY: ${{ inputs.binary }}
+      run: |
+        STORE_DIR=$(mktemp -d) ZWAVE_PORT=/dev/ttyUSB-does-not-exist \
+          timeout 30 "$BINARY" > native.log 2>&1 || true
+        cat native.log
+        if grep -qE "Cannot find module|MODULE_NOT_FOUND" native.log; then
+          echo "The serialport addon was not loadable from the packaged binary" && exit 1
+        fi
+        grep -q "cannot open /dev/ttyUSB-does-not-exist" native.log \
+          || { echo "The serialport addon did not report the expected open failure" && exit 1; }
+
+    - name: Spawn fake stick
+      shell: bash
+      run: nohup npm run fake-stick > fake-stick.log 2>&1 &
+
+    - name: Start broker container
+      shell: bash
+      run: docker run -d --name broker --network="host" eclipse-mosquitto:latest
+
+    - name: Create settings.json
+      shell: bash
+      run: cp test/e2e/settings.json store/settings.json
+
+    - name: Start application
+      shell: bash
+      env:
+        START_COMMAND: ${{ inputs.start-command }}
+      run: nohup bash -c "exec $START_COMMAND" > server.log 2>&1 &
+
+    - name: Wait for the application to answer
+      shell: bash
+      env:
+        PROCESS_PATTERN: ${{ inputs.process-pattern }}
+      run: |
+        for _ in $(seq 1 60); do
+          if curl -fsS -o /dev/null http://127.0.0.1:8091/; then
+            echo "Application is up" && exit 0
+          fi
+          if ! pgrep -f "$PROCESS_PATTERN" > /dev/null; then
+            echo "Application exited during startup" && cat server.log && exit 1
+          fi
+          sleep 1
+        done
+        echo "Application did not answer within 60s" && cat server.log && exit 1
+
+    - name: Test MQTT write and read
+      shell: bash
+      run: |
+        docker exec broker mosquitto_pub -h localhost -p 1883 -t "zwave/nodeID_2/106/0/targetValue/3/set" -m "1"
+        timeout 60 docker exec broker mosquitto_sub -h localhost -p 1883 -t "zwave/nodeID_2/106/0/currentValue/3" -C 1
+
+    # The UI and the Z-Wave config DB are read out of the binary at runtime, so a
+    # broken virtual filesystem only shows up when they are actually read.
+    - name: Test embedded assets
+      if: inputs.binary != ''
+      shell: bash
+      run: |
+        index_size=$(curl -fsS http://127.0.0.1:8091/ | wc -c)
+        echo "UI index.html served from the binary: $index_size bytes"
+        if [ "$index_size" -lt 500 ]; then
+          echo "The UI was not served from the packaged binary" && exit 1
+        fi
+        config_files=$(find store/.config-db -name '*.json' | wc -l)
+        echo "Config DB files extracted: $config_files"
+        if [ "$config_files" -lt 100 ]; then
+          echo "The config DB was not extracted from the packaged binary" && exit 1
+        fi
+
+    - name: Output application logs
+      if: always()
+      shell: bash
+      run: cat server.log
+
+    - name: Output broker logs
+      if: always()
+      shell: bash
+      run: docker logs broker
+
+    - name: Ensure application is still running
+      if: always()
+      shell: bash
+      env:
+        PROCESS_PATTERN: ${{ inputs.process-pattern }}
+      run: |
+        if ! pgrep -f "$PROCESS_PATTERN" > /dev/null; then
+          echo "Application crashed!" && exit 1
+        fi
+        echo "Application is running successfully."
+
+    - name: Tear down
+      if: always()
+      shell: bash
+      env:
+        PROCESS_PATTERN: ${{ inputs.process-pattern }}
+      run: |
+        pkill -f "$PROCESS_PATTERN" || true
+        pkill -f mock-server || true
+        docker rm -f broker || true

--- a/.github/actions/e2e/action.yml
+++ b/.github/actions/e2e/action.yml
@@ -2,11 +2,12 @@ name: "End-to-end test"
 description: "Boots the app against the mock Z-Wave stick and an MQTT broker, then checks it works end to end"
 
 inputs:
-  start-command:
-    description: "Command that starts the app under test"
-    required: true
   binary:
-    description: "Path to the packaged binary. When set, the assets embedded in it are checked too."
+    description: "Path to the packaged binary under test. When set it is also what gets started, and the assets embedded in it are checked too."
+    required: false
+    default: ""
+  start-command:
+    description: "Command that starts the app under test, when it is not a packaged binary. Trusted literals only: it is passed to a shell."
     required: false
     default: ""
 
@@ -23,24 +24,35 @@ runs:
       env:
         BINARY: ${{ inputs.binary }}
       run: |
-        STORE_DIR=$(mktemp -d) ZWAVE_PORT=/dev/ttyUSB-does-not-exist \
-          timeout 30 "$BINARY" > native.log 2>&1 || true
+        # own store and http port so this probe cannot collide with the app run
+        STORE_DIR=$(mktemp -d) PORT=18091 ZWAVE_PORT=/dev/ttyUSB-does-not-exist \
+          timeout -k 5 30 "$BINARY" > native.log 2>&1 || true
         cat native.log
+        if ! grep -q "Listening on port" native.log; then
+          echo "The packaged binary did not start, so the addon was never reached" && exit 1
+        fi
         if grep -qE "Cannot find module|MODULE_NOT_FOUND" native.log; then
           echo "The serialport addon was not loadable from the packaged binary" && exit 1
         fi
-        grep -q "cannot open /dev/ttyUSB-does-not-exist" native.log \
-          || { echo "The serialport addon did not report the expected open failure" && exit 1; }
+        if ! grep -q "cannot open /dev/ttyUSB-does-not-exist" native.log; then
+          echo "The serialport addon did not report the expected open failure" && exit 1
+        fi
 
     - name: Spawn fake stick
       shell: bash
       run: |
-        nohup npm run fake-stick > fake-stick.log 2>&1 &
+        # own process group, so tear-down can kill npm and the node child it spawns
+        setsid nohup npm run fake-stick > fake-stick.log 2>&1 &
         echo $! > fake-stick.pid
 
+    # pinned by digest: this runs in the same job that holds the release token.
+    # Bump with: docker manifest inspect eclipse-mosquitto:<version>
     - name: Start broker container
       shell: bash
-      run: docker run -d --name broker --network="host" eclipse-mosquitto:latest
+      run: |
+        docker run -d --name broker -p 1883:1883 \
+          -v "$PWD/test/e2e/mosquitto.conf:/mosquitto/config/mosquitto.conf" \
+          eclipse-mosquitto@sha256:212f89e1eaeb2c322d6441b64396e3346026674db8fa9c27beac293405c32b3c
 
     - name: Create settings.json
       shell: bash
@@ -50,15 +62,22 @@ runs:
       shell: bash
       env:
         START_COMMAND: ${{ inputs.start-command }}
+        BINARY: ${{ inputs.binary }}
       run: |
-        nohup bash -c "$START_COMMAND" > server.log 2>&1 &
+        COMMAND=${START_COMMAND:-$BINARY}
+        if [ -z "$COMMAND" ]; then
+          echo "Pass either 'binary' or 'start-command' to this action" && exit 1
+        fi
+        setsid nohup bash -c "$COMMAND" > server.log 2>&1 &
         echo $! > app.pid
 
     - name: Wait for the application to answer
       shell: bash
       run: |
+        # any HTTP answer means the server is listening; the status itself is not
+        # meaningful here because the UI is only built for the packaged binary
         for _ in $(seq 1 60); do
-          if curl -fs -o /dev/null http://127.0.0.1:8091/; then
+          if curl -s -o /dev/null http://127.0.0.1:8091/; then
             echo "Application is up" && exit 0
           fi
           if ! kill -0 "$(cat app.pid)" 2>/dev/null; then
@@ -68,11 +87,43 @@ runs:
         done
         echo "Application did not answer within 60s" && cat server.log && exit 1
 
+    # The HTTP server is up long before the driver has interviewed the mock nodes,
+    # and only then does the gateway act on `.../set` topics.
+    - name: Wait for the Z-Wave driver
+      shell: bash
+      run: |
+        for _ in $(seq 1 90); do
+          if grep -q "Driver ready" server.log; then
+            echo "Driver is ready" && exit 0
+          fi
+          if ! kill -0 "$(cat app.pid)" 2>/dev/null; then
+            echo "Application exited before the driver was ready" && cat server.log && exit 1
+          fi
+          sleep 1
+        done
+        echo "Driver was not ready within 90s" && cat server.log && exit 1
+
     - name: Test MQTT write and read
       shell: bash
       run: |
-        docker exec broker mosquitto_pub -h localhost -p 1883 -t "zwave/nodeID_2/106/0/targetValue/3/set" -m "1"
-        timeout 60 docker exec broker mosquitto_sub -h localhost -p 1883 -t "zwave/nodeID_2/106/0/currentValue/3" -C 1
+        # subscribe first, and with -R so the copy retained from startup is
+        # skipped: otherwise this reads back the pre-set value and passes
+        # whether or not the gateway ever handled the write
+        received=$(mktemp)
+        timeout 60 docker exec broker \
+          mosquitto_sub -h localhost -p 1883 -t "zwave/nodeID_2/106/0/currentValue/3" -C 1 -R \
+          > "$received" &
+        subscriber=$!
+        sleep 2
+        timeout 30 docker exec broker \
+          mosquitto_pub -h localhost -p 1883 -t "zwave/nodeID_2/106/0/targetValue/3/set" -m "1"
+        wait "$subscriber"
+        value=$(cat "$received")
+        echo "currentValue reported over MQTT: $value"
+        case "$value" in
+          *'"value":1'*|1) ;;
+          *) echo "The gateway did not apply the write" && exit 1 ;;
+        esac
 
     # The UI and the Z-Wave config DB are read out of the binary at runtime, so a
     # broken virtual filesystem only shows up when they are actually read.
@@ -80,10 +131,15 @@ runs:
       if: inputs.binary != ''
       shell: bash
       run: |
-        index_size=$(curl -fsS http://127.0.0.1:8091/ | wc -c)
+        # a temp file, not ./index.html: that one is the Vite entry point
+        index=$(mktemp)
+        if ! curl -fsS http://127.0.0.1:8091/ > "$index"; then
+          echo "The UI was not served from the packaged binary" && exit 1
+        fi
+        index_size=$(wc -c < "$index")
         echo "UI index.html served from the binary: $index_size bytes"
         if [ "$index_size" -lt 500 ]; then
-          echo "The UI was not served from the packaged binary" && exit 1
+          echo "The UI served from the packaged binary looks truncated" && exit 1
         fi
         if [ ! -d store/.config-db ]; then
           echo "The config DB was not extracted from the packaged binary" && exit 1
@@ -94,20 +150,24 @@ runs:
           echo "The config DB was only partially extracted from the packaged binary" && exit 1
         fi
 
-    - name: Output application logs
+    - name: Output logs
       if: always()
       shell: bash
-      run: cat server.log
-
-    - name: Output broker logs
-      if: always()
-      shell: bash
-      run: docker logs broker
+      run: |
+        for log in server.log fake-stick.log; do
+          echo "===== $log ====="
+          [ -f "$log" ] && cat "$log"
+        done
+        echo "===== broker ====="
+        docker logs broker || true
 
     - name: Ensure application is still running
       if: always()
       shell: bash
       run: |
+        if [ ! -f app.pid ]; then
+          echo "Application was never started" && exit 1
+        fi
         if ! kill -0 "$(cat app.pid)" 2>/dev/null; then
           echo "Application crashed!" && exit 1
         fi
@@ -120,12 +180,13 @@ runs:
         for pidfile in app.pid fake-stick.pid; do
           [ -f "$pidfile" ] || continue
           pid=$(cat "$pidfile")
-          pkill -P "$pid" 2>/dev/null || true
-          kill "$pid" 2>/dev/null || true
+          # the process is its own group leader thanks to setsid, so this reaches
+          # every child npm or the app spawned
+          kill -- "-$pid" 2>/dev/null || true
           for _ in $(seq 1 10); do
             kill -0 "$pid" 2>/dev/null || break
             sleep 1
           done
-          kill -9 "$pid" 2>/dev/null || true
+          kill -9 -- "-$pid" 2>/dev/null || true
         done
         docker rm -f broker || true

--- a/.github/agents/build-agent.md
+++ b/.github/agents/build-agent.md
@@ -196,7 +196,7 @@ esbuild.build({
   entryPoints: ['api/app.ts'],
   bundle: true,
   platform: 'node',
-  target: 'node20',
+  target: 'node18',
   outfile: 'build/zwavejs2mqtt',
   external: [
     // Native modules that can't be bundled

--- a/.github/agents/build-agent.md
+++ b/.github/agents/build-agent.md
@@ -380,10 +380,14 @@ npm run pkg
 **Output**:
 ```
 build/pkg/
-├── zwave-js-ui-linux           # SEA, stock Node 22
-├── zwave-js-ui-win.exe         # SEA, stock Node 22
+├── zwave-js-ui-linux           # x64  - SEA, stock Node from .nvmrc
+├── zwave-js-ui-win.exe         # x64  - SEA, stock Node from .nvmrc
+├── zwave-js-ui                 # arm64 or armv7, depending on --arch
 └── zwave-js-ui-vX.Y.Z-*.zip    # release assets
 ```
+
+A release therefore ships two Node majors: armv7 on the legacy pkg-fetch Node 20,
+every other target on the stock Node pinned by `.nvmrc`.
 
 ## Build Validation
 

--- a/.github/agents/build-agent.md
+++ b/.github/agents/build-agent.md
@@ -352,6 +352,10 @@ services:
 
 ## Binary Packaging
 
+x64 and arm64 targets are packaged with `pkg --sea`, which bakes the app into a
+stock Node.js binary instead of a patched one, so they need Node >= 22 on the
+build machine. armv7 still uses the legacy `pkg-fetch` pipeline.
+
 ### pkg Configuration
 
 ```json
@@ -364,10 +368,10 @@ services:
       "node_modules/serialport/**/*"
     ],
     "targets": [
-      "node20-linux-x64",
-      "node20-linux-arm64",
-      "node20-macos-x64",
-      "node20-win-x64"
+      "node22-linux-x64",
+      "node22-linux-arm64",
+      "node22-macos-x64",
+      "node22-win-x64"
     ],
     "outputPath": "build/pkg"
   }

--- a/.github/agents/build-agent.md
+++ b/.github/agents/build-agent.md
@@ -358,22 +358,15 @@ build machine. armv7 still uses the legacy `pkg-fetch` pipeline.
 
 ### pkg Configuration
 
+`package.json`'s `pkg` field lists what to embed; the targets, the SEA/legacy
+split and the pinned Node version live in [`package.sh`](../../package.sh).
+
 ```json
 // package.json
 {
   "pkg": {
-    "scripts": "server/**/*.js",
-    "assets": [
-      "dist/**/*",
-      "node_modules/serialport/**/*"
-    ],
-    "targets": [
-      "node22-linux-x64",
-      "node22-linux-arm64",
-      "node22-macos-x64",
-      "node22-win-x64"
-    ],
-    "outputPath": "build/pkg"
+    "scripts": ["server/**/*", "node_modules/axios/dist/node/*"],
+    "assets": ["dist/**/*", "snippets/**", "node_modules/@serialport/**", "..."]
   }
 }
 ```
@@ -387,10 +380,9 @@ npm run pkg
 **Output**:
 ```
 build/pkg/
-├── zwave-js-ui-linux-x64
-├── zwave-js-ui-linux-arm64
-├── zwave-js-ui-macos-x64
-└── zwave-js-ui-win-x64.exe
+├── zwave-js-ui-linux           # SEA, stock Node 22
+├── zwave-js-ui-win.exe         # SEA, stock Node 22
+└── zwave-js-ui-vX.Y.Z-*.zip    # release assets
 ```
 
 ## Build Validation

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -236,7 +236,7 @@ Example MCP queries:
 
 ### Prerequisites and Installation
 
--   Requires Node.js 20.19+ (check with `node --version`)
+-   Requires Node.js 20.19+ to run (check with `node --version`); `npm run pkg` needs Node 22+ because the SEA binaries are built on a stock Node 22
 -   Use npm for package management (bundled with Node.js)
 -   Install dependencies: `npm ci` -- takes ~60 seconds with network delays
 

--- a/.github/workflows/package_arm64.yml
+++ b/.github/workflows/package_arm64.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-24.04-arm
     strategy:
       matrix:
-        node-version: [20.x]
+        node-version: [22.x] # NB: SEA builds require Node >= 22 on the build host
     steps:
       - uses: actions/checkout@v5
 
@@ -30,7 +30,27 @@ jobs:
       - name: Build for arm64
         run: |
           npm run pkg -- --bundle --skip-build --arch=arm64
-      
+
+      - name: Test built package
+        run: |
+          echo "Testing application startup..."
+          ./build/pkg/zwave-js-ui > server.log 2>&1 &
+          app_pid=$!
+          sleep 15
+          if ! kill -0 $app_pid 2>/dev/null; then
+            echo "Package test failed: application crashed on startup"
+            cat server.log
+            exit 1
+          fi
+          kill $app_pid 2>/dev/null || true
+          wait $app_pid 2>/dev/null || true
+          if ! grep -q "Listening on port" server.log; then
+            echo "Package test failed: server never started listening"
+            cat server.log
+            exit 1
+          fi
+          echo "Package test passed: application started successfully"
+
       - name: Upload artifacts
         if: github.event_name == 'workflow_dispatch'
         uses: actions/upload-artifact@v4

--- a/.github/workflows/package_arm64.yml
+++ b/.github/workflows/package_arm64.yml
@@ -35,7 +35,6 @@ jobs:
         uses: ./.github/actions/e2e
         with:
           start-command: ./build/pkg/zwave-js-ui
-          process-pattern: build/pkg/zwave-js-ui
           binary: ./build/pkg/zwave-js-ui
 
       - name: Upload artifacts

--- a/.github/workflows/package_arm64.yml
+++ b/.github/workflows/package_arm64.yml
@@ -6,20 +6,20 @@ on:
       - created
   workflow_dispatch:
 
+permissions:
+  contents: write
+
 jobs:
   build:
     name: Build package and attach to release
     runs-on: ubuntu-24.04-arm
-    strategy:
-      matrix:
-        node-version: [22.x] # NB: SEA builds require Node >= 22 on the build host
     steps:
       - uses: actions/checkout@v5
 
-      - name: Use Node.js ${{ matrix.node-version }}
+      - name: Use Node.js
         uses: actions/setup-node@v5
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version-file: ".nvmrc"
           cache: "npm"
 
       - name: Install and pre-build

--- a/.github/workflows/package_arm64.yml
+++ b/.github/workflows/package_arm64.yml
@@ -31,25 +31,12 @@ jobs:
         run: |
           npm run pkg -- --bundle --skip-build --arch=arm64
 
-      - name: Test built package
-        run: |
-          echo "Testing application startup..."
-          ./build/pkg/zwave-js-ui > server.log 2>&1 &
-          app_pid=$!
-          sleep 15
-          if ! kill -0 $app_pid 2>/dev/null; then
-            echo "Package test failed: application crashed on startup"
-            cat server.log
-            exit 1
-          fi
-          kill $app_pid 2>/dev/null || true
-          wait $app_pid 2>/dev/null || true
-          if ! grep -q "Listening on port" server.log; then
-            echo "Package test failed: server never started listening"
-            cat server.log
-            exit 1
-          fi
-          echo "Package test passed: application started successfully"
+      - name: Test packaged binary
+        uses: ./.github/actions/e2e
+        with:
+          start-command: ./build/pkg/zwave-js-ui
+          process-pattern: build/pkg/zwave-js-ui
+          binary: ./build/pkg/zwave-js-ui
 
       - name: Upload artifacts
         if: github.event_name == 'workflow_dispatch'

--- a/.github/workflows/package_arm64.yml
+++ b/.github/workflows/package_arm64.yml
@@ -34,7 +34,6 @@ jobs:
       - name: Test packaged binary
         uses: ./.github/actions/e2e
         with:
-          start-command: ./build/pkg/zwave-js-ui
           binary: ./build/pkg/zwave-js-ui
 
       - name: Upload artifacts

--- a/.github/workflows/package_armv7.yml
+++ b/.github/workflows/package_armv7.yml
@@ -48,7 +48,8 @@ jobs:
       # target parser rejects, so `--sea` cannot be used here yet.
       - name: Build for armv7
         run: |
-          curl https://github.com/yao-pkg/pkg-binaries/releases/download/node20/node-v20.19.5-linux-armv7 -LOJ
+          # -f so a 404 fails here instead of saving an HTML body as PKG_NODE_PATH
+          curl https://github.com/yao-pkg/pkg-binaries/releases/download/node20/node-v20.19.5-linux-armv7 -fLOJ
           export PKG_NODE_PATH=$(pwd)/node-v20.19.5-linux-armv7
           npm run pkg -- --bundle --skip-build --arch=armv7
 

--- a/.github/workflows/package_armv7.yml
+++ b/.github/workflows/package_armv7.yml
@@ -43,6 +43,9 @@ jobs:
             cd /app
             npm rebuild
 
+      # armv7 is the only target still built with the legacy pkg-fetch pipeline:
+      # pkg addresses the stock nodejs.org armv7 archive as `armv7l`, which its
+      # target parser rejects, so `--sea` cannot be used here yet.
       - name: Build for armv7
         run: |
           curl https://github.com/yao-pkg/pkg-binaries/releases/download/node20/node-v20.19.5-linux-armv7 -LOJ

--- a/.github/workflows/package_armv7.yml
+++ b/.github/workflows/package_armv7.yml
@@ -6,20 +6,20 @@ on:
       - created
   workflow_dispatch:
 
+permissions:
+  contents: write
+
 jobs:
   build:
     name: Build package and attach to release
     runs-on: ubuntu-24.04-arm
-    strategy:
-      matrix:
-        node-version: [22.x] # NB: host only; the packaged target major is LEGACY_NODE_MAJOR in package.sh
     steps:
       - uses: actions/checkout@v5
 
-      - name: Setup Node.js
+      - name: Use Node.js
         uses: actions/setup-node@v5
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version-file: ".nvmrc"
           cache: "npm"
 
       - name: Install and pre-build

--- a/.github/workflows/package_armv7.yml
+++ b/.github/workflows/package_armv7.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-24.04-arm
     strategy:
       matrix:
-        node-version: [20.x] # NB: when pkg-fetch bumps binaries, this must be updated
+        node-version: [22.x] # NB: host only; the packaged target major is LEGACY_NODE_MAJOR in package.sh
     steps:
       - uses: actions/checkout@v5
 

--- a/.github/workflows/package_x64.yml
+++ b/.github/workflows/package_x64.yml
@@ -39,7 +39,6 @@ jobs:
         uses: ./.github/actions/e2e
         with:
           start-command: ./build/pkg/zwave-js-ui-linux
-          process-pattern: build/pkg/zwave-js-ui-linux
           binary: ./build/pkg/zwave-js-ui-linux
 
       - name: Upload artifacts

--- a/.github/workflows/package_x64.yml
+++ b/.github/workflows/package_x64.yml
@@ -10,20 +10,20 @@ on:
       - master
   pull_request:
 
+permissions:
+  contents: write
+
 jobs:
   build:
     name: Build package and attach to release
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        node-version: [22.x] # NB: SEA builds require Node >= 22 on the build host
     steps:
       - uses: actions/checkout@v5
 
-      - name: Use Node.js ${{ matrix.node-version }}
+      - name: Use Node.js
         uses: actions/setup-node@v5
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version-file: ".nvmrc"
           cache: "npm"
 
       - name: Install and pre-build

--- a/.github/workflows/package_x64.yml
+++ b/.github/workflows/package_x64.yml
@@ -35,57 +35,12 @@ jobs:
         run: |
           npm run pkg -- --bundle --skip-build
 
-      - name: Spawn fake stick
-        run: |
-          nohup npm run fake-stick &
-
-      - name: Start Broker container
-        run: |
-          docker run -d --name broker --network="host" eclipse-mosquitto:latest
-
-      - name: Create settings.json
-        run: cp test/e2e/settings.json store/settings.json
-
-      - name: Start packaged binary
-        run: |
-          nohup ./build/pkg/zwave-js-ui-linux > server.log 2>&1 &
-          sleep 25
-
-      - name: Test MQTT write and read
-        timeout-minutes: 1
-        run: |
-          docker exec broker mosquitto_pub -h localhost -p 1883 -t "zwave/nodeID_2/106/0/targetValue/3/set" -m "1"
-          docker exec broker mosquitto_sub -h localhost -p 1883 -t "zwave/nodeID_2/106/0/currentValue/3" -C 1
-
-      - name: Test embedded assets
-        run: |
-          # the UI and the Z-Wave config DB live inside the binary: a broken
-          # virtual filesystem only shows up when they are actually read
-          curl -fsS -o /dev/null http://127.0.0.1:8091/health/
-          config_files=$(find store/.config-db -name '*.json' | wc -l)
-          echo "Config DB files extracted: $config_files"
-          if [ "$config_files" -lt 100 ]; then
-            echo "Config DB was not extracted from the packaged binary" && exit 1
-          fi
-
-      - name: Output backend logs
-        if: always()
-        run: |
-          sleep 5
-          cat server.log
-
-      - name: Output broker logs
-        if: always()
-        run: |
-          docker logs broker
-
-      - name: Ensure backend is running
-        if: always()
-        run: |
-          if ! pgrep -f "zwave-js-ui-linux" > /dev/null; then
-            echo "Backend crashed!" && exit 1
-          fi
-          echo "Backend is running successfully."
+      - name: Test packaged binary
+        uses: ./.github/actions/e2e
+        with:
+          start-command: ./build/pkg/zwave-js-ui-linux
+          process-pattern: build/pkg/zwave-js-ui-linux
+          binary: ./build/pkg/zwave-js-ui-linux
 
       - name: Upload artifacts
         if: github.event_name == 'workflow_dispatch'

--- a/.github/workflows/package_x64.yml
+++ b/.github/workflows/package_x64.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [20.x]
+        node-version: [22.x] # NB: SEA builds require Node >= 22 on the build host
     steps:
       - uses: actions/checkout@v5
 
@@ -35,26 +35,57 @@ jobs:
         run: |
           npm run pkg -- --bundle --skip-build
 
-      - name: Test built package
+      - name: Spawn fake stick
         run: |
-          
-          echo "Testing application startup..."
-          timeout 10s ./build/pkg/zwave-js-ui-linux &
-          app_pid=$!
-          
-          # Wait a few seconds for the app to start
-          sleep 5
-          
-          # Check if process is still running (indicates successful startup)
-          if kill -0 $app_pid 2>/dev/null; then
-            echo "Package test passed: Application started successfully"
-            # Kill the application
-            kill $app_pid 2>/dev/null || true
-            wait $app_pid 2>/dev/null || true
-          else
-            echo "Package test failed: Application failed to start or crashed immediately"
-            exit 1
+          nohup npm run fake-stick &
+
+      - name: Start Broker container
+        run: |
+          docker run -d --name broker --network="host" eclipse-mosquitto:latest
+
+      - name: Create settings.json
+        run: cp test/e2e/settings.json store/settings.json
+
+      - name: Start packaged binary
+        run: |
+          nohup ./build/pkg/zwave-js-ui-linux > server.log 2>&1 &
+          sleep 25
+
+      - name: Test MQTT write and read
+        timeout-minutes: 1
+        run: |
+          docker exec broker mosquitto_pub -h localhost -p 1883 -t "zwave/nodeID_2/106/0/targetValue/3/set" -m "1"
+          docker exec broker mosquitto_sub -h localhost -p 1883 -t "zwave/nodeID_2/106/0/currentValue/3" -C 1
+
+      - name: Test embedded assets
+        run: |
+          # the UI and the Z-Wave config DB live inside the binary: a broken
+          # virtual filesystem only shows up when they are actually read
+          curl -fsS -o /dev/null http://127.0.0.1:8091/health/
+          config_files=$(find store/.config-db -name '*.json' | wc -l)
+          echo "Config DB files extracted: $config_files"
+          if [ "$config_files" -lt 100 ]; then
+            echo "Config DB was not extracted from the packaged binary" && exit 1
           fi
+
+      - name: Output backend logs
+        if: always()
+        run: |
+          sleep 5
+          cat server.log
+
+      - name: Output broker logs
+        if: always()
+        run: |
+          docker logs broker
+
+      - name: Ensure backend is running
+        if: always()
+        run: |
+          if ! pgrep -f "zwave-js-ui-linux" > /dev/null; then
+            echo "Backend crashed!" && exit 1
+          fi
+          echo "Backend is running successfully."
 
       - name: Upload artifacts
         if: github.event_name == 'workflow_dispatch'

--- a/.github/workflows/package_x64.yml
+++ b/.github/workflows/package_x64.yml
@@ -38,7 +38,6 @@ jobs:
       - name: Test packaged binary
         uses: ./.github/actions/e2e
         with:
-          start-command: ./build/pkg/zwave-js-ui-linux
           binary: ./build/pkg/zwave-js-ui-linux
 
       - name: Upload artifacts

--- a/.github/workflows/test-application.yml
+++ b/.github/workflows/test-application.yml
@@ -29,52 +29,8 @@ jobs:
                   nohup npm run fake-stick &
 
             - name: Create settings.json
-              run: |
-                  echo '{
-                    "zwave": {
-                      "port": "tcp://127.0.0.1:5555",
-                      "enabled": true,
-                      "logLevel": "debug",
-                      "logEnabled": true,
-                       "logToFile": true,
-                       "serverEnabled": true
-                    },
-                    "mqtt": {
-                        "name": "zwavejs2mqtt",
-                        "host": "127.0.0.1",
-                        "port": 1883,
-                        "qos": 1,
-                        "prefix": "zwave",
-                        "reconnectPeriod": 3000,
-                        "retain": true,
-                        "clean": true,
-                        "disabled": false
-                    },
-                    "gateway": {
-                        "type": 0,
-                        "payloadType": 0,
-                        "nodeNames": true,
-                        "hassDiscovery": true,
-                        "discoveryPrefix": "homeassistant",
-                        "logEnabled": true,
-                        "logLevel": "debug",
-                        "logToFile": true
-                    },
-                    "backup": {
-                        "storeBackup": true,
-                        "storeCron": "10 9 * * *",
-                        "storeKeep": 7,
-                        "nvmBackup": true,
-                        "nvmBackupOnEvent": false,
-                        "nvmCron": "19 9 * * *",
-                        "nvmKeep": 7,
-                        "enabled": true,
-                        "cron": "0 * * * *",
-                        "keep": 2
-                    }
-                  }' > store/settings.json
-            
-            
+              run: cp test/e2e/settings.json store/settings.json
+
             - name: Start Broker container
               run: |
                   docker run -d --name broker --network="host" eclipse-mosquitto:latest

--- a/.github/workflows/test-application.yml
+++ b/.github/workflows/test-application.yml
@@ -18,7 +18,7 @@ jobs:
             - name: Set up Node.js
               uses: actions/setup-node@v5
               with:
-                  node-version: '22'
+                  node-version-file: '.nvmrc'
                   cache: 'npm'
 
             - name: Install dependencies

--- a/.github/workflows/test-application.yml
+++ b/.github/workflows/test-application.yml
@@ -24,46 +24,11 @@ jobs:
             - name: Install dependencies
               run: npm ci
 
-            - name: Spawn fake stick
-              run: |
-                  nohup npm run fake-stick &
+            - name: Build backend
+              run: npm run build:server
 
-            - name: Create settings.json
-              run: cp test/e2e/settings.json store/settings.json
-
-            - name: Start Broker container
-              run: |
-                  docker run -d --name broker --network="host" eclipse-mosquitto:latest
-                  
-            - name: Start backend
-              run: |
-                  npm run build:server
-                  nohup npm start > server.log 2>&1 &
-                  sleep 25
-            
-            - name: Test MQTT write and read
-              timeout-minutes: 1
-              run: |
-                  docker exec broker mosquitto_pub -h localhost -p 1883 -t "zwave/nodeID_2/106/0/targetValue/3/set" -m "1"
-                  docker exec broker mosquitto_sub -h localhost -p 1883 -t "zwave/nodeID_2/106/0/currentValue/3" -C 1
-
-            - name: Output backend logs
-              if: always()
-              run: |
-                sleep 5
-                cat server.log
-            
-            - name: Output broker logs
-              if: always()
-              run: |
-                  docker logs broker
-
-            - name: Ensure backend is running
-              if: always()
-              run: |
-                  if ! pgrep -f "npm start" > /dev/null; then
-                    echo "Backend crashed!" && exit 1
-                  fi
-                  echo "Backend is running successfully."
-
-           
+            - name: Test application
+              uses: ./.github/actions/e2e
+              with:
+                  start-command: npm start
+                  process-pattern: npm start

--- a/.github/workflows/test-application.yml
+++ b/.github/workflows/test-application.yml
@@ -31,4 +31,3 @@ jobs:
               uses: ./.github/actions/e2e
               with:
                   start-command: npm start
-                  process-pattern: npm start

--- a/api/lib/PkgFsBindings.ts
+++ b/api/lib/PkgFsBindings.ts
@@ -8,42 +8,62 @@ const __filename = fileURLToPath(new URL('', import.meta.url))
 const __dirname = path.dirname(__filename)
 // Ensures that the Z-Wave JS driver is looking for the right files in the right place
 // when running inside a `pkg` bundle. In this case, it will resolve its embedded
-// configuration dir to the path "/config", but the files reside in "node_modules/@zwave-js/config/config" instead.
+// configuration dir to a path outside the bundle, but the files reside in
+// "node_modules/@zwave-js/config/config" instead.
 
+// `@zwave-js/config` resolves that dir two levels above its own module file.
+// Bundling flattens that file into our entry, so the walk escapes the bundle
+// root: it lands on "/config" in a legacy pkg snapshot and on "/snapshot/config"
+// in a SEA binary. Match both instead of hardcoding a single layout.
+//
 // Inside a pkg bundle, the current filename/directory is always "C:\...",
 // so the config dir needs to be resolved relative to __filename, otherwise
 // it would be relative to the current working directory, which might not be on the same drive.
-const CONFIG_PATH = path.resolve(__filename, '/config')
+const CONFIG_PATHS = [
+	path.resolve(__filename, '/config'),
+	path.resolve(__dirname, '../..', 'config'),
+]
 const CONFIG_PATH_IN_PKG = path.join(
 	__dirname,
 	`node_modules/@zwave-js/config/config`,
 )
 
+/**
+ * Maps a path inside the driver's embedded config dir onto the assets shipped
+ * with the bundle. Returns `undefined` for any path outside of it.
+ */
+function toPkgPath(filePath: string): string | undefined {
+	const configPath = CONFIG_PATHS.find((p) => filePath.startsWith(p))
+	return configPath
+		? filePath.replace(configPath, CONFIG_PATH_IN_PKG)
+		: undefined
+}
+
 export class PkgFsBindings implements FileSystem {
 	readFile(filePath: string): Promise<Uint8Array<ArrayBuffer>> {
 		filePath = path.normalize(filePath)
-		if (filePath.startsWith(CONFIG_PATH)) {
-			filePath = filePath.replace(CONFIG_PATH, CONFIG_PATH_IN_PKG)
-		}
-		return nodeFs.readFile(filePath)
+		return nodeFs.readFile(toPkgPath(filePath) ?? filePath)
 	}
 	writeFile(filePath: string, data: Uint8Array<ArrayBuffer>): Promise<void> {
 		filePath = path.normalize(filePath)
-		if (filePath.startsWith(CONFIG_PATH)) {
+		if (toPkgPath(filePath)) {
 			// The pkg assets are readonly
 			return
 		}
 		return nodeFs.writeFile(filePath, data)
 	}
-	copyFile(source: string, dest: string): Promise<void> {
+	async copyFile(source: string, dest: string): Promise<void> {
 		source = path.normalize(source)
 		dest = path.normalize(dest)
-		if (dest.startsWith(CONFIG_PATH)) {
+		if (toPkgPath(dest)) {
 			// The pkg assets are readonly
 			return
 		}
-		if (source.startsWith(CONFIG_PATH)) {
-			source = source.replace(CONFIG_PATH, CONFIG_PATH_IN_PKG)
+		const pkgSource = toPkgPath(source)
+		if (pkgSource) {
+			// SEA's virtual filesystem cannot copyFile out of an embedded asset,
+			// so read it and write it back out instead
+			return nodeFs.writeFile(dest, await nodeFs.readFile(pkgSource))
 		}
 		return nodeFs.copyFile(source, dest)
 	}
@@ -57,32 +77,24 @@ export class PkgFsBindings implements FileSystem {
 		},
 	): Promise<FileHandle> {
 		filePath = path.normalize(filePath)
-		if (filePath.startsWith(CONFIG_PATH) && flags.write) {
+		const pkgPath = toPkgPath(filePath)
+		if (pkgPath && flags.write) {
 			// The pkg assets are readonly
 			throw new Error(`${filePath} is not writable`)
 		}
-		if (filePath.startsWith(CONFIG_PATH)) {
-			filePath = filePath.replace(CONFIG_PATH, CONFIG_PATH_IN_PKG)
-		}
-		return nodeFs.open(filePath, flags)
+		return nodeFs.open(pkgPath ?? filePath, flags)
 	}
 	readDir(dirPath: string): Promise<string[]> {
 		dirPath = path.normalize(dirPath)
-		if (dirPath.startsWith(CONFIG_PATH)) {
-			dirPath = dirPath.replace(CONFIG_PATH, CONFIG_PATH_IN_PKG)
-		}
-		return nodeFs.readDir(dirPath)
+		return nodeFs.readDir(toPkgPath(dirPath) ?? dirPath)
 	}
 	stat(filePath: string): Promise<FSStats> {
 		filePath = path.normalize(filePath)
-		if (filePath.startsWith(CONFIG_PATH)) {
-			filePath = filePath.replace(CONFIG_PATH, CONFIG_PATH_IN_PKG)
-		}
-		return nodeFs.stat(filePath)
+		return nodeFs.stat(toPkgPath(filePath) ?? filePath)
 	}
 	ensureDir(dirPath: string): Promise<void> {
 		dirPath = path.normalize(dirPath)
-		if (dirPath.startsWith(CONFIG_PATH)) {
+		if (toPkgPath(dirPath)) {
 			// The pkg assets are readonly
 			return
 		}
@@ -90,7 +102,7 @@ export class PkgFsBindings implements FileSystem {
 	}
 	deleteDir(dirPath: string): Promise<void> {
 		dirPath = path.normalize(dirPath)
-		if (dirPath.startsWith(CONFIG_PATH)) {
+		if (toPkgPath(dirPath)) {
 			// The pkg assets are readonly
 			return
 		}

--- a/api/lib/PkgFsBindings.ts
+++ b/api/lib/PkgFsBindings.ts
@@ -38,7 +38,7 @@ function toPkgPath(filePath: string): string | undefined {
 		(p) => filePath === p || filePath.startsWith(p + path.sep),
 	)
 	return configPath
-		? filePath.replace(configPath, CONFIG_PATH_IN_PKG)
+		? CONFIG_PATH_IN_PKG + filePath.slice(configPath.length)
 		: undefined
 }
 
@@ -73,7 +73,7 @@ export class PkgFsBindings implements FileSystem {
 		}
 		return nodeFs.copyFile(source, dest)
 	}
-	open(
+	async open(
 		filePath: string,
 		flags: {
 			read: boolean

--- a/api/lib/PkgFsBindings.ts
+++ b/api/lib/PkgFsBindings.ts
@@ -33,7 +33,10 @@ const CONFIG_PATH_IN_PKG = path.join(
  * with the bundle. Returns `undefined` for any path outside of it.
  */
 function toPkgPath(filePath: string): string | undefined {
-	const configPath = CONFIG_PATHS.find((p) => filePath.startsWith(p))
+	// the separator boundary keeps siblings like `/config-db` out of the match
+	const configPath = CONFIG_PATHS.find(
+		(p) => filePath === p || filePath.startsWith(p + path.sep),
+	)
 	return configPath
 		? filePath.replace(configPath, CONFIG_PATH_IN_PKG)
 		: undefined
@@ -44,7 +47,10 @@ export class PkgFsBindings implements FileSystem {
 		filePath = path.normalize(filePath)
 		return nodeFs.readFile(toPkgPath(filePath) ?? filePath)
 	}
-	writeFile(filePath: string, data: Uint8Array<ArrayBuffer>): Promise<void> {
+	async writeFile(
+		filePath: string,
+		data: Uint8Array<ArrayBuffer>,
+	): Promise<void> {
 		filePath = path.normalize(filePath)
 		if (toPkgPath(filePath)) {
 			// The pkg assets are readonly
@@ -92,7 +98,7 @@ export class PkgFsBindings implements FileSystem {
 		filePath = path.normalize(filePath)
 		return nodeFs.stat(toPkgPath(filePath) ?? filePath)
 	}
-	ensureDir(dirPath: string): Promise<void> {
+	async ensureDir(dirPath: string): Promise<void> {
 		dirPath = path.normalize(dirPath)
 		if (toPkgPath(dirPath)) {
 			// The pkg assets are readonly
@@ -100,7 +106,7 @@ export class PkgFsBindings implements FileSystem {
 		}
 		return nodeFs.ensureDir(dirPath)
 	}
-	deleteDir(dirPath: string): Promise<void> {
+	async deleteDir(dirPath: string): Promise<void> {
 		dirPath = path.normalize(dirPath)
 		if (toPkgPath(dirPath)) {
 			// The pkg assets are readonly

--- a/docs/development/intro.md
+++ b/docs/development/intro.md
@@ -7,7 +7,9 @@ In first terminal run `npm run dev` to start webpack-dev for front-end developin
 
 In the second terminal run `npm run dev:server` to start the backend server with inspect and auto restart features
 
-To package the application run `npm run pkg` command and follow the steps
+To package the application run `npm run pkg` command and follow the steps.
+x64 and arm64 binaries are built as [single executable applications](https://nodejs.org/api/single-executable-applications.html)
+on top of a stock Node.js binary, which requires Node >= 22 on the build machine.
 
 ## Developing against a different backend
 

--- a/esbuild.js
+++ b/esbuild.js
@@ -136,16 +136,28 @@ async function main() {
 	console.log(`Build took ${Date.now() - start}ms`)
 	await printSize(outfile)
 
-	const content = (await readFile(outfile, 'utf-8'))
-		.replace(
-			/__dirname, "\.\.\/"/g,
-			'__dirname, "./node_modules/@serialport/bindings-cpp"',
-		)
-		.replace(
-			`("../../package.json").version`,
-			`("./node_modules/@zwave-js/server/package.json").version`,
-		)
-		.replace(`("../../package.json")`, `("./package.json")`)
+	// a pattern that stops matching would silently ship a broken bundle, so fail
+	// the build instead
+	const patch = (source, pattern, replacement) => {
+		const patched = source.replace(pattern, replacement)
+		if (patched === source) {
+			throw new Error(`Cannot patch bundle: ${pattern} did not match`)
+		}
+		return patched
+	}
+
+	let content = await readFile(outfile, 'utf-8')
+	content = patch(
+		content,
+		/__dirname, "\.\.\/"/g,
+		'__dirname, "./node_modules/@serialport/bindings-cpp"',
+	)
+	content = patch(
+		content,
+		`("../../package.json").version`,
+		`("./node_modules/@zwave-js/server/package.json").version`,
+	)
+	content = patch(content, `("../../package.json")`, `("./package.json")`)
 
 	await writeFile(outfile, content)
 

--- a/esbuild.js
+++ b/esbuild.js
@@ -184,6 +184,9 @@ async function main() {
 	}
 
 	pkgJson.bin = 'index.js'
+	// esbuild emits CommonJS, while the root package.json says "module". SEA runs
+	// the bundle on stock node, which would parse it as ESM and fail on `require`.
+	pkgJson.type = 'commonjs'
 	pkgJson.pkg = {
 		assets: ['dist/**', 'snippets/**', 'node_modules/**'],
 	}

--- a/esbuild.js
+++ b/esbuild.js
@@ -136,8 +136,9 @@ async function main() {
 	console.log(`Build took ${Date.now() - start}ms`)
 	await printSize(outfile)
 
-	// a pattern that stops matching would silently ship a broken bundle, so fail
-	// the build instead
+	// A pattern that stops matching would silently ship a broken bundle, so fail
+	// the build instead. Patterns are global, so a second occurrence introduced by
+	// a future dependency gets patched too rather than slipping through.
 	const patch = (source, pattern, replacement) => {
 		const patched = source.replace(pattern, replacement)
 		if (patched === source) {
@@ -154,10 +155,14 @@ async function main() {
 	)
 	content = patch(
 		content,
-		`("../../package.json").version`,
-		`("./node_modules/@zwave-js/server/package.json").version`,
+		/\("\.\.\/\.\.\/package\.json"\)\.version/g,
+		'("./node_modules/@zwave-js/server/package.json").version',
 	)
-	content = patch(content, `("../../package.json")`, `("./package.json")`)
+	content = patch(
+		content,
+		/\("\.\.\/\.\.\/package\.json"\)/g,
+		'("./package.json")',
+	)
 
 	await writeFile(outfile, content)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -66,7 +66,7 @@
         "@typescript-eslint/parser": "^8.45.0",
         "@vitejs/plugin-vue": "^6.0.2",
         "@vitest/coverage-v8": "^4.1.9",
-        "@yao-pkg/pkg": "^6.10.1",
+        "@yao-pkg/pkg": "^6.22.0",
         "ansi_up": "^6.0.2",
         "axios": "^1.7.2",
         "barcode-detector": "^2.2.11",
@@ -3696,6 +3696,16 @@
         "node": "^18.17.0 || >=20.5.0"
       }
     },
+    "node_modules/@roberts_lando/vfs": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/@roberts_lando/vfs/-/vfs-0.3.3.tgz",
+      "integrity": "sha512-YjkxVSLw5WMZQoARaryRAjcxA+GbBzWMJdwYZX5oLUt9cC/gew9as4Dn7tcLzPp7BPoR221VpTZ+78TRPawnjg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 22"
+      }
+    },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-beta.50",
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.50.tgz",
@@ -5377,25 +5387,29 @@
       }
     },
     "node_modules/@yao-pkg/pkg": {
-      "version": "6.10.1",
-      "resolved": "https://registry.npmjs.org/@yao-pkg/pkg/-/pkg-6.10.1.tgz",
-      "integrity": "sha512-M/eqDg0Iir2nmyZ06Q9ospIPv1Yk7K1du5iLiaYrfMogQcI6bqf82A026MVYngyLH8jZsquZvjNAbvgbW4Uwkw==",
+      "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/@yao-pkg/pkg/-/pkg-6.22.0.tgz",
+      "integrity": "sha512-u+ZgwLsvEFB+Q1rA+IGymgxnm+anl1qGJWsTH6hDHyy2cCiOvMteDNK7NgqFYxN/zdithtORIlCsYSyhAXAgQA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/generator": "^7.23.0",
         "@babel/parser": "^7.23.0",
+        "@babel/traverse": "^7.23.0",
         "@babel/types": "^7.23.0",
-        "@yao-pkg/pkg-fetch": "3.5.30",
-        "into-stream": "^6.0.0",
-        "minimist": "^1.2.6",
+        "@roberts_lando/vfs": "^0.3.3",
+        "@yao-pkg/pkg-fetch": "3.6.5",
+        "esbuild": "^0.28.1",
+        "into-stream": "^9.1.0",
         "multistream": "^4.1.0",
         "picocolors": "^1.1.0",
         "picomatch": "^4.0.2",
+        "postject": "^1.0.0-alpha.6",
         "prebuild-install": "^7.1.1",
         "resolve": "^1.22.10",
+        "resolve.exports": "^2.0.3",
         "stream-meter": "^1.0.4",
-        "tar": "^7.4.3",
+        "tar": "^7.5.7",
         "tinyglobby": "^0.2.11",
         "unzipper": "^0.12.3"
       },
@@ -5403,26 +5417,519 @@
         "pkg": "lib-es5/bin.js"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=22.0.0"
       }
     },
     "node_modules/@yao-pkg/pkg-fetch": {
-      "version": "3.5.30",
-      "resolved": "https://registry.npmjs.org/@yao-pkg/pkg-fetch/-/pkg-fetch-3.5.30.tgz",
-      "integrity": "sha512-OrXQlsR3vE/IvwXSk8R5ETYbcxAFtUPmLkeepbG+ArN82TvlIwcUJ65tEWxLG3Tl89VRbmOupuhkXfmuaO05+Q==",
+      "version": "3.6.5",
+      "resolved": "https://registry.npmjs.org/@yao-pkg/pkg-fetch/-/pkg-fetch-3.6.5.tgz",
+      "integrity": "sha512-Sd1Hff7imsF2rcZ2GLQuIzVm2fc3Za+nE4KSWPTwIYegN/r90UFg3bq0MLSugbWQaVht72zzxV0MiKE0wvT1zA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "https-proxy-agent": "^5.0.0",
-        "node-fetch": "^2.6.6",
         "picocolors": "^1.1.0",
         "progress": "^2.0.3",
         "semver": "^7.3.5",
         "tar-fs": "^3.1.1",
+        "undici": "^7.28.0",
         "yargs": "^16.2.0"
       },
       "bin": {
         "pkg-fetch": "lib-es5/bin.js"
+      }
+    },
+    "node_modules/@yao-pkg/pkg-fetch/node_modules/undici": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
+    "node_modules/@yao-pkg/pkg/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.2.tgz",
+      "integrity": "sha512-XExcO+dvLKvVtNTibSTBej1NCAbaGhWn9Ww1ZPx80qsahhPFe/8jgWP0IchNe0F3HwkU7n8ejhH8bjonqht8mQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@yao-pkg/pkg/node_modules/@esbuild/android-arm": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.2.tgz",
+      "integrity": "sha512-kXXoiPVVGQcnIYGOeaovwOURpniDBpSq4A03qkQ+BMQqtGG6HYap3xne9C1O1yo4TR3qxlCX5IqqmX6fFo2Lqg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@yao-pkg/pkg/node_modules/@esbuild/android-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.2.tgz",
+      "integrity": "sha512-5YfKeeI8qWfBZIX+u2xZC3Zlb3Os/gLS2sbEKM+I4ZOcsWmHS2WLysCcQZDAFRslDUU5Oiq44gf6PYN1vGwG5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@yao-pkg/pkg/node_modules/@esbuild/android-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.2.tgz",
+      "integrity": "sha512-O387ite7SzUyCcy3JQX4P4bLtEA7bLLkx+esve5JHnyYfNTxcVpXZo9jhdB0lTKN44gztELTdU7nS8Nr16Fs1Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@yao-pkg/pkg/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.2.tgz",
+      "integrity": "sha512-n4KqkOQrraxHJcgjM1RvwbigfQKIKJVpM7xp+KsxiyUSrRdIXnt73VhrPAx0fV44hgfmIVKjxMN9J1t5jySVkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@yao-pkg/pkg/node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.2.tgz",
+      "integrity": "sha512-uq6suIWYP37qzGddBKPw5QEQPi6HiLGsO7UmkpfyaYNQ3D+rN6w6WfwH+nuqcGXWvawGwxOEroO4YGnFh95azw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@yao-pkg/pkg/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.2.tgz",
+      "integrity": "sha512-n+I0BTSRIoy+d6RPKnEVwql5UwBJolytvY4mAOIEJorKlqgPII8ix6slVVrfZ5Tnj7glIZvloylbB/EJPMWEXw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@yao-pkg/pkg/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.2.tgz",
+      "integrity": "sha512-78XJTJkvPs0kz2w61301PJjXl4g7q3JqiYMZ/M/yVI73EHBrCRTgkhu9oqG7vPqq+a/yadEW8aD+agKlk5xrmg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@yao-pkg/pkg/node_modules/@esbuild/linux-arm": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.2.tgz",
+      "integrity": "sha512-XlDnu2q5yoqems+xay6wSAcg9DDD7K9RLKZEBOMZm3ckNpJBvOX20tSfby8KfrrhINDyv9V2YVZKY/SpoGJI8w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@yao-pkg/pkg/node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.2.tgz",
+      "integrity": "sha512-pW4AC0P3it8c7do9MVM4p51FzHzdM/TZrerurgRcHJ2WTa1VQ1CIq18xncfpBJw4ojkiZZrKW2yIBWBP92j6Ug==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@yao-pkg/pkg/node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.2.tgz",
+      "integrity": "sha512-CYbnj78HsIeA+DhgUKgFCfvNsTHFhMMrinUrMZpDXJXKN8T3XViTZ/+wtHeVxEWY8ewSzTFN+nRmSwO2tZaLUQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@yao-pkg/pkg/node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.2.tgz",
+      "integrity": "sha512-buwkd8nsph4R+ajRvw0qM5Hja/TXQow3ptzWO2EbG/cqcIkHloRrdlBtQlshyYGTNFvfkfJ5tpPLVkY4DtsPfQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@yao-pkg/pkg/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.2.tgz",
+      "integrity": "sha512-ZVykbDyk7519VwiNb9Lcj9m8XM6v5V9uKPvrEMkkEedVewf+0itkhahp4HDpgERXhwLRpWFypsGbG/J8s0QjJA==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@yao-pkg/pkg/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.2.tgz",
+      "integrity": "sha512-CAXl+Dtd9UUuJd8pKKdwh6MLm3MUMiqMPmhZ3tTSXPqfyQ3vDl6R5hZdZ/kYojK4ofXtdfSv1tFq8XzWx3heNQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@yao-pkg/pkg/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.2.tgz",
+      "integrity": "sha512-GeXCej4IQtU1B+QlDV8W/RRvbzI3O/Stss+/bCXv4lZls5WGRtu2a+3JkA3i4qIUlMXpcHebWpF8AkJhATowuA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@yao-pkg/pkg/node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.2.tgz",
+      "integrity": "sha512-3H1weTYZPxt/WOhByszQZybS9w5lKzUn1FDMsgEChbHWQwHYQQRfBxgCcZvPhjHfKyJjIievvMmEUawJrdY9Dg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@yao-pkg/pkg/node_modules/@esbuild/linux-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.2.tgz",
+      "integrity": "sha512-4xTZr1FUmSoQW4XIWmit3tzQrUTZM+N3P0XV8xROKYF50XfI7xeO90+1bZvNwxIufQ9hDQVRJH5YhgPVF8A/HQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@yao-pkg/pkg/node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.2.tgz",
+      "integrity": "sha512-sSATRjPeDBg3pdgHoQfoYBob11Kk1FGa9lui5RIHZCoCkJa9QKlvl3/vKz2usCmYYjs7ymJR/2Nnsqe+Hjt5nw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@yao-pkg/pkg/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.2.tgz",
+      "integrity": "sha512-lqnzCV+mM0gIADaKihiCg6ifgfU2L3h5E33rNQBN1Y4MaVGnzryzmvvf7UHxprpQdE8hpqLolJ9Rl+SkIRDpyw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@yao-pkg/pkg/node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.2.tgz",
+      "integrity": "sha512-AL2qJILH7lNjrDmCQDvdxMfAUIv8KMNZOvrwAQ8i8//ntL9FflhOyMJ8OZSMBb8/AWXe3/5v5S20y3zCoZWKoQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@yao-pkg/pkg/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.2.tgz",
+      "integrity": "sha512-QtiuPytchRyC4rwUKhexJdQKvDuZ6hWloi3igqPQNUJCS1/v9EiO3UTOXR6A3FoMo4fnAKbWJdqaIwhOzh8qEw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@yao-pkg/pkg/node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.2.tgz",
+      "integrity": "sha512-WkhYDmpTjLvGlScA1rwjRUmhl4k8oXR3cIbtqWmELgU/dFeHHlEllxDvdWcNJV9rbzCexB5vz8gtNewWLgCT7Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@yao-pkg/pkg/node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.2.tgz",
+      "integrity": "sha512-GPMSkTOtMnv2U2F8gxe4Io6qmVs+YKyp832Etqqxr0hFngmXQ3rzwytelm3GIn7T4VviRUlf3sOgBOiTdvaf7g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@yao-pkg/pkg/node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.2.tgz",
+      "integrity": "sha512-PIhhEkE9uPBleRBrQEJpUn7MBnibZzbGzYWPmY3x+YoVg/95zbjB4CxPPOQ8l5tYYM4mMaCthF8/1DIfBQQyWQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@yao-pkg/pkg/node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.2.tgz",
+      "integrity": "sha512-YmJbfTlvU7Sdn9BB+4PRES4oB6pxgS37MAONj+hBr/cpXS1aBPKXxNnDbu+QCWPj0o9dgyxeq79g6c5P8KeuYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@yao-pkg/pkg/node_modules/@esbuild/win32-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.2.tgz",
+      "integrity": "sha512-5ebpxr3nWMzrL/rnUI755Jkuee0bHL/Gq0WTF9lvcpv73wAp5eu8MfBUgWK9bhWvZjj7yX8etf/8tI8Ney695g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@yao-pkg/pkg/node_modules/esbuild": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.2.tgz",
+      "integrity": "sha512-HKVLS8dvII+xoKW9kmqxbRKrnWEXfJJr/FZhhJmiqIB0e053QNYFqOBouTMO/k5sID4MvCiUCvv8b9M4h32wIA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.2",
+        "@esbuild/android-arm": "0.28.2",
+        "@esbuild/android-arm64": "0.28.2",
+        "@esbuild/android-x64": "0.28.2",
+        "@esbuild/darwin-arm64": "0.28.2",
+        "@esbuild/darwin-x64": "0.28.2",
+        "@esbuild/freebsd-arm64": "0.28.2",
+        "@esbuild/freebsd-x64": "0.28.2",
+        "@esbuild/linux-arm": "0.28.2",
+        "@esbuild/linux-arm64": "0.28.2",
+        "@esbuild/linux-ia32": "0.28.2",
+        "@esbuild/linux-loong64": "0.28.2",
+        "@esbuild/linux-mips64el": "0.28.2",
+        "@esbuild/linux-ppc64": "0.28.2",
+        "@esbuild/linux-riscv64": "0.28.2",
+        "@esbuild/linux-s390x": "0.28.2",
+        "@esbuild/linux-x64": "0.28.2",
+        "@esbuild/netbsd-arm64": "0.28.2",
+        "@esbuild/netbsd-x64": "0.28.2",
+        "@esbuild/openbsd-arm64": "0.28.2",
+        "@esbuild/openbsd-x64": "0.28.2",
+        "@esbuild/openharmony-arm64": "0.28.2",
+        "@esbuild/sunos-x64": "0.28.2",
+        "@esbuild/win32-arm64": "0.28.2",
+        "@esbuild/win32-ia32": "0.28.2",
+        "@esbuild/win32-x64": "0.28.2"
       }
     },
     "node_modules/@zwave-js/cc": {
@@ -6120,19 +6627,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/agent-base": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
-      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 6.0.0"
-      }
-    },
     "node_modules/ajv": {
       "version": "6.14.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
@@ -6584,9 +7078,9 @@
       }
     },
     "node_modules/b4a": {
-      "version": "1.7.3",
-      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.7.3.tgz",
-      "integrity": "sha512-5Q2mfq2WfGuFp3uS//0s6baOJLMoVduPYVeNmDYxu5OUA1/cBfvr2RIS7vi62LdNj/urk1hfmj867I3qt6uZ7Q==",
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.8.1.tgz",
+      "integrity": "sha512-aiqre1Nr0B/6DgE2N5vwTc+2/oQZ4Wh1t4NznYY4E00y8LCt6NqdRv81so00oo27D8MVKTpUa/MwUUtBLXCoDw==",
       "license": "Apache-2.0",
       "peerDependencies": {
         "react-native-b4a": "*"
@@ -6697,9 +7191,9 @@
       }
     },
     "node_modules/bare-fs": {
-      "version": "4.5.1",
-      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.5.1.tgz",
-      "integrity": "sha512-zGUCsm3yv/ePt2PHNbVxjjn0nNB1MkIaR4wOCxJ2ig5pCf5cCVAYJXVhQg/3OhhJV6DB1ts7Hv0oUaElc2TPQg==",
+      "version": "4.8.1",
+      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.8.1.tgz",
+      "integrity": "sha512-N1nnXdHZAOSstz0XiHikGS4HGMH4CnSwhqWdGQQMqqdvp4Jybm9sE3R1WVnpWVd4SFkc8ryPDBLViNLwiEqECg==",
       "dev": true,
       "license": "Apache-2.0",
       "optional": true,
@@ -6711,7 +7205,7 @@
         "fast-fifo": "^1.3.2"
       },
       "engines": {
-        "bare": ">=1.16.0"
+        "bare": ">=1.28.0"
       },
       "peerDependencies": {
         "bare-buffer": "*"
@@ -6722,43 +7216,35 @@
         }
       }
     },
-    "node_modules/bare-os": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-3.6.2.tgz",
-      "integrity": "sha512-T+V1+1srU2qYNBmJCXZkUY5vQ0B4FSlL3QDROnKQYOqeiQR8UbjNHlPa+TIbM4cuidiN9GaTaOZgSEgsvPbh5A==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "engines": {
-        "bare": ">=1.14.0"
-      }
-    },
     "node_modules/bare-path": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/bare-path/-/bare-path-3.0.0.tgz",
-      "integrity": "sha512-tyfW2cQcB5NN8Saijrhqn0Zh7AnFNsnczRcuWODH0eYAXBsJ5gVxAUuNr7tsHSC6IZ77cA0SitzT+s47kot8Mw==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bare-path/-/bare-path-3.1.2.tgz",
+      "integrity": "sha512-ZyKbsuuqK6Ag0K8pX6V5Txq6XeJRvY+wXucnFGRjiyVYP9YWDpIQugk/b+enRYrEYBJaqLzghRQpXPMR7341Nw==",
       "dev": true,
       "license": "Apache-2.0",
-      "optional": true,
-      "dependencies": {
-        "bare-os": "^3.0.1"
-      }
+      "optional": true
     },
     "node_modules/bare-stream": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.7.0.tgz",
-      "integrity": "sha512-oyXQNicV1y8nc2aKffH+BUHFRXmx6VrPzlnaEvMhram0nPBrKcEdcyBg5r08D0i8VxngHFAiVyn1QKXpSG0B8A==",
+      "version": "2.13.4",
+      "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.13.4.tgz",
+      "integrity": "sha512-PcrQ8lVLbiJscNm1Kez+Yp4Gy4AHGcN1lzwjvf5NybWen7VvEgUfyfnXYJ2zNqWnzOfCb1Abq6lH8ti0syQszA==",
       "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
-        "streamx": "^2.21.0"
+        "b4a": "^1.8.1",
+        "streamx": "^2.25.0",
+        "teex": "^1.0.1"
       },
       "peerDependencies": {
+        "bare-abort-controller": "*",
         "bare-buffer": "*",
         "bare-events": "*"
       },
       "peerDependenciesMeta": {
+        "bare-abort-controller": {
+          "optional": true
+        },
         "bare-buffer": {
           "optional": true
         },
@@ -6768,9 +7254,9 @@
       }
     },
     "node_modules/bare-url": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.3.2.tgz",
-      "integrity": "sha512-ZMq4gd9ngV5aTMa5p9+UfY0b3skwhHELaDkhEHetMdX0LRkW9kzaym4oo/Eh+Ghm0CCDuMTsRIGM/ytUc1ZYmw==",
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.5.3.tgz",
+      "integrity": "sha512-3absfEzoyFosWT8v83ZcJgbTJxv+S/sI7jBfeCMlUVatSaefRmwweqBhFpMllQv+HTxs/FbbToVOw1c05NORkQ==",
       "dev": true,
       "license": "Apache-2.0",
       "optional": true,
@@ -11352,57 +11838,6 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/from2": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/from2/-/from2-2.3.0.tgz",
-      "integrity": "sha512-OMcX/4IC/uqEPVgGeyfN22LJk6AZrMkRZHxcHBMBvHScDGgwTm2GT2Wkgtocyd3JfZffjj2kYUDXXII0Fk9W0g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "inherits": "^2.0.1",
-        "readable-stream": "^2.0.0"
-      }
-    },
-    "node_modules/from2/node_modules/isarray": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/from2/node_modules/readable-stream": {
-      "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
-      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.1.1",
-        "util-deprecate": "~1.0.1"
-      }
-    },
-    "node_modules/from2/node_modules/safe-buffer": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/from2/node_modules/string_decoder": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "~5.1.0"
-      }
-    },
     "node_modules/fs-constants": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
@@ -12125,20 +12560,6 @@
         "node": ">= 14"
       }
     },
-    "node_modules/https-proxy-agent": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
-      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "agent-base": "6",
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/human-signals": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-5.0.0.tgz",
@@ -12328,17 +12749,13 @@
       }
     },
     "node_modules/into-stream": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/into-stream/-/into-stream-6.0.0.tgz",
-      "integrity": "sha512-XHbaOAvP+uFKUFsOgoNPRjLkwB+I22JFPFe5OjTkQ0nwgj6+pSjb4NmB6VMxaPshLiOf+zcpOCBQuLwC1KHhZA==",
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/into-stream/-/into-stream-9.1.0.tgz",
+      "integrity": "sha512-DRsRnQrbzdFjaQ1oe4C6/EIUymIOEix1qROEJTF9dbMq+M4Zrm6VaLp6SD/B9IsiEjPZuBSnWWFN+udajugdWA==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "from2": "^2.3.0",
-        "p-is-promise": "^3.0.0"
-      },
       "engines": {
-        "node": ">=10"
+        "node": ">=20"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -15905,16 +16322,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/p-is-promise": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-3.0.0.tgz",
-      "integrity": "sha512-Wo8VsW4IRQSKVXsJCn7TomUaVtyfjVDn3nUP7kE967BQk0CwFpdbZs0X0uk5sW9mkBa9eNM7hCMaG93WUAwxYQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/p-limit": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
@@ -16385,6 +16792,32 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/postject": {
+      "version": "1.0.0-alpha.6",
+      "resolved": "https://registry.npmjs.org/postject/-/postject-1.0.0-alpha.6.tgz",
+      "integrity": "sha512-b9Eb8h2eVqNE8edvKdwqkrY6O7kAwmI8kcnBv1NScolYJbo59XUF0noFq+lxbC1yN20bmC0WBEbDC5H/7ASb0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^9.4.0"
+      },
+      "bin": {
+        "postject": "dist/cli.js"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/postject/node_modules/commander": {
+      "version": "9.5.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
+      "integrity": "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || >=14"
       }
     },
     "node_modules/prebuild-install": {
@@ -17385,6 +17818,16 @@
       "integrity": "sha512-C7rARubxI8bXFNB/hqcp/4iUeIXJhJZvFPFPiSPRnhU5UPxzMFIl+2E6yY6c4k9giDJAhtV+enfA+G89N6Csng==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/resolve.exports": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/resolve.exports/-/resolve.exports-2.0.3.tgz",
+      "integrity": "sha512-OcXjMsGdhL4XnbShKpAcSqPMzQoYkYyhbEaeSko47MjRP9NfEQMhZkXL1DoFlt9LWQn4YttrdnV6X2OiyzBi+A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/responselike": {
       "version": "1.0.2",
@@ -18562,9 +19005,9 @@
       }
     },
     "node_modules/streamx": {
-      "version": "2.23.0",
-      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.23.0.tgz",
-      "integrity": "sha512-kn+e44esVfn2Fa/O0CPFcex27fjIL6MkVae0Mm6q+E6f0hWv578YCERbv+4m02cjxvDsPKLnmxral/rR6lBMAg==",
+      "version": "2.28.1",
+      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.28.1.tgz",
+      "integrity": "sha512-zEzXb0s5Cds7tqMH6rhZ05lcJydCWiQPEwiNngVqzsxCc962vLY4Uw+mW7od8kDH258k2Uz/JrOkdIAAhSh9VA==",
       "license": "MIT",
       "dependencies": {
         "events-universal": "^1.0.0",
@@ -18933,9 +19376,9 @@
       }
     },
     "node_modules/tar-fs": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.1.1.tgz",
-      "integrity": "sha512-LZA0oaPOc2fVo82Txf3gw+AkEd38szODlptMYejQUhndHMLQ9M059uXR+AfS7DNo0NpINvSqDsvyaCrBVkptWg==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.1.3.tgz",
+      "integrity": "sha512-/hU4AXnIdZu+Gvl1pk0oI5f5HxWsCJRtY2aFaJdk9VvyL48DWU6iU5WAIPG+wIi1YvWA6eTJvIviP/tMAZZNwQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -18975,6 +19418,17 @@
       "license": "MIT",
       "dependencies": {
         "bintrees": "1.0.2"
+      }
+    },
+    "node_modules/teex": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/teex/-/teex-1.0.1.tgz",
+      "integrity": "sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "streamx": "^2.12.5"
       }
     },
     "node_modules/temp-dir": {
@@ -21520,9 +21974,9 @@
       }
     },
     "node_modules/yargs": {
-      "version": "16.2.0",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
-      "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+      "version": "16.2.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.2.tgz",
+      "integrity": "sha512-Nt9ZJjXTv5R8MHbqby/wXQ6Gi0Bb3TcYZkR1bzuL4yB2OxWPkXknz513gEF0GoA6tn00UpbPvERW8rzCuWCA6w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -129,7 +129,7 @@
     "@typescript-eslint/parser": "^8.45.0",
     "@vitejs/plugin-vue": "^6.0.2",
     "@vitest/coverage-v8": "^4.1.9",
-    "@yao-pkg/pkg": "^6.10.1",
+    "@yao-pkg/pkg": "^6.22.0",
     "ansi_up": "^6.0.2",
     "axios": "^1.7.2",
     "barcode-detector": "^2.2.11",

--- a/package.sh
+++ b/package.sh
@@ -59,8 +59,8 @@ fi
 # would not ship the same runtime. Must stay >= 22, which is what pkg requires
 # for its enhanced SEA pipeline.
 SEA_NODE_VERSION=$(tr -d 'v \t\n\r' < .nvmrc)
-if ! [[ "$SEA_NODE_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-	echo "Expected a x.y.z Node version in .nvmrc, got '$SEA_NODE_VERSION'" >&2
+if ! [[ "$SEA_NODE_VERSION" =~ ^([0-9]+)\.[0-9]+\.[0-9]+$ ]] || ((BASH_REMATCH[1] < 22)); then
+	echo "Expected a x.y.z Node version >= 22 in .nvmrc, got '$SEA_NODE_VERSION'" >&2
 	exit 1
 fi
 

--- a/package.sh
+++ b/package.sh
@@ -54,7 +54,24 @@ else
 	ARCH=$(uname -m)
 fi
 
-pack() {
+# Node major baked into SEA builds. Stock nodejs.org binaries only expose the
+# `node:sea` API from v22, and it must stay in sync with docker/Dockerfile.
+SEA_NODE_MAJOR=22
+
+# Compression of the SEA archive. Brotli gives the smallest binary and, since the
+# archive is decompressed lazily per file, costs no measurable startup time.
+SEA_COMPRESS=Brotli
+
+# SEA mode bakes the payload into a stock, unpatched nodejs.org binary, so there
+# is no pkg-fetch patched-Node dependency to wait on.
+pack_sea() {
+	echo executing: pkg . --sea --compress $SEA_COMPRESS --out-path $PKG_FOLDER -t $1
+	npx pkg . --sea --compress $SEA_COMPRESS --out-path $PKG_FOLDER -t $1
+}
+
+# Legacy pkg-fetch pipeline, still needed for targets nodejs.org has no stock
+# binary for (armv6/armv7/x86) or that pkg cannot address in SEA mode (alpine).
+pack_legacy() {
 	echo executing: pkg . --out-path $PKG_FOLDER --options experimental-require-module -t $1 $2
 	npx pkg . --out-path $PKG_FOLDER --options experimental-require-module -t $1 $2
 }
@@ -82,11 +99,11 @@ if [ ! -z "$1" ]; then
 	fi
 
 	if [ "$ARCH" = "aarch64" ] || [ "$ARCH" = "arm64" ]; then
-		pack node$NODE_MAJOR-linux-arm64
+		pack_sea node$SEA_NODE_MAJOR-linux-arm64
 	elif [ "$ARCH" = "armv7" ]; then
-		pack node$NODE_MAJOR-linux-armv7 --public-packages=*
+		pack_legacy node$NODE_MAJOR-linux-armv7 --public-packages=*
 	else
-		pack node$NODE_MAJOR-linux-x64,node$NODE_MAJOR-win-x64
+		pack_sea node$SEA_NODE_MAJOR-linux-x64,node$SEA_NODE_MAJOR-win-x64
 	fi
 
 else
@@ -115,32 +132,32 @@ else
 		case "$REPLY" in
 			1)
 				echo "## Creating application package in $PKG_FOLDER folder"
-				pack node$NODE_MAJOR-linux-x64
+				pack_sea node$SEA_NODE_MAJOR-linux-x64
 				break
 				;;
 			2)
 				echo "## Creating application package in $PKG_FOLDER folder"
-				pack node$NODE_MAJOR-linux-armv7 --public-packages=*
+				pack_legacy node$NODE_MAJOR-linux-armv7 --public-packages=*
 				break
 				;;
 			3)
 				echo "## Creating application package in $PKG_FOLDER folder"
-				pack node$NODE_MAJOR-linux-armv6 --public-packages=*
+				pack_legacy node$NODE_MAJOR-linux-armv6 --public-packages=*
 				break
 				;;
 			4)
 				echo "## Creating application package in $PKG_FOLDER folder"
-				pack node$NODE_MAJOR-linux-x86
+				pack_legacy node$NODE_MAJOR-linux-x86
 				break
 				;;
 			5)
 				echo "## Creating application package in $PKG_FOLDER folder"
-				pack node$NODE_MAJOR-alpine-x64
+				pack_legacy node$NODE_MAJOR-alpine-x64
 				break
 				;;
 			6)
 				echo "## Creating application package in $PKG_FOLDER folder"
-				pack node$NODE_MAJOR-linux-arm64 --public-packages=*
+				pack_sea node$SEA_NODE_MAJOR-linux-arm64
 				break
 				;;
 			*)

--- a/package.sh
+++ b/package.sh
@@ -52,12 +52,17 @@ else
 	ARCH=$(uname -m)
 fi
 
-# Node version baked into SEA builds. Pinned to the full x.y.z on purpose: pkg
-# would otherwise resolve `node22` to whatever nodejs.org calls latest at build
-# time, so two builds of the same tag would not ship the same runtime. Keep it in
-# sync with NODE_VERSION in docker/Dockerfile. Must stay >= 22, which is the
-# first release exposing the `node:sea` API on stock binaries.
-SEA_NODE_VERSION=22.20.0
+# Node version baked into SEA builds. Read from .nvmrc so the renovate bump that
+# moves the rest of the repo onto a Node security release moves the packaged
+# binaries too. The full x.y.z matters: given just `node22`, pkg resolves it to
+# whatever nodejs.org calls latest at build time, so two builds of the same tag
+# would not ship the same runtime. Must stay >= 22, which is what pkg requires
+# for its enhanced SEA pipeline.
+SEA_NODE_VERSION=$(tr -d 'v \t\n\r' < .nvmrc)
+if ! [[ "$SEA_NODE_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+	echo "Expected a x.y.z Node version in .nvmrc, got '$SEA_NODE_VERSION'" >&2
+	exit 1
+fi
 
 # Node major used by the legacy pkg-fetch targets, which only exist for the
 # architectures pkg-fetch still publishes patched binaries for.

--- a/package.sh
+++ b/package.sh
@@ -42,8 +42,6 @@ echo "App-name: $APP"
 VERSION=$(node -p "require('./package.json').version")
 echo "Version: $VERSION"
 
-NODE_MAJOR=$(node -v | grep -E -o '[0-9].' | head -n 1)
-
 echo "## Clear $PKG_FOLDER folder"
 rm -rf $PKG_FOLDER/*
 
@@ -54,9 +52,16 @@ else
 	ARCH=$(uname -m)
 fi
 
-# Node major baked into SEA builds. Stock nodejs.org binaries only expose the
-# `node:sea` API from v22, and it must stay in sync with docker/Dockerfile.
-SEA_NODE_MAJOR=22
+# Node version baked into SEA builds. Pinned to the full x.y.z on purpose: pkg
+# would otherwise resolve `node22` to whatever nodejs.org calls latest at build
+# time, so two builds of the same tag would not ship the same runtime. Keep it in
+# sync with NODE_VERSION in docker/Dockerfile. Must stay >= 22, which is the
+# first release exposing the `node:sea` API on stock binaries.
+SEA_NODE_VERSION=22.20.0
+
+# Node major used by the legacy pkg-fetch targets, which only exist for the
+# architectures pkg-fetch still publishes patched binaries for.
+LEGACY_NODE_MAJOR=20
 
 # Compression of the SEA archive. Brotli gives the smallest binary and, since the
 # archive is decompressed lazily per file, costs no measurable startup time.
@@ -64,6 +69,11 @@ SEA_COMPRESS=Brotli
 
 # SEA mode bakes the payload into a stock, unpatched nodejs.org binary, so there
 # is no pkg-fetch patched-Node dependency to wait on.
+#
+# No `--options experimental-require-module`: SEA runs on Node >= 22, which has
+# `require(esm)` on by default, and pkg does not bake v8 options in SEA mode.
+# No `--public-packages` either: it only controls V8-bytecode packing, which SEA
+# does not do -- it stores sources as-is.
 pack_sea() {
 	echo executing: pkg . --sea --compress $SEA_COMPRESS --out-path $PKG_FOLDER -t $1
 	npx pkg . --sea --compress $SEA_COMPRESS --out-path $PKG_FOLDER -t $1
@@ -99,11 +109,11 @@ if [ ! -z "$1" ]; then
 	fi
 
 	if [ "$ARCH" = "aarch64" ] || [ "$ARCH" = "arm64" ]; then
-		pack_sea node$SEA_NODE_MAJOR-linux-arm64
+		pack_sea node$SEA_NODE_VERSION-linux-arm64
 	elif [ "$ARCH" = "armv7" ]; then
-		pack_legacy node$NODE_MAJOR-linux-armv7 --public-packages=*
+		pack_legacy node$LEGACY_NODE_MAJOR-linux-armv7 --public-packages=*
 	else
-		pack_sea node$SEA_NODE_MAJOR-linux-x64,node$SEA_NODE_MAJOR-win-x64
+		pack_sea node$SEA_NODE_VERSION-linux-x64,node$SEA_NODE_VERSION-win-x64
 	fi
 
 else
@@ -132,32 +142,32 @@ else
 		case "$REPLY" in
 			1)
 				echo "## Creating application package in $PKG_FOLDER folder"
-				pack_sea node$SEA_NODE_MAJOR-linux-x64
+				pack_sea node$SEA_NODE_VERSION-linux-x64
 				break
 				;;
 			2)
 				echo "## Creating application package in $PKG_FOLDER folder"
-				pack_legacy node$NODE_MAJOR-linux-armv7 --public-packages=*
+				pack_legacy node$LEGACY_NODE_MAJOR-linux-armv7 --public-packages=*
 				break
 				;;
 			3)
 				echo "## Creating application package in $PKG_FOLDER folder"
-				pack_legacy node$NODE_MAJOR-linux-armv6 --public-packages=*
+				pack_legacy node$LEGACY_NODE_MAJOR-linux-armv6 --public-packages=*
 				break
 				;;
 			4)
 				echo "## Creating application package in $PKG_FOLDER folder"
-				pack_legacy node$NODE_MAJOR-linux-x86
+				pack_legacy node$LEGACY_NODE_MAJOR-linux-x86
 				break
 				;;
 			5)
 				echo "## Creating application package in $PKG_FOLDER folder"
-				pack_legacy node$NODE_MAJOR-alpine-x64
+				pack_legacy node$LEGACY_NODE_MAJOR-alpine-x64
 				break
 				;;
 			6)
 				echo "## Creating application package in $PKG_FOLDER folder"
-				pack_sea node$SEA_NODE_MAJOR-linux-arm64
+				pack_sea node$SEA_NODE_VERSION-linux-arm64
 				break
 				;;
 			*)

--- a/test/e2e/mosquitto.conf
+++ b/test/e2e/mosquitto.conf
@@ -1,0 +1,2 @@
+listener 1883 0.0.0.0
+allow_anonymous true

--- a/test/e2e/settings.json
+++ b/test/e2e/settings.json
@@ -1,0 +1,43 @@
+{
+	"zwave": {
+		"port": "tcp://127.0.0.1:5555",
+		"enabled": true,
+		"logLevel": "debug",
+		"logEnabled": true,
+		"logToFile": true,
+		"serverEnabled": true
+	},
+	"mqtt": {
+		"name": "zwavejs2mqtt",
+		"host": "127.0.0.1",
+		"port": 1883,
+		"qos": 1,
+		"prefix": "zwave",
+		"reconnectPeriod": 3000,
+		"retain": true,
+		"clean": true,
+		"disabled": false
+	},
+	"gateway": {
+		"type": 0,
+		"payloadType": 0,
+		"nodeNames": true,
+		"hassDiscovery": true,
+		"discoveryPrefix": "homeassistant",
+		"logEnabled": true,
+		"logLevel": "debug",
+		"logToFile": true
+	},
+	"backup": {
+		"storeBackup": true,
+		"storeCron": "10 9 * * *",
+		"storeKeep": 7,
+		"nvmBackup": true,
+		"nvmBackupOnEvent": false,
+		"nvmCron": "19 9 * * *",
+		"nvmKeep": 7,
+		"enabled": true,
+		"cron": "0 * * * *",
+		"keep": 2
+	}
+}


### PR DESCRIPTION
## What

Switches the x64 (linux + windows) and arm64 release binaries from the legacy `pkg` pipeline to `pkg --sea`.

SEA mode bakes the app into a **stock, unpatched `nodejs.org` binary** using Node's official `node:sea` API, instead of a patched Node build produced by `pkg-fetch`. Practical effect: when Node ships a security release we can rebuild immediately, instead of waiting for `pkg-fetch` to publish a patched binary for that version. It also removes the "when pkg-fetch bumps binaries, this must be updated" maintenance loop, and the packaging step drops from minutes to ~20s.

The Node version comes from **`.nvmrc`** — both the build host (`node-version-file`) and the exact `x.y.z` baked into the binaries. Renovate's `nvm` manager already bumps that file, so a Node security release reaches the packaged binaries through the same PR that moves the rest of the repo. `package.sh` fails the build if `.nvmrc` is not an `x.y.z` version `>= 22`.

Pinning the full `x.y.z` is deliberate: given just `node22`, pkg resolves it to whatever `nodejs.org` calls latest at build time, so two builds of the same tag would not ship the same runtime.

## Compression

Built with `--compress Brotli`. The SEA archive is compressed per file at build time and decompressed lazily on first read:

```
SEA archive compressed with Brotli: 26,360,424 -> 5,353,673 bytes (20.3%)
```

Effect on the linux x64 artifacts:

| Build | Binary on disk | Release zip |
| --- | --- | --- |
| SEA, no compression | 150,801,600 (143.8 MiB) | 47,068,402 (44.9 MiB) |
| SEA, Zstd | 131,402,944 (125.3 MiB) | 48,294,097 (46.1 MiB) |
| **SEA, Brotli** | **129,830,080 (123.8 MiB)** | **46,735,717 (44.6 MiB)** |

Brotli wins on both the unpacked binary (-20.0 MiB vs uncompressed) and the zip. Zstd makes the zip *larger* — already-compressed bytes do not deflate again — while Brotli's archive is small enough to still come out ahead.

Startup cost is not measurable. Time from process start until the full Z-Wave config DB (2385 JSON files) has been read out of the binary and written to `store/.config-db`, 3 runs each on the same machine against the mock stick:

| | run 1 | run 2 | run 3 |
| --- | --- | --- | --- |
| no compression | 2.09s | 2.09s | 2.09s |
| Zstd | 2.19s | 2.10s | 2.31s |
| Brotli | 2.31s | 2.30s | 2.20s |

## Size delta vs the current release

Measured against the actual published `v11.23.0` assets (legacy pkg, Node 20), unzipped for the binary sizes:

| Asset | v11.23.0 (legacy) | This PR (SEA + Brotli) | Delta |
| --- | --- | --- | --- |
| `…-linux.zip` | 32,147,170 (30.7 MiB) | 46,735,717 (44.6 MiB) | **+14,588,547 (+45.4%)** |
| `…-linux-arm64.zip` | 31,148,241 (29.7 MiB) | 46,655,549 (44.5 MiB) | **+15,507,308 (+49.8%)** |
| `…-win.zip` | 27,727,175 (26.4 MiB) | 38,203,718 (36.4 MiB) | **+10,476,543 (+37.8%)** |
| `…-linux-armv7.zip` | unchanged | unchanged | — (still legacy) |

Unpacked binaries:

| Target | v11.23.0 (legacy) | This PR (SEA) | Delta |
| --- | --- | --- | --- |
| linux-x64 | 98,018,304 | 129,830,080 | +31,811,776 (+32.5%) |
| linux-arm64 | 93,749,480 | 127,011,968 | +33,262,488 (+35.5%) |
| win-x64 | 84,140,645 | 92,274,176 | +8,133,531 (+9.7%) |

Where the growth comes from — it is **not** our payload:

| Target | Stock Node 22.20.0 | SEA binary | Our payload |
| --- | --- | --- | --- |
| linux-x64 | 123,183,528 | 129,830,080 | +6,646,552 |
| linux-arm64 | 120,348,024 | 127,011,968 | +6,663,944 |
| win-x64 | 85,588,976 | 92,274,176 | +6,685,200 |

The app adds ~6.6 MB to a stock Node binary on every target. The delta versus the legacy builds is almost entirely "stock Node 22 release binary" vs "`pkg-fetch`'s size-optimised Node 20 build", plus the loss of V8-bytecode packing (SEA stores JS as source). For reference, the whole legacy Windows binary (84.1 MB) was *smaller than a bare stock `node.exe`* (85.6 MB) — that is how much `pkg-fetch` strips. That is the price of not depending on patched Node binaries.

## armv7 stays on the legacy pipeline

`pkg` cannot build armv7 in SEA mode today: its target parser only accepts `armv7`, but `sea.js` addresses the `nodejs.org` archive as `armv7l` and rejects `armv7`:

```
$ pkg . --sea -t node22-linux-armv7
> Error! Error: Unsupported architecture: armv7
    at getNodeArch (.../lib-es5/sea.js:196:15)
```

`-t node22-linux-armv7l` fails earlier with `Unknown token 'armv7l'`. So `package_armv7.yml` keeps using `pkg-fetch` + `PKG_NODE_PATH`, with its target major pinned separately as `LEGACY_NODE_MAJOR` in `package.sh`. Worth reporting upstream — it looks like a one-line arch mapping. This does mean a release ships two Node majors: armv7 on 20, everything else on whatever `.nvmrc` says.

## Bundle fixes SEA surfaced

Running on stock Node instead of a patched one exposed two latent bugs that the legacy pkg runtime happened to paper over:

1. **`build/package.json` claimed ESM.** It is generated from the root `package.json`, which has `"type": "module"`, but esbuild emits CommonJS. Stock Node parsed the entry as ESM and it died immediately with `ReferenceError: require is not defined in ES module scope`. Fixed by writing `"type": "commonjs"` into the generated manifest.

2. **The Z-Wave device config DB was never extracted.** `@zwave-js/config` resolves its config folder relative to its own module file (`<pkg>/build/esm/..` -> `<pkg>/config`). Bundling flattens that file into `build/index.js`, so the walk escapes the bundle root — it lands on `/config` under the legacy snapshot and `/snapshot/config` under SEA. `PkgFsBindings` existed precisely to remap that, but only knew the `/config` form, so under SEA it fell through to the real filesystem:

   ```
   Cannot read directory: "/snapshot/config": ENOENT
   ```

   and the driver silently ran with no device config files at all. `PkgFsBindings` now derives both forms, matches them on a path-separator boundary (so a store at `/config-db` is not swallowed by the read-only branches), and copies embedded assets with read+write instead of `copyFile`, which SEA's virtual filesystem does not support for a source inside the archive.

`esbuild.js` also fails the build now when one of its bundle patches stops matching. A silent no-op there is exactly how bug 2 stayed hidden.

Both fixes were verified against a legacy build too, so the armv7 path is unaffected.

## Testing

The e2e steps are now a shared composite action, `.github/actions/e2e`, used by `package_x64`, `package_arm64` and `test-application`. It replaces `package_x64`'s old smoke test ("did the process survive 5 seconds") and `package_arm64`'s nonexistent one. It waits for each dependency rather than sleeping, and against a **packaged binary** it additionally:

- asserts the serialport **native addon** loads out of the archive, by pointing at a device that does not exist so the failure has to come from the addon's own `cannot open` errno rather than from module resolution. Native-addon extraction is the biggest behavioural difference between patched-Node pkg and stock-Node SEA, and nothing exercised it before
- asserts `index.html` is served out of the embedded `dist/`
- asserts the config DB was extracted out of the binary — the check that would have caught bug 2 above

`arm64` previously only checked that the process stayed alive with no `settings.json`, so the driver never started and `PkgFsBindings` was never called — a broken arm64 VFS would have shipped green. It now runs the same suite.

Three review rounds hardened the harness itself, each time against a failure it actually produced:

- the MQTT round trip read back the value *retained from startup*, so it passed whether or not the gateway ever handled the write. It now polls the retained value, requires it to flip to `1`, and repeats the idempotent write because a single attempt is dropped if the gateway is not subscribed yet
- the write was being published a second before node 2 was ready, so the gateway dropped it. The step now waits for the node
- the mock controller crashes on the first bytes if the app connects while it is still coming up, which is what the old blind `sleep 25` had been hiding
- the broker is pinned by digest, bound to loopback, and proven to accept connections before use; `docker run -d` succeeds even when mosquitto dies on its config
- the app and the mock stick run under `setsid` and are tracked by pid, so tear-down actually reaches npm's children
- the three packaging workflows scope `GITHUB_TOKEN` to `contents: write`, matching `docker-release.yml`

Every step was executed verbatim from `action.yml` against both a packaged SEA binary and `npm start` on a cold store: node 2 ready, MQTT round trip returning `{"time":…,"value":1}`, 2386 config DB files extracted, UI served, addon loaded.

### Known gaps

- The Windows binary is built but never executed in CI; that needs a Windows runner and is a pre-existing gap.
- armv7 has no CI smoke test — running an armv7 binary would need QEMU emulation on the arm64 runner, and I could not validate such a step locally before adding it to a release-only workflow. Instead the legacy pipeline was verified locally end to end, built with pkg 6.22 on a Node 20 host (the armv7 CI configuration): identical results to the SEA binary. A manual armv7 smoke run before the first release is still worthwhile.
