### PR TITLE
ci(renovate): give each docker base image its own full-ref ARG

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -42,13 +42,24 @@
       "pinDigests": true
     },
     {
-      // ALPINE_VERSION feeds two refs in docker/Dockerfile: `alpine:${ALPINE_VERSION}`
-      // and `node:${NODE_VERSION}-alpine${ALPINE_VERSION}`. A digest appended to the ARG
-      // is only valid for the first, so pinning it yields an unresolvable
-      // `node:<v>-alpine<v>@sha256:<alpine digest>` and breaks the docker build.
+      // docker/Dockerfile stands node's binaries on a bare alpine base, so both images
+      // must be on the same Alpine release - the apk packages (openssl, libusb, eudev)
+      // have to match what the node binary was linked against. Keep the two in one PR.
+      "matchManagers": ["dockerfile"],
+      "matchDepNames": ["node", "alpine"],
+      "groupName": "docker base images"
+    },
+    {
+      // Docker versioning keeps the tag suffix fixed, so node only ever moves
+      // 22.x-alpine3.22 -> 22.y-alpine3.22; it can't tell whether the alpine bump has a
+      // matching node tag (node:22.20.0-alpine3.24 does not exist - Alpine variants are
+      // only published for the newest patch of a line). Alpine minors therefore need a
+      // human to move the ALPINE_IMAGE and the NODE_IMAGE suffix together. Digest pins
+      // and node patch updates stay automatic.
       "matchManagers": ["dockerfile"],
       "matchDepNames": ["alpine"],
-      "pinDigests": false
+      "matchUpdateTypes": ["major", "minor"],
+      "dependencyDashboardApproval": true
     },
     {
       // All gh-aw pins move in one PR so the recompiled workflows match

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -42,6 +42,15 @@
       "pinDigests": true
     },
     {
+      // ALPINE_VERSION feeds two refs in docker/Dockerfile: `alpine:${ALPINE_VERSION}`
+      // and `node:${NODE_VERSION}-alpine${ALPINE_VERSION}`. A digest appended to the ARG
+      // is only valid for the first, so pinning it yields an unresolvable
+      // `node:<v>-alpine<v>@sha256:<alpine digest>` and breaks the docker build.
+      "matchManagers": ["dockerfile"],
+      "matchDepNames": ["alpine"],
+      "pinDigests": false
+    },
+    {
       // All gh-aw pins move in one PR so the recompiled workflows match
       "matchDepNames": ["github/gh-aw"],
       "groupName": "gh-aw",

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,12 +1,15 @@
 # syntax=docker/dockerfile:1
 ARG image=zwave-js-ui
-ARG NODE_VERSION=22.20.0
-ARG ALPINE_VERSION=3.22
+# Full image refs, one per ARG: Renovate rewrites the ARG line that holds the whole
+# ref, so a shared version fragment gets the digest of only one of the two images.
+# Keep the -alpine suffix here in sync with ALPINE_IMAGE.
+ARG NODE_IMAGE=node:22.20.0-alpine3.22
+ARG ALPINE_IMAGE=alpine:3.22
 ARG BUILDPLATFORM
 
-FROM node:${NODE_VERSION}-alpine${ALPINE_VERSION} AS node
+FROM ${NODE_IMAGE} AS node
 
-FROM alpine:${ALPINE_VERSION} AS base
+FROM ${ALPINE_IMAGE} AS base
 
 RUN --mount=type=cache,target=/var/cache/apk,sharing=locked \
     apk add \


### PR DESCRIPTION
## Problem

`docker/Dockerfile` drove two images from two version *fragments*:

```dockerfile
ARG NODE_VERSION=22.20.0
ARG ALPINE_VERSION=3.22

FROM node:${NODE_VERSION}-alpine${ALPINE_VERSION} AS node
FROM alpine:${ALPINE_VERSION} AS base
```

Renovate's dockerfile manager (`lib/modules/manager/dockerfile/extract.ts`) resolves the
ARGs inside a `FROM`, then in `processDepForAutoReplace` keeps only the lines that contain
the **resolved value verbatim**. That gives two distinct failures:

- **`node` was never updatable.** The resolved value `22.20.0-alpine3.22` appears on no
  single line, so no line qualifies, `replaceString` is never set, and Renovate silently
  skipped the dep. That is why `NODE_VERSION` has never been bumped or pinned.
- **`alpine` was updated destructively.** `3.22` does appear on the `ALPINE_VERSION` line,
  so `pinDigests` rewrote it to `3.22@sha256:14358309a3…` — `alpine:3.22`'s digest, landing
  in an ARG the *node* ref also reads:

  ```
  ERROR: failed to solve:
  docker.io/library/node:22.20.0-alpine3.22@sha256:14358309a3…: not found
  ```

That broke the Docker Test build on every platform in #4807 (arm/v7 failed, fail-fast
cancelled amd64 and arm64 — those `CANCELLED` checks are not passes). #4808 hit the same
thing with `3.24`.

## Fix

Each ARG now holds a complete image ref, so each is an ordinary, independently pinnable dep:

```dockerfile
ARG NODE_IMAGE=node:22.20.0-alpine3.22
ARG ALPINE_IMAGE=alpine:3.22

FROM ${NODE_IMAGE} AS node
FROM ${ALPINE_IMAGE} AS base
```

Renovate now writes `node:22.23.2-alpine3.22@sha256:<node digest>` and
`alpine:3.24@sha256:<alpine digest>` — each digest on its own image. Nothing else in the
Dockerfile changes, and neither ARG is passed as a `build-arg` anywhere
(`docker-release.yml` only passes `image=zwavejs2mqtt`).

Verified locally: the current form and the digest-pinned form both build the `base` target
and produce the **same image id** (`f5a72524c8e9`).

## Keeping the two images in lockstep

The `base` stage stands node's binaries on a bare Alpine (`COPY --from=node /usr/lib`, …),
so both must be on the same Alpine release — the apk packages (`openssl`, `libusb`,
`eudev`) have to match what the node binary was linked against. Two Renovate rules:

- **Grouped** into one `docker base images` PR, so they always move together.
- **Alpine major/minor needs dashboard approval.** Docker versioning holds the tag suffix
  fixed, so node only ever moves `22.x-alpine3.22` → `22.y-alpine3.22`; Renovate cannot
  tell that the alpine bump has no matching node tag. `node:22.20.0-alpine3.24` does not
  exist — Alpine variants are only published for the newest patch of a line (exact tags
  with `alpine3.24` start at `22.22.3`). So moving `ALPINE_IMAGE` and the `NODE_IMAGE`
  suffix together stays a human call.

Digest pins and node patch updates remain fully automatic — only the one update Renovate
provably cannot verify is gated.

## Follow-up

#4807 and #4808 both need closing or rebasing so Renovate regenerates them against this
config. Merging this does not retroactively fix those branches.
