### PR TITLE
feat: local names for access-control users

### DIFF
--- a/api/lib/ZwaveClient.ts
+++ b/api/lib/ZwaveClient.ts
@@ -321,6 +321,7 @@ export const allowedApis = validateMethods([
 	'accessControlCancelCredentialLearn',
 	'accessControlGetAdminCode',
 	'accessControlSetAdminCode',
+	'accessControlSetUserLocalName',
 ] as const)
 
 export type ZwaveNodeEvents = ZWaveNodeEvents | 'statistics updated'
@@ -607,7 +608,10 @@ export interface ZUIScheduleConfig<T> {
 	slots: ZUISlot<T>[]
 }
 
-export type ZUIAccessControlUser = UserData
+export type ZUIAccessControlUser = UserData & {
+	/** Local-only friendly name, stored in zwave-js-ui and never sent to the device. */
+	localName?: string
+}
 
 export type ZUIAccessControlCredential = {
 	userId: number
@@ -734,6 +738,8 @@ export type ZUINode = {
 		enabled: number[]
 	}
 	accessControl?: ZUIAccessControl
+	/** Local-only access-control user names, keyed by endpointIndex then userId. Never sent to the device. */
+	accessControlUserNames?: Record<number, Record<number, string>>
 	defaultTransitionDuration?: string
 	defaultVolume?: number
 	protocol?: Protocols
@@ -1685,7 +1691,15 @@ class ZwaveClient extends TypedEventEmitter<ZwaveClientEventCallbacks> {
 					zwaveNode,
 					idx,
 				)
-				const users = accessControl.getUsersCached()
+				const localNames =
+					this.storeNodes[zwaveNode.id]?.accessControlUserNames?.[idx]
+				const users = accessControl
+					.getUsersCached()
+					.map((u) =>
+						localNames?.[u.userId]
+							? { ...u, localName: localNames[u.userId] }
+							: u,
+					)
 				const credentials = accessControl
 					.getAllCredentialsCached()
 					.map((c) => this._mapCredentialData(c))
@@ -1753,6 +1767,41 @@ class ZwaveClient extends TypedEventEmitter<ZwaveClientEventCallbacks> {
 		const users = await accessControl.getUsers()
 		this._refreshAccessControlState(zwaveNode)
 		return users
+	}
+
+	/**
+	 * Sets a local-only friendly name for an access-control user. This is
+	 * stored in zwave-js-ui's local store only — it is never sent to the
+	 * Z-Wave device (unlike `userName`, which is part of the User
+	 * Credential CC and lives on the lock itself).
+	 */
+	async accessControlSetUserLocalName(
+		nodeId: number,
+		endpointIndex: number | undefined,
+		userId: number,
+		name: string,
+	): Promise<void> {
+		const zwaveNode = this._requireNode(nodeId)
+		const { index: idx } = this._resolveAccessControlEndpoint(
+			zwaveNode,
+			endpointIndex,
+		)
+		if (!this.storeNodes[nodeId]) {
+			this.storeNodes[nodeId] = {} as ZUINode
+		}
+		if (!this.storeNodes[nodeId].accessControlUserNames) {
+			this.storeNodes[nodeId].accessControlUserNames = {}
+		}
+		if (!this.storeNodes[nodeId].accessControlUserNames[idx]) {
+			this.storeNodes[nodeId].accessControlUserNames[idx] = {}
+		}
+		if (name) {
+			this.storeNodes[nodeId].accessControlUserNames[idx][userId] = name
+		} else {
+			delete this.storeNodes[nodeId].accessControlUserNames[idx][userId]
+		}
+		await this.updateStoreNodes()
+		this._refreshAccessControlState(zwaveNode)
 	}
 
 	async accessControlRefreshCredentials(
@@ -1826,11 +1875,18 @@ class ZwaveClient extends TypedEventEmitter<ZwaveClientEventCallbacks> {
 		userId: number,
 	): Promise<SetUserResult> {
 		const zwaveNode = this._requireNode(nodeId)
-		const { accessControl } = this._resolveAccessControlEndpoint(
-			zwaveNode,
-			endpointIndex,
-		)
-		return accessControl.deleteUser(userId)
+		const { index: idx, accessControl } =
+			this._resolveAccessControlEndpoint(zwaveNode, endpointIndex)
+		const result = await accessControl.deleteUser(userId)
+		if (
+			result === SetUserResult.OK &&
+			this.storeNodes[nodeId]?.accessControlUserNames?.[idx]?.[userId] !==
+				undefined
+		) {
+			delete this.storeNodes[nodeId].accessControlUserNames[idx][userId]
+			await this.updateStoreNodes()
+		}
+		return result
 	}
 
 	async accessControlDeleteAllUsers(
@@ -1838,15 +1894,17 @@ class ZwaveClient extends TypedEventEmitter<ZwaveClientEventCallbacks> {
 		endpointIndex?: number,
 	): Promise<SetUserResult> {
 		const zwaveNode = this._requireNode(nodeId)
-		const { accessControl } = this._resolveAccessControlEndpoint(
-			zwaveNode,
-			endpointIndex,
-		)
+		const { index: idx, accessControl } =
+			this._resolveAccessControlEndpoint(zwaveNode, endpointIndex)
 		// zwave-js purges its cache silently here without emitting per-user
 		// `user deleted` / `credential deleted` events, so push a refresh so
 		// the UI catches up.
 		const result = await accessControl.deleteAllUsers()
 		if (result === SetUserResult.OK) {
+			if (this.storeNodes[nodeId]?.accessControlUserNames?.[idx]) {
+				this.storeNodes[nodeId].accessControlUserNames[idx] = {}
+				await this.updateStoreNodes()
+			}
 			this._refreshAccessControlState(zwaveNode)
 		}
 		return result

--- a/src/components/nodes-table/AccessControl.vue
+++ b/src/components/nodes-table/AccessControl.vue
@@ -116,6 +116,70 @@
 												`User ${user.userId}`
 											}}
 										</span>
+										<v-text-field
+											v-if="
+												editingLocalNameUserId ===
+												user.userId
+											"
+											v-model="localNameDraft"
+											density="compact"
+											variant="outlined"
+											hide-details
+											single-line
+											label="Local name"
+											autofocus
+											style="max-width: 160px"
+											class="mr-2 local-name-field"
+											:disabled="savingLocalName"
+											@click.stop
+											@keyup.enter.stop="
+												saveLocalName(user)
+											"
+											@keyup.esc.stop="
+												cancelEditLocalName
+											"
+										/>
+										<template
+											v-if="
+												editingLocalNameUserId ===
+												user.userId
+											"
+										>
+											<v-btn
+												icon="check"
+												size="x-small"
+												variant="text"
+												density="comfortable"
+												class="mr-1"
+												:loading="savingLocalName"
+												@click.stop="
+													saveLocalName(user)
+												"
+											/>
+											<v-btn
+												icon="close"
+												size="x-small"
+												variant="text"
+												density="comfortable"
+												class="mr-2"
+												:disabled="savingLocalName"
+												@click.stop="
+													cancelEditLocalName
+												"
+											/>
+										</template>
+										<v-chip
+											v-else-if="user.localName"
+											size="x-small"
+											variant="tonal"
+											prepend-icon="badge"
+											class="mr-2"
+											@click.stop="
+												startEditLocalName(user)
+											"
+										>
+											{{ user.localName }}
+										</v-chip>
 										<v-chip
 											v-if="
 												user.credentialRule &&
@@ -179,6 +243,18 @@
 										>
 											<v-list-item-title>
 												Edit user
+											</v-list-item-title>
+										</v-list-item>
+										<v-list-item
+											prepend-icon="badge"
+											@click="startEditLocalName(user)"
+										>
+											<v-list-item-title>
+												{{
+													user.localName
+														? 'Edit local name'
+														: 'Set local name'
+												}}
 											</v-list-item-title>
 										</v-list-item>
 										<v-list-item
@@ -938,6 +1014,9 @@ export default {
 			deletingAllUsers: false,
 			deletingCredentials: false,
 			revealedCredentials: new Set(),
+			editingLocalNameUserId: null,
+			localNameDraft: '',
+			savingLocalName: false,
 			userDialog: {
 				show: false,
 				initial: null,
@@ -1736,6 +1815,35 @@ export default {
 				}
 			} finally {
 				this.deletingCredentials = false
+			}
+		},
+		startEditLocalName(user) {
+			this.editingLocalNameUserId = user.userId
+			this.localNameDraft = user.localName || ''
+		},
+		cancelEditLocalName() {
+			this.editingLocalNameUserId = null
+			this.localNameDraft = ''
+		},
+		async saveLocalName(user) {
+			if (!this.currentEndpoint || this.savingLocalName) return
+			this.savingLocalName = true
+			try {
+				const res = await this.app.apiRequest(
+					'accessControlSetUserLocalName',
+					[
+						this.node.id,
+						this.currentEndpoint.endpointIndex,
+						user.userId,
+						this.localNameDraft.trim(),
+					],
+					{ infoSnack: false, errorSnack: true },
+				)
+				if (!res.success) return
+				this.editingLocalNameUserId = null
+				this.localNameDraft = ''
+			} finally {
+				this.savingLocalName = false
 			}
 		},
 		startAdminPinEdit() {

--- a/test/lib/ZwaveClient.test.ts
+++ b/test/lib/ZwaveClient.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { SetUserResult } from 'zwave-js'
 import ZwaveClient from '../../api/lib/ZwaveClient.ts'
 
 // `throttle` only touches `throttledFunctions`, so these tests skip the real
@@ -184,6 +185,216 @@ describe('#ZwaveClient', () => {
 
 			vi.advanceTimersByTime(1000)
 			expect(fn).toHaveBeenCalledTimes(1)
+		})
+	})
+
+	describe('access-control local user names', () => {
+		// These methods only touch `storeNodes`, `updateStoreNodes` and the
+		// access-control resolution helpers, so the constructor (which reads
+		// json stores and needs a socket server) is skipped here too.
+		const NODE_ID = 5
+		const ENDPOINT_INDEX = 0
+
+		let client: ZwaveClient
+		let accessControl: {
+			deleteUser: ReturnType<typeof vi.fn>
+			deleteAllUsers: ReturnType<typeof vi.fn>
+		}
+
+		beforeEach(() => {
+			client = Object.create(ZwaveClient.prototype) as ZwaveClient
+			client['storeNodes'] = {}
+			client['_requireNode'] = vi.fn().mockReturnValue({ id: NODE_ID })
+			accessControl = {
+				deleteUser: vi.fn(),
+				deleteAllUsers: vi.fn(),
+			}
+			client['_resolveAccessControlEndpoint'] = vi
+				.fn()
+				.mockImplementation((_zwaveNode, endpointIndex) => ({
+					index: endpointIndex ?? ENDPOINT_INDEX,
+					accessControl,
+					endpoint: {},
+				}))
+			client['updateStoreNodes'] = vi.fn().mockResolvedValue(undefined)
+			client['_refreshAccessControlState'] = vi.fn()
+		})
+
+		describe('#accessControlSetUserLocalName()', () => {
+			it('stores a local name, creating the nested store entries', async () => {
+				await client.accessControlSetUserLocalName(
+					NODE_ID,
+					ENDPOINT_INDEX,
+					1,
+					'Front door key',
+				)
+
+				expect(
+					client['storeNodes'][NODE_ID].accessControlUserNames[
+						ENDPOINT_INDEX
+					][1],
+				).to.equal('Front door key')
+				expect(client['updateStoreNodes']).toHaveBeenCalledTimes(1)
+				expect(
+					client['_refreshAccessControlState'],
+				).toHaveBeenCalledWith({ id: NODE_ID })
+			})
+
+			it('overwrites an existing local name for the same user', async () => {
+				await client.accessControlSetUserLocalName(
+					NODE_ID,
+					ENDPOINT_INDEX,
+					1,
+					'Old name',
+				)
+				await client.accessControlSetUserLocalName(
+					NODE_ID,
+					ENDPOINT_INDEX,
+					1,
+					'New name',
+				)
+
+				expect(
+					client['storeNodes'][NODE_ID].accessControlUserNames[
+						ENDPOINT_INDEX
+					][1],
+				).to.equal('New name')
+			})
+
+			it('clears the local name when given an empty string', async () => {
+				await client.accessControlSetUserLocalName(
+					NODE_ID,
+					ENDPOINT_INDEX,
+					1,
+					'Front door key',
+				)
+				await client.accessControlSetUserLocalName(
+					NODE_ID,
+					ENDPOINT_INDEX,
+					1,
+					'',
+				)
+
+				expect(
+					client['storeNodes'][NODE_ID].accessControlUserNames[
+						ENDPOINT_INDEX
+					],
+				).to.not.have.property('1')
+			})
+
+			it('keys names by endpoint so different endpoints do not collide', async () => {
+				await client.accessControlSetUserLocalName(
+					NODE_ID,
+					0,
+					1,
+					'Root',
+				)
+				await client.accessControlSetUserLocalName(
+					NODE_ID,
+					2,
+					1,
+					'Endpoint 2',
+				)
+
+				expect(
+					client['storeNodes'][NODE_ID].accessControlUserNames[0][1],
+				).to.equal('Root')
+				expect(
+					client['storeNodes'][NODE_ID].accessControlUserNames[2][1],
+				).to.equal('Endpoint 2')
+			})
+		})
+
+		describe('#accessControlDeleteUser()', () => {
+			beforeEach(() => {
+				client['storeNodes'][NODE_ID] = {
+					accessControlUserNames: {
+						[ENDPOINT_INDEX]: { 1: 'Front door key', 2: 'Garage' },
+					},
+				} as never
+			})
+
+			it('removes the stored local name once the device confirms deletion', async () => {
+				accessControl.deleteUser.mockResolvedValue(SetUserResult.OK)
+
+				const result = await client.accessControlDeleteUser(
+					NODE_ID,
+					ENDPOINT_INDEX,
+					1,
+				)
+
+				expect(result).to.equal(SetUserResult.OK)
+				expect(
+					client['storeNodes'][NODE_ID].accessControlUserNames[
+						ENDPOINT_INDEX
+					],
+				).to.deep.equal({ 2: 'Garage' })
+				expect(client['updateStoreNodes']).toHaveBeenCalledTimes(1)
+			})
+
+			it('leaves the stored local name untouched when the device refuses', async () => {
+				accessControl.deleteUser.mockResolvedValue(
+					SetUserResult.Error_Unknown,
+				)
+
+				await client.accessControlDeleteUser(NODE_ID, ENDPOINT_INDEX, 1)
+
+				expect(
+					client['storeNodes'][NODE_ID].accessControlUserNames[
+						ENDPOINT_INDEX
+					],
+				).to.deep.equal({ 1: 'Front door key', 2: 'Garage' })
+				expect(client['updateStoreNodes']).not.toHaveBeenCalled()
+			})
+		})
+
+		describe('#accessControlDeleteAllUsers()', () => {
+			beforeEach(() => {
+				client['storeNodes'][NODE_ID] = {
+					accessControlUserNames: {
+						[ENDPOINT_INDEX]: { 1: 'Front door key', 2: 'Garage' },
+					},
+				} as never
+			})
+
+			it('clears every stored local name once the device confirms deletion', async () => {
+				accessControl.deleteAllUsers.mockResolvedValue(SetUserResult.OK)
+
+				const result = await client.accessControlDeleteAllUsers(
+					NODE_ID,
+					ENDPOINT_INDEX,
+				)
+
+				expect(result).to.equal(SetUserResult.OK)
+				expect(
+					client['storeNodes'][NODE_ID].accessControlUserNames[
+						ENDPOINT_INDEX
+					],
+				).to.deep.equal({})
+				expect(client['updateStoreNodes']).toHaveBeenCalledTimes(1)
+				expect(client['_refreshAccessControlState']).toHaveBeenCalled()
+			})
+
+			it('leaves stored local names untouched when the device refuses', async () => {
+				accessControl.deleteAllUsers.mockResolvedValue(
+					SetUserResult.Error_Unknown,
+				)
+
+				await client.accessControlDeleteAllUsers(
+					NODE_ID,
+					ENDPOINT_INDEX,
+				)
+
+				expect(
+					client['storeNodes'][NODE_ID].accessControlUserNames[
+						ENDPOINT_INDEX
+					],
+				).to.deep.equal({ 1: 'Front door key', 2: 'Garage' })
+				expect(client['updateStoreNodes']).not.toHaveBeenCalled()
+				expect(
+					client['_refreshAccessControlState'],
+				).not.toHaveBeenCalled()
+			})
 		})
 	})
 })


### PR DESCRIPTION
## Summary
- Access-control users only expose the device's own `userName` (part of the User Credential CC) — there was no way to label a user without writing that label back to the lock. Adds `accessControlSetUserLocalName` and a `localName` field, persisted locally in `store/nodes.json` (same mechanism already used for node name/location) and never sent to the device. The name is cleaned up automatically when a user is deleted.
- Adds an inline editor in the Users list (chip + text field, matching the existing admin PIN inline-edit pattern already in this component) to set/edit that local name without opening a dialog.

## Test plan
- [x] `npx tsc --noEmit -p tsconfig.json` — no errors
- [x] `npx eslint` on all changed files — no errors
- [x] `npx vitest run` — 310/320 passing; the 10 failures are pre-existing symlink/unix-socket tests that need privileges unavailable on this Windows dev machine, unrelated to this change
- [x] Added unit tests in `test/lib/ZwaveClient.test.ts` covering `accessControlSetUserLocalName`, and the local-name cleanup in `accessControlDeleteUser` / `accessControlDeleteAllUsers`
- [ ] Manual UI verification against a real/mock device (not performed in this environment)

🤖 Generated with [Claude Code](https://claude.com/claude-code)