### PR TITLE
fix(api): do not let a stuck driver shutdown block the client restart

### DIFF
--- a/api/lib/ZwaveClient.ts
+++ b/api/lib/ZwaveClient.ts
@@ -175,6 +175,10 @@ export const configManager = new ConfigManager({
 
 const logger = LogManager.module('Z-Wave')
 
+// How long close() waits for the server and the driver to shut down before
+// carrying on without them
+const CLOSE_STEP_TIMEOUT = 60_000
+
 const NEIGHBORS_LOCK_REFRESH = 60 * 1000
 
 /** Maximum length of a multicast group name (avoids bloating MQTT topics). */
@@ -1494,13 +1498,32 @@ class ZwaveClient extends TypedEventEmitter<ZwaveClientEventCallbacks> {
 			this.throttledFunctions.delete(key)
 		}
 
+		// A cleanup step that never completes would block every later restart,
+		// so the client could never reconnect after the driver failed. Log which
+		// step timed out and carry on, leaking the stuck instance instead.
 		if (this.server) {
-			await this.server.destroy()
+			const settled = await utils.settledWithin(
+				this.server.destroy(),
+				CLOSE_STEP_TIMEOUT,
+			)
+			if (!settled) {
+				logger.error(
+					`Timed out after ${CLOSE_STEP_TIMEOUT / 1000}s waiting for the Z-Wave server to close, continuing anyway`,
+				)
+			}
 			this.server = null
 		}
 
 		if (this._driver) {
-			await this._driver.destroy()
+			const settled = await utils.settledWithin(
+				this._driver.destroy(),
+				CLOSE_STEP_TIMEOUT,
+			)
+			if (!settled) {
+				logger.error(
+					`Timed out after ${CLOSE_STEP_TIMEOUT / 1000}s waiting for the driver to be destroyed, continuing anyway`,
+				)
+			}
 			this._driver = null
 		}
 

--- a/api/lib/utils.ts
+++ b/api/lib/utils.ts
@@ -714,3 +714,25 @@ export function applyOperation(value: any, op: string): any {
 
 	return Number.isFinite(result) ? result : value
 }
+
+/**
+ * Waits for `promise` to settle, but at most `timeoutMs` milliseconds.
+ * Resolves with `true` when the promise settled in time and `false` when the
+ * timeout elapsed first. A rejection is propagated when it happens in time and
+ * ignored afterwards, so a late failure cannot surface as an unhandled rejection.
+ */
+export async function settledWithin(
+	promise: Promise<unknown>,
+	timeoutMs: number,
+): Promise<boolean> {
+	let timer: NodeJS.Timeout | undefined
+	const timeout = new Promise<false>((resolve) => {
+		timer = setTimeout(() => resolve(false), timeoutMs)
+	})
+	try {
+		return await Promise.race([promise.then(() => true as const), timeout])
+	} finally {
+		clearTimeout(timer)
+		promise.catch(() => {})
+	}
+}

--- a/test/lib/utils.test.ts
+++ b/test/lib/utils.test.ts
@@ -20,6 +20,7 @@ import {
 	isValidNodeIdString,
 	isValidOperation,
 	applyOperation,
+	settledWithin,
 } from '../../api/lib/utils.ts'
 
 declare let process: NodeJS.Process & {
@@ -354,5 +355,32 @@ describe('#utils', () => {
 		it('returns the value on a non-finite result (divide by zero)', () => {
 			expect(applyOperation(100, '/0')).to.equal(100)
 		})
+	})
+})
+
+describe('settledWithin', () => {
+	it('resolves true when the promise settles in time', async () => {
+		expect(await settledWithin(Promise.resolve(), 100)).toBe(true)
+	})
+
+	it('resolves false when the timeout elapses first', async () => {
+		expect(await settledWithin(new Promise(() => {}), 10)).toBe(false)
+	})
+
+	it('propagates a rejection that happens in time', async () => {
+		await expect(
+			settledWithin(Promise.reject(new Error('boom')), 100),
+		).rejects.toThrow('boom')
+	})
+
+	it('ignores a rejection that happens after the timeout', async () => {
+		let reject!: (error: Error) => void
+		const promise = new Promise<void>((_, r) => {
+			reject = r
+		})
+		expect(await settledWithin(promise, 10)).toBe(false)
+		reject(new Error('late'))
+		// An unhandled rejection here would fail the test run
+		await new Promise((resolve) => setTimeout(resolve, 0))
 	})
 })


### PR DESCRIPTION
## Problem

When the driver emits a `Driver_Failed` error, the client schedules a restart. `restart()` calls `close()`, which awaits `this.server.destroy()` and `this._driver.destroy()` with no bound. If either never settles, the restart hangs forever and the client never reconnects.

I observed this with zwave-js 15.27.0 and an `esphome://` connection. After a network outage the driver gave up reopening the port and started destroying itself, but its `destroy()` never completed (the `driver instance destroyed` log line never appeared and the instance's timers kept firing for two more days). The client stayed stuck in `close()` and no new driver was ever created until the container was restarted. See zwave-js/zwave-js#9249 for the driver-side logging change.

## Change

- Add `settledWithin()` to `utils.ts`, which waits for a promise for at most a given time and reports whether it settled. A rejection is propagated when it happens in time and ignored afterwards so it cannot become an unhandled rejection.
- In `close()`, wait at most 60 seconds each for the server and the driver to shut down. When a step times out, log an error naming it and continue, leaking the stuck instance instead of blocking the restart.
- Unit tests for the helper.

The 60 second bound is longer than the 30 second watchdog proposed in the driver PR, so the driver's warning naming the stuck step arrives in the log before the client gives up on it.